### PR TITLE
fix(network_config): handle varying API response formats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "PyYAML>=6.0",
     "python-dotenv>=1.0.0",
     "agnost>=0.1.0",
+    "mcp[cli]>=1.16.0",
 ]
 
 [project.optional-dependencies]

--- a/src/tools/network_config.py
+++ b/src/tools/network_config.py
@@ -234,7 +234,10 @@ async def update_network(
 
             # Get existing network
             response = await client.get(f"/ea/sites/{site_id}/rest/networkconf")
-            networks_data: list[dict[str, Any]] = response.get("data", [])
+            if isinstance(response, list):
+                networks_data: list[dict[str, Any]] = response
+            else:
+                networks_data = response.get("data", [])
 
             existing_network = None
             for network in networks_data:
@@ -272,7 +275,10 @@ async def update_network(
             response = await client.put(
                 f"/ea/sites/{site_id}/rest/networkconf/{network_id}", json_data=update_data
             )
-            updated_network: dict[str, Any] = response.get("data", [{}])[0]
+            if isinstance(response, list):
+                updated_network: dict[str, Any] = response[0] if response else {}
+            else:
+                updated_network = response.get("data", [{}])[0]
 
             logger.info(f"Updated network '{network_id}' in site '{site_id}'")
             log_audit(

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,18 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "agnost"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/9b/06311f487b0a974d4a2b39f4823f3995b0be3c7c6b8edffad33098e09364/agnost-0.1.8.tar.gz", hash = "sha256:f3b784a766c0afd83eea3e13256a6c3928c02506aed8aa18c6daeb280de864e2", size = 11093, upload-time = "2025-10-17T10:59:19.912Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/ba/4b6b0e2f2795e516fcca83c6d5e9b31fc789d05746ea8e0253b8c1defbd4/agnost-0.1.8-py3-none-any.whl", hash = "sha256:c87dfb43708b0d4075a97035efb71178f5c20bf9a1b7c9c63c79a345d268380f", size = 12304, upload-time = "2025-10-17T10:59:18.792Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -995,6 +1007,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/0e/7cebc88e17daf94ebe28c95633af595ccb2864dc2ee7abd75542d98495cc/mcp-1.16.0-py3-none-any.whl", hash = "sha256:ec917be9a5d31b09ba331e1768aa576e0af45470d657a0319996a20a57d7d633", size = 167266, upload-time = "2025-10-02T16:58:19.039Z" },
 ]
 
+[package.optional-dependencies]
+cli = [
+    { name = "python-dotenv" },
+    { name = "typer" },
+]
+
 [[package]]
 name = "mdurl"
 version = "0.1.2"
@@ -1973,6 +1991,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/fa/3234f913fe9a6525a7b97c6dad1f51e72b917e6872e051a5e2ffd8b16fbb/ruamel.yaml.clib-0.2.14-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:70eda7703b8126f5e52fcf276e6c0f40b0d314674f896fc58c47b0aef2b9ae83", size = 137970, upload-time = "2025-09-22T19:51:09.472Z" },
     { url = "https://files.pythonhosted.org/packages/ef/ec/4edbf17ac2c87fa0845dd366ef8d5852b96eb58fcd65fc1ecf5fe27b4641/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a0cb71ccc6ef9ce36eecb6272c81afdc2f565950cdcec33ae8e6cd8f7fc86f27", size = 739639, upload-time = "2025-09-22T19:51:10.566Z" },
     { url = "https://files.pythonhosted.org/packages/15/18/b0e1fafe59051de9e79cdd431863b03593ecfa8341c110affad7c8121efc/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7cb9ad1d525d40f7d87b6df7c0ff916a66bc52cb61b66ac1b2a16d0c1b07640", size = 764456, upload-time = "2025-09-22T19:51:11.736Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/cd/150fdb96b8fab27fe08d8a59fe67554568727981806e6bc2677a16081ec7/ruamel_yaml_clib-0.2.14-cp314-cp314-win32.whl", hash = "sha256:9b4104bf43ca0cd4e6f738cb86326a3b2f6eef00f417bd1e7efb7bdffe74c539", size = 102394, upload-time = "2025-11-14T21:57:36.703Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e6/a3fa40084558c7e1dc9546385f22a93949c890a8b2e445b2ba43935f51da/ruamel_yaml_clib-0.2.14-cp314-cp314-win_amd64.whl", hash = "sha256:13997d7d354a9890ea1ec5937a219817464e5cc344805b37671562a401ca3008", size = 122673, upload-time = "2025-11-14T21:57:38.177Z" },
 ]
 
 [[package]]
@@ -2303,11 +2323,13 @@ wheels = [
 
 [[package]]
 name = "unifi-mcp-server"
-version = "0.1.0"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
+    { name = "agnost" },
     { name = "fastmcp" },
     { name = "httpx" },
+    { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -2335,12 +2357,14 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agnost", specifier = ">=0.1.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
     { name = "fastmcp", specifier = ">=0.1.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.13.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.16.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
### **User description**
Handle cases where UniFi API returns data directly as a list instead of wrapped in a 'data' property.


___

### **PR Type**
Bug fix


___

### **Description**
- Handle UniFi API responses returned as lists instead of wrapped in 'data' property

- Add defensive checks for both GET and PUT API response formats

- Add mcp[cli] dependency to project requirements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API Response"] --> B{"Is List?"}
  B -->|Yes| C["Use directly as networks_data"]
  B -->|No| D["Extract from response.get('data')"]
  C --> E["Process network data"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network_config.py</strong><dd><code>Add API response format flexibility checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/network_config.py

<ul><li>Added type checking for API responses to handle both list and dict <br>formats<br> <li> Modified GET endpoint response handling to check if response is a list <br>before accessing 'data' property<br> <li> Modified PUT endpoint response handling with same defensive check for <br>updated_network extraction<br> <li> Ensures backward compatibility with wrapped responses while supporting <br>direct list responses</ul>


</details>


  </td>
  <td><a href="https://github.com/enuno/unifi-mcp-server/pull/9/files#diff-70dd076c229583851e0004f9f478da7b0bc40eb137bdf2b0c48333e69dccd9b9">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Add mcp CLI dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Added mcp[cli] dependency version 1.16.0 or higher to project <br>dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/enuno/unifi-mcp-server/pull/9/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

