### PR TITLE
fix: use stderr for logging to avoid corrupting MCP stdio transport

### DIFF
--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -28,7 +28,7 @@ def get_logger(name: str, level: str | None = None) -> logging.Logger:
     # Avoid duplicate handlers
     if not logger.handlers:
         # Console handler
-        handler = logging.StreamHandler(sys.stdout)
+        handler = logging.StreamHandler(sys.stderr)
         handler.setLevel(logging.DEBUG)
 
         # Formatter


### PR DESCRIPTION
### **User description**
The logger was writing to stdout which corrupts the JSON-RPC stream when using stdio transport. MCP servers must only write protocol messages to stdout; all logging should go to stderr.


___

### **PR Type**
Bug fix


___

### **Description**
- Redirect logger output from stdout to stderr

- Prevents corruption of MCP JSON-RPC protocol stream

- Ensures protocol messages remain on stdout only


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Logger["Logger Handler"] -- "changed from stdout" --> Stderr["stderr"]
  Stderr -- "preserves" --> Protocol["JSON-RPC Protocol Stream on stdout"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logger.py</strong><dd><code>Redirect console handler output to stderr</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/logger.py

<ul><li>Changed <code>logging.StreamHandler</code> to write to <code>sys.stderr</code> instead of <br><code>sys.stdout</code><br> <li> Prevents logger output from corrupting the JSON-RPC message stream<br> <li> Maintains MCP server protocol compliance by reserving stdout for <br>protocol messages only</ul>


</details>


  </td>
  <td><a href="https://github.com/enuno/unifi-mcp-server/pull/8/files#diff-ad4da9b8b5606f71c499d9a6545da468984701965cb2802104d496c0d77964a3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

