### PR TITLE
fix: implement username/password authentication for local gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,18 @@
 # UniFi API Configuration
+# Authentication method depends on API type:
+# - Cloud APIs (cloud-v1, cloud-ea): Require API key
+# - Local API (local): Requires username and password
+
+# Cloud API Authentication (Required for cloud-v1 or cloud-ea)
 # Obtain your API key from https://unifi.ui.com
 # Navigate to: Settings → Control Plane → Integrations → Create API Key
 # IMPORTANT: API key is shown only once - save it securely!
-
-# Required: UniFi API Key
 UNIFI_API_KEY=your-api-key-here
+
+# Local API Authentication (Required for local mode)
+# Use your UniFi console username and password
+# UNIFI_USERNAME=admin
+# UNIFI_PASSWORD=your-password-here
 
 # API Type: Choose based on your UniFi API access
 # - 'cloud-v1': Official stable v1 API (https://api.ui.com/v1/...)

--- a/src/api/client.py
+++ b/src/api/client.py
@@ -87,6 +87,8 @@ class UniFiClient:
         self._site_id_cache: dict[str, str] = {}
         # Cache for site UUID -> internalReference mapping (needed for local API)
         self._site_uuid_to_name: dict[str, str] = {}
+        # Session cookie storage for local API authentication
+        self._session_cookie: str | None = None
 
     async def __aenter__(self) -> "UniFiClient":
         """Async context manager entry."""
@@ -187,42 +189,103 @@ class UniFiClient:
     async def authenticate(self) -> None:
         """Authenticate with the UniFi API.
 
+        For Cloud APIs: Validates API key by making a test request
+        For Local API: Performs login with username/password to get session cookie
+
         Raises:
             AuthenticationError: If authentication fails
         """
         try:
-            # Test authentication with a simple API call
-            # Use appropriate endpoint based on API type
-            if self.settings.api_type == APIType.CLOUD_V1:
-                test_endpoint = "/v1/hosts"  # V1 stable API
+            if self.settings.api_type == APIType.LOCAL:
+                # Local gateway requires username/password login
+                await self._authenticate_local()
             else:
-                test_endpoint = "/ea/sites"  # EA API or local (will be auto-translated)
+                # Cloud API uses API key authentication
+                await self._authenticate_cloud()
 
-            response = await self._request("GET", test_endpoint)
-            
-            # Handle both dict and list responses
-            # Local API (after normalization) returns list directly
-            # Cloud API returns dict with "meta", "data", etc.
-            if isinstance(response, list):
-                # List response means we got data successfully (local API)
-                self._authenticated = True
-                # Build site UUID -> name mapping for local API
-                if self.settings.api_type == APIType.LOCAL:
-                    self._build_site_uuid_map(response)
-            elif isinstance(response, dict):
-                # Dict response - check for success indicators
-                self._authenticated = (
-                    response.get("meta", {}).get("rc") == "ok"
-                    or response.get("data") is not None
-                    or response.get("count") is not None
-                )
-            else:
-                self._authenticated = False
-                
-            self.logger.info(f"Successfully authenticated with UniFi API (response type: {type(response).__name__})")
+            self.logger.info(f"Successfully authenticated with UniFi API ({self.settings.api_type.value} mode)")
         except Exception as e:
             self.logger.error(f"Authentication failed: {e}")
             raise AuthenticationError(f"Failed to authenticate with UniFi API: {e}") from e
+
+    async def _authenticate_local(self) -> None:
+        """Authenticate with local UniFi gateway using username/password.
+
+        Raises:
+            AuthenticationError: If login fails
+        """
+        login_url = f"{self.settings.base_url}/api/auth/login"
+
+        login_payload = {
+            "username": self.settings.username,
+            "password": self.settings.password,
+            "remember": True,  # Request persistent session
+        }
+
+        self.logger.debug(f"Attempting local gateway login at {login_url}")
+
+        try:
+            response = await self.client.post(
+                login_url,
+                json=login_payload,
+            )
+
+            if response.status_code != 200:
+                raise AuthenticationError(
+                    f"Local gateway login failed with status {response.status_code}: {response.text}"
+                )
+
+            # Extract session cookie from response
+            # UniFi gateways typically use 'unifises' or 'TOKEN' cookie
+            cookies = response.cookies
+            if not cookies:
+                raise AuthenticationError("No session cookie received from local gateway")
+
+            # Store cookies for subsequent requests
+            # The httpx client will automatically maintain cookies
+            self._authenticated = True
+
+            # Now fetch sites to build UUID mapping
+            test_endpoint = "/ea/sites"
+            response_data = await self._request("GET", test_endpoint)
+
+            # Build site UUID -> name mapping for local API
+            if isinstance(response_data, list):
+                self._build_site_uuid_map(response_data)
+
+            self.logger.debug(f"Local gateway login successful, session established")
+
+        except httpx.HTTPError as e:
+            raise AuthenticationError(f"HTTP error during local gateway login: {e}") from e
+
+    async def _authenticate_cloud(self) -> None:
+        """Authenticate with Cloud API by validating API key.
+
+        Raises:
+            AuthenticationError: If API key is invalid
+        """
+        # Test authentication with a simple API call
+        # Use appropriate endpoint based on API type
+        if self.settings.api_type == APIType.CLOUD_V1:
+            test_endpoint = "/v1/hosts"  # V1 stable API
+        else:
+            test_endpoint = "/ea/sites"  # EA API
+
+        response = await self._request("GET", test_endpoint)
+
+        # Handle both dict and list responses
+        if isinstance(response, list):
+            # List response means we got data successfully
+            self._authenticated = True
+        elif isinstance(response, dict):
+            # Dict response - check for success indicators
+            self._authenticated = (
+                response.get("meta", {}).get("rc") == "ok"
+                or response.get("data") is not None
+                or response.get("count") is not None
+            )
+        else:
+            self._authenticated = False
     
     def _build_site_uuid_map(self, sites: list[dict[str, Any]]) -> None:
         """Build a mapping of site UUIDs to internal reference names.

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -29,10 +29,22 @@ class Settings(BaseSettings):
     )
 
     # API Configuration
-    api_key: str = Field(
-        ...,
-        description="UniFi API key (X-API-Key header)",
+    api_key: str | None = Field(
+        default=None,
+        description="UniFi API key (X-API-Key header) - required for Cloud APIs",
         validation_alias="UNIFI_API_KEY",
+    )
+
+    username: str | None = Field(
+        default=None,
+        description="UniFi username - required for Local API",
+        validation_alias="UNIFI_USERNAME",
+    )
+
+    password: str | None = Field(
+        default=None,
+        description="UniFi password - required for Local API",
+        validation_alias="UNIFI_PASSWORD",
     )
 
     api_type: APIType = Field(
@@ -190,8 +202,14 @@ class Settings(BaseSettings):
         Raises:
             ValueError: If local API is selected but host is not provided
         """
