### PR TITLE
fix(firewall_zones): use networkIds instead of networks in zone PUT payload

### DIFF
--- a/src/tools/firewall_zones.py
+++ b/src/tools/firewall_zones.py
@@ -250,7 +250,7 @@ async def assign_network_to_zone(
             settings.get_integration_path(f"sites/{resolved_site_id}/firewall/zones/{zone_id}")
         )
         zone_data = zone_response.get("data", {})
-        current_networks = zone_data.get("networks", [])
+        current_networks = zone_data.get("networkIds", [])
 
         if network_id in current_networks:
             logger.info(f"Network {network_id} already assigned to zone {zone_id}")
@@ -262,7 +262,7 @@ async def assign_network_to_zone(
 
         updated_networks = list(current_networks) + [network_id]
 
-        payload = {"networks": updated_networks}
+        payload = {"networkIds": updated_networks}
 
         if dry_run:
             logger.info(f"[DRY RUN] Would assign network {network_id} to zone {zone_id}")
@@ -315,7 +315,7 @@ async def get_zone_networks(site_id: str, zone_id: str, settings: Settings) -> l
             settings.get_integration_path(f"sites/{resolved_site_id}/firewall/zones/{zone_id}")
         )
         zone_data = response.get("data", {})
-        network_ids = zone_data.get("networks", [])
+        network_ids = zone_data.get("networkIds", [])
 
         # Fetch network details for each network ID
         networks = []
@@ -439,7 +439,7 @@ async def unassign_network_from_zone(
             settings.get_integration_path(f"sites/{resolved_site_id}/firewall/zones/{zone_id}")
         )
         zone_data = zone_response.get("data", {})
-        current_networks = zone_data.get("networks", [])
+        current_networks = zone_data.get("networkIds", [])
 
         if network_id not in current_networks:
             raise ValueError(f"Network {network_id} is not assigned to zone {zone_id}")
