### PR TITLE
feat(firewall_policies): add client-side limit/offset pagination to list_firewall_policies

### DIFF
--- a/src/tools/firewall_policies.py
+++ b/src/tools/firewall_policies.py
@@ -6,7 +6,7 @@ from ..api.client import UniFiClient
 from ..config import APIType, Settings
 from ..models.firewall_policy import FirewallPolicy, FirewallPolicyCreate
 from ..utils import ResourceNotFoundError, get_logger, log_audit
-from ..utils.validators import coerce_bool
+from ..utils.validators import coerce_bool, validate_limit_offset
 
 logger = get_logger(__name__)
 
@@ -23,15 +23,22 @@ def _ensure_local_api(settings: Settings) -> None:
 async def list_firewall_policies(
     site_id: str,
     settings: Settings,
+    limit: int | None = None,
+    offset: int | None = None,
 ) -> list[dict[str, Any]]:
     """List all firewall policies (Traffic & Firewall Rules) for a site.
 
     This tool fetches firewall policies from the UniFi v2 API endpoint.
     Only available with local gateway API (api_type="local").
 
+    The UniFi v2 API returns all policies in a single response (no server-side
+    pagination). Use limit and offset to page through results client-side.
+
     Args:
         site_id: Site identifier (default: "default")
         settings: Application settings
+        limit: Maximum number of policies to return
+        offset: Number of policies to skip
 
     Returns:
         List of firewall policy objects
@@ -45,6 +52,7 @@ async def list_firewall_policies(
         and UNIFI_LOCAL_HOST to use this tool.
     """
     _ensure_local_api(settings)
+    limit, offset = validate_limit_offset(limit, offset)
 
     async with UniFiClient(settings) as client:
         logger.info(f"Listing firewall policies for site {site_id}")
@@ -57,7 +65,8 @@ async def list_firewall_policies(
 
         policies_data = response if isinstance(response, list) else response.get("data", [])
 
-        return [FirewallPolicy(**policy).model_dump() for policy in policies_data]
+        all_policies = [FirewallPolicy(**policy).model_dump() for policy in policies_data]
+        return all_policies[offset : offset + limit]
 
 
 async def get_firewall_policy(

--- a/tests/unit/tools/test_firewall_policies.py
+++ b/tests/unit/tools/test_firewall_policies.py
@@ -221,6 +221,94 @@ class TestListFirewallPolicies:
 
             mock_client.authenticate.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_list_firewall_policies_limit(
+        self, local_settings: Settings, sample_policy_response: list[dict]
+    ) -> None:
+        """Test that limit slices the result set."""
+        from src.tools.firewall_policies import list_firewall_policies
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = sample_policy_response
+
+            result = await list_firewall_policies("default", local_settings, limit=1)
+
+            assert len(result) == 1
+            assert result[0]["name"] == "Block IOT to Internal"
+
+    @pytest.mark.asyncio
+    async def test_list_firewall_policies_offset(
+        self, local_settings: Settings, sample_policy_response: list[dict]
+    ) -> None:
+        """Test that offset skips entries."""
+        from src.tools.firewall_policies import list_firewall_policies
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = sample_policy_response
+
+            result = await list_firewall_policies("default", local_settings, offset=1)
+
+            assert len(result) == 1
+            assert result[0]["name"] == "Allow All Traffic"
+
+    @pytest.mark.asyncio
+    async def test_list_firewall_policies_limit_and_offset(
+        self, local_settings: Settings, sample_policy_response: list[dict]
+    ) -> None:
+        """Test limit and offset together."""
+        from src.tools.firewall_policies import list_firewall_policies
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = sample_policy_response
+
+            result = await list_firewall_policies("default", local_settings, limit=1, offset=1)
+
+            assert len(result) == 1
+            assert result[0]["name"] == "Allow All Traffic"
+
+    @pytest.mark.asyncio
+    async def test_list_firewall_policies_offset_beyond_end(
+        self, local_settings: Settings, sample_policy_response: list[dict]
+    ) -> None:
+        """Test offset beyond list length returns empty list."""
+        from src.tools.firewall_policies import list_firewall_policies
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = sample_policy_response
+
+            result = await list_firewall_policies("default", local_settings, offset=100)
+
+            assert result == []
+
+    @pytest.mark.asyncio
+    async def test_list_firewall_policies_no_pagination_returns_all(
+        self, local_settings: Settings, sample_policy_response: list[dict]
+    ) -> None:
+        """Test that omitting limit/offset returns all results."""
+        from src.tools.firewall_policies import list_firewall_policies
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = sample_policy_response
+
+            result = await list_firewall_policies("default", local_settings)
+
+            assert len(result) == 2
+
 
 class TestGetFirewallPolicy:
     """Tests for get_firewall_policy function."""


### PR DESCRIPTION
## Description

The UniFi v2 firewall-policies endpoint (`/proxy/network/v2/api/site/{site}/firewall-policies`) returns a flat list with no server-side pagination support — it ignores all pagination query params (`limit`, `offset`, `pageSize`, etc.) and always returns the full result set.

This PR adds client-side `limit` and `offset` parameters to `list_firewall_policies`, allowing callers to page through large policy sets. The implementation follows the established pattern used by `wifi.py` (`list_wlans`) and `dpi.py` (`get_client_dpi_statistics`), using the shared `validate_limit_offset` utility.

**Key behaviour:**
- Without `limit`/`offset`: returns all policies (backwards compatible)
- `limit=N`: returns first N policies
- `offset=N`: skips first N policies
- `limit` + `offset`: standard pagination window
- `offset` beyond list length: returns `[]`

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- 5 new unit tests covering: `limit` only, `offset` only, `limit` + `offset`, offset-beyond-end, and no-args passthrough
- All 1,142 existing unit tests continue to pass
- Investigated live against a UDM-Pro-Max with 120 policies — confirmed the API returns a flat list with no pagination envelope or headers

## Checklist

- [x] Code follows style guidelines (ruff, black, isort — all clean)
- [x] Self-review completed
- [x] Updated docstring to document `limit`/`offset` params and note the API's flat-list behaviour
- [x] Added tests (5 new pagination tests)
- [x] Tests pass (1,142 passing)
- [x] No new warnings

## AI Assistance

This PR was created with assistance from Claude Code.