### PR TITLE
feat: add update_port_forward tool

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -935,6 +935,39 @@ async def create_port_forward(
 
 
 @mcp.tool()
+async def update_port_forward(
+    site_id: str,
+    rule_id: str,
+    name: str | None = None,
+    dst_port: int | None = None,
+    fwd_ip: str | None = None,
+    fwd_port: int | None = None,
+    protocol: str | None = None,
+    src: str | None = None,
+    enabled: bool | None = None,
+    log: bool | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict:
+    """Update an existing port forwarding rule (requires confirm=True)."""
+    return await port_fwd_tools.update_port_forward(
+        site_id,
+        rule_id,
+        settings,
+        name,
+        dst_port,
+        fwd_ip,
+        fwd_port,
+        protocol,
+        src,
+        enabled,
+        log,
+        confirm,
+        dry_run,
+    )
+
+
+@mcp.tool()
 async def delete_port_forward(
     site_id: str, rule_id: str, confirm: bool | str = False, dry_run: bool | str = False
 ) -> dict:

--- a/src/tools/port_forwarding.py
+++ b/src/tools/port_forwarding.py
@@ -183,6 +183,153 @@ async def create_port_forward(
         raise
 
 
+async def update_port_forward(
+    site_id: str,
+    rule_id: str,
+    settings: Settings,
+    name: str | None = None,
+    dst_port: int | None = None,
+    fwd_ip: str | None = None,
+    fwd_port: int | None = None,
+    protocol: str | None = None,
+    src: str | None = None,
+    enabled: bool | None = None,
+    log: bool | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Update an existing port forwarding rule.
+
+    Args:
+        site_id: Site identifier
+        rule_id: Port forwarding rule ID
+        settings: Application settings
+        name: New rule name/description
+        dst_port: New destination port (external/WAN port)
+        fwd_ip: New forward-to IP address (internal/LAN)
+        fwd_port: New forward-to port (internal)
+        protocol: New protocol (tcp, udp, tcp_udp)
+        src: New source restriction (any, or specific IP/network)
+        enabled: Enable or disable the rule
+        log: Enable or disable logging for this rule
+        confirm: Confirmation flag (must be True to execute)
+        dry_run: If True, validate but don't update the rule
+
+    Returns:
+        Updated port forwarding rule dictionary or dry-run result
+
+    Raises:
+        ConfirmationRequiredError: If confirm is not True
+        ResourceNotFoundError: If rule not found
+        ValidationError: If validation fails
+    """
+    site_id = validate_site_id(site_id)
+    validate_confirmation(confirm, "port forwarding operation", dry_run)
+    logger = get_logger(__name__, settings.log_level)
+
+    # Validate optional fields if provided
+    if dst_port is not None:
+        validate_port(dst_port)
+    if fwd_port is not None:
+        validate_port(fwd_port)
+    if fwd_ip is not None:
+        validate_ip_address(fwd_ip)
+    if protocol is not None:
+        valid_protocols = ["tcp", "udp", "tcp_udp"]
+        if protocol not in valid_protocols:
+            raise ValidationError(
+                f"Invalid protocol '{protocol}'. Must be one of: {valid_protocols}"
+            )
+    if src is not None and src != "any":
+        validate_ip_address(src.split("/")[0])  # Validate IP part of CIDR
+
+    parameters = {
+        "site_id": site_id,
+        "rule_id": rule_id,
+        "name": name,
+        "dst_port": dst_port,
+        "fwd_ip": fwd_ip,
+        "fwd_port": fwd_port,
+        "protocol": protocol,
+        "src": src,
+        "enabled": enabled,
+        "log": log,
+    }
+
+    if dry_run:
+        logger.info(f"DRY RUN: Would update port forwarding rule '{rule_id}' in site '{site_id}'")
+        log_audit(
+            operation="update_port_forward",
+            parameters=parameters,
+            result="dry_run",
+            site_id=site_id,
+            dry_run=True,
+        )
+        return {"dry_run": True, "would_update": parameters}
+
+    try:
+        async with UniFiClient(settings) as client:
+            await client.authenticate()
+
+            # Get existing rule
+            response = await client.get(f"/ea/sites/{site_id}/rest/portforward")
+            rules_data: list[dict[str, Any]] = (
+                response if isinstance(response, list) else response.get("data", [])
+            )
+
+            existing_rule = next((r for r in rules_data if r.get("_id") == rule_id), None)
+            if not existing_rule:
+                raise ResourceNotFoundError("port_forward_rule", rule_id)
+
+            # Build update data by merging provided fields into existing rule
+            update_data = existing_rule.copy()
+            if name is not None:
+                update_data["name"] = name
+            if dst_port is not None:
+                update_data["dst_port"] = str(dst_port)
+            if fwd_ip is not None:
+                update_data["fwd"] = fwd_ip
+            if fwd_port is not None:
+                update_data["fwd_port"] = str(fwd_port)
+            if protocol is not None:
+                update_data["proto"] = protocol
+            if src is not None:
+                update_data["src"] = src
+            if enabled is not None:
+                update_data["enabled"] = enabled
+            if log is not None:
+                update_data["log"] = log
+
+            response = await client.put(
+                f"/ea/sites/{site_id}/rest/portforward/{rule_id}", json_data=update_data
+            )
+            if isinstance(response, list):
+                updated_rule: dict[str, Any] = response[0]
+            else:
+                data_list = response.get("data", [{}])
+                updated_rule = data_list[0] if isinstance(data_list, list) else {}
+
+            logger.info(f"Updated port forwarding rule '{rule_id}' in site '{site_id}'")
+            log_audit(
+                operation="update_port_forward",
+                parameters=parameters,
+                result="success",
+                site_id=site_id,
+            )
+
+            return updated_rule
+
+    except Exception as e:
+        logger.error(f"Failed to update port forwarding rule '{rule_id}': {e}")
+        log_audit(
+            operation="update_port_forward",
+            parameters=parameters,
+            result="failed",
+            site_id=site_id,
+        )
+        raise
+
+
 async def delete_port_forward(
     site_id: str,
     rule_id: str,

--- a/tests/unit/tools/test_port_forwarding_tools.py
+++ b/tests/unit/tools/test_port_forwarding_tools.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import src.tools.port_forwarding as pf_module
-from src.tools.port_forwarding import create_port_forward, delete_port_forward, list_port_forwards
+from src.tools.port_forwarding import (
+    create_port_forward,
+    update_port_forward,
+    delete_port_forward,
+    list_port_forwards,
+)
 from src.utils.exceptions import ResourceNotFoundError, ValidationError
 
 
@@ -322,6 +327,227 @@ async def test_create_port_forward_with_logging(mock_settings):
     call_args = mock_client.post.call_args
     json_data = call_args[1]["json_data"]
     assert json_data["log"] is True
+
+
+# =============================================================================
+# update_port_forward Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_update_port_forward_name_success(mock_settings):
+    """Test updating port forward name."""
+    existing_rule = {
+        "_id": "pf1",
+        "name": "Old Name",
+        "dst_port": "80",
+        "fwd": "192.168.2.100",
+        "fwd_port": "80",
+        "proto": "tcp_udp",
+        "src": "any",
+        "enabled": True,
+        "log": False,
+    }
+    updated_rule = {**existing_rule, "name": "New Name"}
+    mock_get_response = {"data": [existing_rule]}
+    mock_put_response = {"data": [updated_rule]}
+
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_get_response)
+    mock_client.put = AsyncMock(return_value=mock_put_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(pf_module, "UniFiClient", return_value=mock_client):
+        result = await update_port_forward(
+            site_id="default",
+            rule_id="pf1",
+            settings=mock_settings,
+            name="New Name",
+            confirm=True,
+        )
+
+    assert result["name"] == "New Name"
+    put_args = mock_client.put.call_args[1]["json_data"]
+    assert put_args["name"] == "New Name"
+    assert put_args["dst_port"] == "80"  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_update_port_forward_multiple_fields(mock_settings):
+    """Test updating multiple port forward fields at once."""
+    existing_rule = {
+        "_id": "pf1",
+        "name": "Web",
+        "dst_port": "80",
+        "fwd": "192.168.2.100",
+        "fwd_port": "80",
+        "proto": "tcp",
+        "src": "any",
+        "enabled": True,
+        "log": False,
+    }
+    mock_get_response = {"data": [existing_rule]}
+    mock_put_response = [
+        {**existing_rule, "dst_port": "8080", "fwd": "192.168.2.200", "fwd_port": "8080"}
+    ]
+
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_get_response)
+    mock_client.put = AsyncMock(return_value=mock_put_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(pf_module, "UniFiClient", return_value=mock_client):
+        result = await update_port_forward(
+            site_id="default",
+            rule_id="pf1",
+            settings=mock_settings,
+            dst_port=8080,
+            fwd_ip="192.168.2.200",
+            fwd_port=8080,
+            confirm=True,
+        )
+
+    put_args = mock_client.put.call_args[1]["json_data"]
+    assert put_args["dst_port"] == "8080"
+    assert put_args["fwd"] == "192.168.2.200"
+    assert put_args["fwd_port"] == "8080"
+    assert put_args["proto"] == "tcp"  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_update_port_forward_dry_run(mock_settings):
+    """Test port forward update dry run."""
+    result = await update_port_forward(
+        site_id="default",
+        rule_id="pf1",
+        settings=mock_settings,
+        name="New Name",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert result["dry_run"] is True
+    assert result["would_update"]["rule_id"] == "pf1"
+    assert result["would_update"]["name"] == "New Name"
+
+
+@pytest.mark.asyncio
+async def test_update_port_forward_not_found(mock_settings):
+    """Test updating a non-existent port forward."""
+    mock_get_response = {"data": []}
+
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_get_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(pf_module, "UniFiClient", return_value=mock_client):
+        with pytest.raises(ResourceNotFoundError):
+            await update_port_forward(
+                site_id="default",
+                rule_id="nonexistent",
+                settings=mock_settings,
+                name="New Name",
+                confirm=True,
+            )
+
+
+@pytest.mark.asyncio
+async def test_update_port_forward_no_confirm(mock_settings):
+    """Test port forward update fails without confirmation."""
+    with pytest.raises(ValidationError) as excinfo:
+        await update_port_forward(
+            site_id="default",
+            rule_id="pf1",
+            settings=mock_settings,
+            name="New Name",
+            confirm=False,
+        )
+
+    assert "requires confirmation" in str(excinfo.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_update_port_forward_invalid_protocol(mock_settings):
+    """Test update fails with invalid protocol."""
+    with pytest.raises(ValidationError) as excinfo:
+        await update_port_forward(
+            site_id="default",
+            rule_id="pf1",
+            settings=mock_settings,
+            protocol="invalid",
+            confirm=True,
+        )
+
+    assert "Invalid protocol" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_update_port_forward_invalid_port(mock_settings):
+    """Test update fails with invalid port."""
+    with pytest.raises(ValidationError):
+        await update_port_forward(
+            site_id="default",
+            rule_id="pf1",
+            settings=mock_settings,
+            dst_port=99999,
+            confirm=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_port_forward_invalid_ip(mock_settings):
+    """Test update fails with invalid IP address."""
+    with pytest.raises(ValidationError):
+        await update_port_forward(
+            site_id="default",
+            rule_id="pf1",
+            settings=mock_settings,
+            fwd_ip="not-an-ip",
+            confirm=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_port_forward_enable_disable(mock_settings):
+    """Test enabling and disabling a port forward rule."""
+    existing_rule = {
+        "_id": "pf1",
+        "name": "Web",
+        "dst_port": "80",
+        "fwd": "192.168.2.100",
+        "fwd_port": "80",
+        "proto": "tcp_udp",
+        "src": "any",
+        "enabled": True,
+        "log": False,
+    }
+    mock_get_response = {"data": [existing_rule]}
+    mock_put_response = {"data": [{**existing_rule, "enabled": False}]}
+
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_get_response)
+    mock_client.put = AsyncMock(return_value=mock_put_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(pf_module, "UniFiClient", return_value=mock_client):
+        await update_port_forward(
+            site_id="default",
+            rule_id="pf1",
+            settings=mock_settings,
+            enabled=False,
+            confirm=True,
+        )
+
+    put_args = mock_client.put.call_args[1]["json_data"]
+    assert put_args["enabled"] is False
 
 
 # =============================================================================


### PR DESCRIPTION
# NOTICE:
This was written mostly by Claude Sonnet 4.6 as I was adding your MCP library and noticed there was no way to update a port forward rule. Feel free to close this if you don't want to review AI stuff. I figured I would put it out there in case it benefits others.

## Summary

- Adds `update_port_forward` MCP tool to allow modifying existing port forwarding rules in-place, without requiring delete-and-recreate
- Supports partial updates: only fields explicitly provided are changed; all others are preserved from the existing rule
- Updatable fields: `name`, `dst_port`, `fwd_ip`, `fwd_port`, `protocol`, `src`, `enabled`, `log`

## Implementation

Follows the same patterns as `update_firewall_rule`:
1. Validate site ID and confirmation
2. Fetch existing rule via `GET /ea/sites/{site_id}/rest/portforward`
3. Raise `ResourceNotFoundError` if rule not found
4. Merge non-`None` fields into the existing rule data
5. `PUT` the full merged object back to `/ea/sites/{site_id}/rest/portforward/{rule_id}`
6. Log audit entry and return the updated rule

Includes `dry_run` support, `confirm` requirement, full input validation (port ranges, IP addresses, protocol values), and audit logging on success and failure.

## Test plan

- [x] 9 new unit tests added to `tests/unit/tools/test_port_forwarding_tools.py`
- [x] All 25 tests in the file pass
- [x] Manually tested against a live UniFi Dream Machine (UDM) via the MCP server: dry run, single-field update, multi-field update, and revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)