### PR TITLE
feat: Migrate to Alpine Linux base image to eliminate 67+ system CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
 # Multi-stage build for UniFi MCP Server
-FROM python:3.12-slim AS builder
+# Using Alpine Linux for minimal attack surface and reduced CVEs
+
+FROM python:3.12-alpine AS builder
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Install build dependencies (removed after build)
+RUN apk add --no-cache --virtual .build-deps \
+    gcc \
+    musl-dev \
+    libffi-dev \
+    openssl-dev \
+    cargo \
+    rust
 
 # Install uv for faster dependency management
 RUN pip install uv
@@ -22,17 +33,25 @@ RUN uv venv /opt/venv && \
     . /opt/venv/bin/activate && \
     uv pip install --no-cache .
 
-# Final stage
-FROM python:3.12-slim
+# Final stage - minimal runtime image
+FROM python:3.12-alpine
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PATH="/opt/venv/bin:$PATH"
 
+# Install only runtime dependencies (no build tools)
+RUN apk add --no-cache \
+    libffi \
+    openssl \
+    ca-certificates && \
+    # Remove apk cache
+    rm -rf /var/cache/apk/*
+
 # Create non-root user
-RUN groupadd -r mcp && \
-    useradd -r -g mcp -u 1000 -s /sbin/nologin -c "MCP Server User" mcp
+RUN addgroup -S mcp && \
+    adduser -S -G mcp -u 1000 -s /sbin/nologin -D mcp
 
 # Set working directory
 WORKDIR /app
@@ -54,6 +73,9 @@ USER mcp
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import sys; from src.config import Settings; Settings(); sys.exit(0)" || exit 1
+
+# Expose MCP server port (if applicable)
+# EXPOSE 8000
 
 # Default command - run via FastMCP
 CMD ["python", "-m", "src.main"]


### PR DESCRIPTION
### **User description**
## Summary
Migrates the Docker base image from `python:3.12-slim` (Debian-based) to `python:3.12-alpine` (Alpine Linux) to address security vulnerabilities identified in issue #21.

## Changes
- **Base Image**: Changed from `python:3.12-slim` to `python:3.12-alpine`
- **Multi-stage Build**: Enhanced with Alpine-specific dependencies
  - Builder stage: gcc, musl-dev, libffi-dev, openssl-dev, cargo, rust
  - Runtime stage: only libffi, openssl, ca-certificates
- **User Management**: Updated to Alpine-style commands (addgroup/adduser)
- **Cleanup**: Added apk cache removal to reduce image size

## Security Improvements
- **CVE Reduction**: 67+ HIGH/CRITICAL CVEs → **0 vulnerabilities** (Trivy scan)
- **Attack Surface**: Reduced from ~130MB (Debian) to ~50MB (Alpine)
- **Dependency Chain**: musl libc instead of glibc reduces CVE exposure
- **Build Dependencies**: Isolated in builder stage, not included in runtime image

## Testing
✅ Container builds successfully
✅ Python 3.12.12 available
✅ All core dependencies installed and working
✅ Trivy security scan: **0 HIGH/CRITICAL vulnerabilities**

## Verification
```bash
# Build and scan
docker build -t unifi-mcp-server:alpine-test .
docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
  aquasec/trivy:latest image --severity HIGH,CRITICAL unifi-mcp-server:alpine-test

# Result: 0 vulnerabilities found
```

Closes #21


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Migrate base image from Debian to Alpine Linux

- Eliminate 67+ HIGH/CRITICAL system CVEs

- Reduce attack surface from ~130MB to ~50MB

- Implement multi-stage build with isolated dependencies

- Update user creation to Alpine-specific commands


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["python:3.12-slim<br/>Debian-based<br/>67+ CVEs"] -->|"Multi-stage build"| B["Builder Stage<br/>gcc, musl-dev, libffi-dev<br/>openssl-dev, cargo, rust"]
  B -->|"Copy venv only"| C["python:3.12-alpine<br/>Runtime Stage<br/>libffi, openssl, ca-certs"]
  C -->|"Result"| D["Minimal Image<br/>~50MB<br/>0 CVEs"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement, security, configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Alpine Linux migration with multi-stage optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<ul><li>Changed base image from <code>python:3.12-slim</code> to <code>python:3.12-alpine</code><br> <li> Added Alpine-specific build dependencies in builder stage (gcc, <br>musl-dev, libffi-dev, openssl-dev, cargo, rust)<br> <li> Added minimal runtime dependencies in final stage (libffi, openssl, <br>ca-certificates)<br> <li> Replaced Linux user creation commands with Alpine equivalents <br>(addgroup/adduser instead of groupadd/useradd)<br> <li> Added apk cache cleanup to reduce final image size<br> <li> Added commented EXPOSE directive for documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/enuno/unifi-mcp-server/pull/25/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+27/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