-        if self.api_type == APIType.LOCAL and not self.local_host:
-            raise ValueError("local_host is required when api_type is 'local'")
+        if self.api_type == APIType.LOCAL:
+            if not self.local_host:
+                raise ValueError("local_host is required when api_type is 'local'")
+            if not self.username or not self.password:
+                raise ValueError("username and password are required for local API authentication")
+        elif self.api_type in (APIType.CLOUD_V1, APIType.CLOUD_EA):
+            if not self.api_key:
+                raise ValueError("api_key is required for Cloud API authentication")
         return self
 
     @property
@@ -314,8 +332,13 @@ class Settings(BaseSettings):
         Returns:
             Dictionary of HTTP headers
         """
-        return {
-            "X-API-KEY": self.api_key,  # UniFi API expects all caps
+        headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
+
+        # Only include API key for Cloud APIs
+        if self.api_type in (APIType.CLOUD_V1, APIType.CLOUD_EA) and self.api_key:
+            headers["X-API-KEY"] = self.api_key  # UniFi API expects all caps
+
+        return headers


### PR DESCRIPTION
### **User description**
## Summary
Fixes authentication failures when using local UniFi gateway.

## Problem
Local gateways returned 401 Unauthorized - code was using API key auth instead of username/password.

## Solution  
- Added username/password config fields for local authentication
- Implemented proper local gateway login flow (POST to /api/auth/login)
- Split authentication into separate Cloud and Local methods
- Session cookies automatically maintained by httpx

## Testing
Add to .env:
```
UNIFI_USERNAME=your-username
UNIFI_PASSWORD=your-password
```

Then run the test suite to verify authentication succeeds.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Implement username/password authentication for local UniFi gateways

- Split authentication logic into separate Cloud and Local methods

- Make API key optional, require credentials based on API type

- Add session cookie handling for local gateway login flow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Auth["authenticate()"]
  Auth -- "api_type == LOCAL" --> Local["_authenticate_local()"]
  Auth -- "api_type == CLOUD" --> Cloud["_authenticate_cloud()"]
  Local -- "POST /api/auth/login" --> LocalGW["Local Gateway"]
  LocalGW -- "session cookie" --> Client["httpx Client"]
  Cloud -- "GET test endpoint" --> CloudAPI["Cloud API"]
  CloudAPI -- "validate API key" --> Client
  Client -- "subsequent requests" --> Success["_authenticated = True"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Split authentication into Cloud and Local flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/api/client.py

<ul><li>Added <code>_session_cookie</code> instance variable for local API authentication<br> <li> Split <code>authenticate()</code> into <code>_authenticate_local()</code> and <br><code>_authenticate_cloud()</code> methods<br> <li> Implemented <code>_authenticate_local()</code> with POST to <code>/api/auth/login</code> <br>endpoint<br> <li> Refactored <code>_authenticate_cloud()</code> to validate API key via test request<br> <li> Session cookies automatically maintained by httpx client for local <br>gateway</ul>


</details>


  </td>
  <td><a href="https://github.com/enuno/unifi-mcp-server/pull/15/files#diff-984094d00058b4bfa5d67edd74969ea5f1196b98f7f89cbe70677839ed5891a9">+90/-27</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Add username/password fields and conditional validation</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/config/config.py

<ul><li>Changed <code>api_key</code> field from required to optional with default None<br> <li> Added <code>username</code> optional field for local API authentication<br> <li> Added <code>password</code> optional field for local API authentication<br> <li> Updated <code>validate_local_configuration()</code> to require username/password <br>for local API<br> <li> Updated <code>validate_local_configuration()</code> to require api_key for Cloud <br>APIs<br> <li> Modified <code>get_headers()</code> to only include X-API-KEY header for Cloud APIs</ul>


</details>


  </td>
  <td><a href="https://github.com/enuno/unifi-mcp-server/pull/15/files#diff-d79bc1bd337636d39caddab7cf7002bb45999f8c724305708d7ac7a702df0816">+30/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.example</strong><dd><code>Document authentication requirements by API type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.env.example

<ul><li>Added documentation explaining authentication method depends on API <br>type<br> <li> Clarified Cloud API requires API key authentication<br> <li> Clarified Local API requires username and password<br> <li> Added commented example for UNIFI_USERNAME and UNIFI_PASSWORD fields<br> <li> Reorganized comments to group authentication methods by type</ul>


</details>


  </td>
  <td><a href="https://github.com/enuno/unifi-mcp-server/pull/15/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