@@ -447,7 +447,7 @@ async def unassign_network_from_zone(
         # Remove network from list
         updated_networks = [nid for nid in current_networks if nid != network_id]
 
-        payload = {"networks": updated_networks}
+        payload = {"networkIds": updated_networks}
 
         if dry_run:
             logger.info(f"[DRY RUN] Would remove network {network_id} from zone {zone_id}")

--- a/tests/unit/tools/test_firewall_zones_tools.py
+++ b/tests/unit/tools/test_firewall_zones_tools.py
@@ -366,7 +366,7 @@ class TestAssignNetworkToZone:
     async def test_assign_network_to_zone_success(self, mock_settings, sample_firewall_zones):
         from src.tools.firewall_zones import assign_network_to_zone
 
-        zone_data = {"data": {"networks": ["net-001"]}}
+        zone_data = {"data": {"networkIds": ["net-001"]}}
         network_data = {"data": {"name": "NewNetwork"}}
 
         with (
@@ -397,13 +397,15 @@ class TestAssignNetworkToZone:
 
             assert result["zone_id"] == "zone-001"
             assert result["network_id"] == "net-new"
-            mock_instance.put.assert_called_once()
+            _, kwargs = mock_instance.put.call_args
+            assert "networkIds" in kwargs["json_data"]
+            assert "net-new" in kwargs["json_data"]["networkIds"]
 
     @pytest.mark.asyncio
     async def test_assign_network_to_zone_already_assigned(self, mock_settings):
         from src.tools.firewall_zones import assign_network_to_zone
 
-        zone_data = {"data": {"networks": ["net-001", "net-002"]}}
+        zone_data = {"data": {"networkIds": ["net-001", "net-002"]}}
 
         with patch("src.tools.firewall_zones.UniFiClient") as mock_client:
             mock_instance = AsyncMock()
@@ -428,7 +430,7 @@ class TestAssignNetworkToZone:
     async def test_assign_network_to_zone_dry_run(self, mock_settings):
         from src.tools.firewall_zones import assign_network_to_zone
 
-        zone_data = {"data": {"networks": []}}
+        zone_data = {"data": {"networkIds": []}}
 
         with patch("src.tools.firewall_zones.UniFiClient") as mock_client:
             mock_instance = AsyncMock()
@@ -448,6 +450,7 @@ class TestAssignNetworkToZone:
             )
 
             assert result["dry_run"] is True
+            assert "networkIds" in result["payload"]
             mock_instance.put.assert_not_called()
 
 
@@ -456,7 +459,7 @@ class TestUnassignNetworkFromZone:
     async def test_unassign_network_from_zone_success(self, mock_settings):
         from src.tools.firewall_zones import unassign_network_from_zone
 
-        zone_data = {"data": {"networks": ["net-001", "net-002"]}}
+        zone_data = {"data": {"networkIds": ["net-001", "net-002"]}}
 
         with (
             patch("src.tools.firewall_zones.UniFiClient") as mock_client,
@@ -480,13 +483,15 @@ class TestUnassignNetworkFromZone:
 
             assert result["status"] == "success"
             assert result["action"] == "unassigned"
-            mock_instance.put.assert_called_once()
+            _, kwargs = mock_instance.put.call_args
+            assert "networkIds" in kwargs["json_data"]
+            assert "net-001" not in kwargs["json_data"]["networkIds"]
 
     @pytest.mark.asyncio
     async def test_unassign_network_not_in_zone_error(self, mock_settings):
         from src.tools.firewall_zones import unassign_network_from_zone
 
-        zone_data = {"data": {"networks": ["net-001"]}}
+        zone_data = {"data": {"networkIds": ["net-001"]}}
 
         with patch("src.tools.firewall_zones.UniFiClient") as mock_client:
             mock_instance = AsyncMock()
@@ -509,7 +514,7 @@ class TestUnassignNetworkFromZone:
     async def test_unassign_network_from_zone_dry_run(self, mock_settings):
         from src.tools.firewall_zones import unassign_network_from_zone
 
-        zone_data = {"data": {"networks": ["net-001", "net-002"]}}
+        zone_data = {"data": {"networkIds": ["net-001", "net-002"]}}
 
         with patch("src.tools.firewall_zones.UniFiClient") as mock_client:
             mock_instance = AsyncMock()
@@ -529,6 +534,7 @@ class TestUnassignNetworkFromZone:
             )
 
             assert result["dry_run"] is True
+            assert "networkIds" in result["payload"]
             mock_instance.put.assert_not_called()
 
 
@@ -537,7 +543,7 @@ class TestGetZoneNetworks:
     async def test_get_zone_networks_success(self, mock_settings):
         from src.tools.firewall_zones import get_zone_networks
 
-        zone_data = {"data": {"networks": ["net-001", "net-002"]}}
+        zone_data = {"data": {"networkIds": ["net-001", "net-002"]}}
         network1_data = {"data": {"name": "Network1"}}
         network2_data = {"data": {"name": "Network2"}}
 
@@ -573,7 +579,7 @@ class TestGetZoneNetworks:
     async def test_get_zone_networks_empty(self, mock_settings):
         from src.tools.firewall_zones import get_zone_networks
 
-        zone_data = {"data": {"networks": []}}
+        zone_data = {"data": {"networkIds": []}}
 
         with patch("src.tools.firewall_zones.UniFiClient") as mock_client:
             mock_instance = AsyncMock()
@@ -591,7 +597,7 @@ class TestGetZoneNetworks:
     async def test_get_zone_networks_fetch_error_handled(self, mock_settings):
         from src.tools.firewall_zones import get_zone_networks
 
-        zone_data = {"data": {"networks": ["net-001"]}}
+        zone_data = {"data": {"networkIds": ["net-001"]}}
 
         with patch("src.tools.firewall_zones.UniFiClient") as mock_client:
             mock_instance = AsyncMock()


### PR DESCRIPTION
## Description

Three functions in `src/tools/firewall_zones.py` were reading and writing the `networks` key when interacting with the firewall zones API. The actual UniFi API uses `networkIds` (confirmed from the verified working `create_firewall_zone` and `update_firewall_zone` implementations in the same file, and validated against a live UDM-Pro-Max).

**Functions affected:**
- `assign_network_to_zone` — read `zone_data.get("networks", [])`, sent `{"networks": ...}` in PUT payload
- `unassign_network_from_zone` — same field name bug
- `get_zone_networks` — read `zone_data.get("networks", [])`, always returned empty list

**Root cause:** Inconsistency introduced during initial implementation — `create_firewall_zone` and `update_firewall_zone` used `networkIds` correctly, but the three network-assignment functions used the wrong key.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

**Unit tests:** All 24 tests in `TestAssignNetworkToZone`, `TestUnassignNetworkFromZone`, and `TestGetZoneNetworks` pass. Mock data updated from `"networks"` to `"networkIds"`. Added explicit payload assertions to `test_assign_network_to_zone_success` and `test_unassign_network_from_zone_success` to verify the correct key is sent to the API.

**Live controller validation:** Ran the full integration test suite (`tests/integration/test_firewall_zones_suite.py`) against a UDM-Pro-Max running UniFi Network 9.x. All 7 applicable tests passed (1 skipped — cloud API rejection test, expected on local API):
- `test_list_firewall_zones` — PASS (8 zones returned)
- `test_create_and_delete_firewall_zone` — PASS (create/verify/delete/verify round-trip)
- `test_update_firewall_zone` — PASS
- `test_create_firewall_zone_dry_run` — PASS
- `test_get_zone_networks` — PASS (correctly returns empty list for new zone)
- `test_delete_firewall_zone_dry_run` — PASS

All test objects created during integration testing were cleaned up.

**Full test suite:** 1,137 tests passing, no regressions.

**Note on pre-commit:** `mypy` reports 9 pre-existing errors in `firewall_zones.py` (missing `assigned_at` argument on `ZoneNetworkAssignment`) and 2 in the test file (`var-annotated`). These are identical before and after this change — verified by running mypy on the original commit. This PR introduces zero new mypy issues.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (docstrings unchanged — behaviour fix, not interface change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## AI Assistance

This PR was created with assistance from Claude (Anthropic). All changes were reviewed and validated by the human contributor against a live UniFi controller before submission.