### PR TITLE
fix: integration API compatibility across ACLs, zones, devices, traffic flows

### DIFF
--- a/src/models/acl.py
+++ b/src/models/acl.py
@@ -7,7 +7,10 @@ class ACLRule(BaseModel):
     """ACL rule model."""
 
     id: str = Field(..., alias="_id", description="ACL rule identifier")
-    site_id: str = Field(..., description="Site identifier")
+    site_id: str | None = Field(
+        None,
+        description="Site identifier (not returned by UniFi integration API v1)",
+    )
     name: str = Field(..., description="Rule name")
     enabled: bool = Field(True, description="Whether the rule is enabled")
     action: str = Field(..., description="Action to take (allow/deny)")

--- a/src/tools/acls.py
+++ b/src/tools/acls.py
@@ -9,6 +9,43 @@ from ..utils import audit_action, get_logger, sanitize_log_message, validate_con
 
 logger = get_logger(__name__)
 
+# The UniFi integration API accepts only these values on ACL rules.
+_VALID_ACTIONS = ("ALLOW", "BLOCK")
+_VALID_TYPES = ("IPV4", "MAC")
+
+
+def _normalise_action(action: str) -> str:
+    upper = action.upper()
+    if upper not in _VALID_ACTIONS:
+        raise ValueError(
+            f"Invalid action '{action}'. UniFi integration API accepts only "
+            f"{_VALID_ACTIONS}."
+        )
+    return upper
+
+
+def _normalise_type(type_value: str) -> str:
+    upper = type_value.upper()
+    if upper not in _VALID_TYPES:
+        raise ValueError(
+            f"Invalid type '{type_value}'. UniFi integration API accepts only "
+            f"{_VALID_TYPES}."
+        )
+    return upper
+
+
+def _warn_deprecated(operation: str, deprecated: dict[str, Any]) -> None:
+    """Log a warning when a caller passes parameters that the UniFi integration
+    API no longer accepts. Kept in the signature for backwards compatibility."""
+    supplied = [name for name, value in deprecated.items() if value is not None]
+    if supplied:
+        logger.warning(
+            sanitize_log_message(
+                f"{operation}: parameters {sorted(supplied)} are not accepted by "
+                "the UniFi integration API and will be ignored."
+            )
+        )
+
 
 async def list_acl_rules(
     site_id: str,
@@ -43,8 +80,12 @@ async def list_acl_rules(
         if filter_expr:
             params["filter"] = filter_expr
 
-        response = await client.get(f"/integration/v1/sites/{site_id}/acls", params=params)
-        data = response.get("data", [])
+        resolved_site_id = await client.resolve_site_id(site_id)
+        response = await client.get(
+            settings.get_integration_path(f"sites/{resolved_site_id}/acl-rules"),
+            params=params,
+        )
+        data = response if isinstance(response, list) else response.get("data", [])
 
         return [ACLRule(**rule).model_dump() for rule in data]
 
@@ -66,7 +107,12 @@ async def get_acl_rule(site_id: str, acl_rule_id: str, settings: Settings) -> di
         if not client.is_authenticated:
             await client.authenticate()
 
-        response = await client.get(f"/integration/v1/sites/{site_id}/acls/{acl_rule_id}")
+        resolved_site_id = await client.resolve_site_id(site_id)
+        response = await client.get(
+            settings.get_integration_path(
+                f"sites/{resolved_site_id}/acl-rules/{acl_rule_id}"
+            )
+        )
         data = response.get("data", response)
 
         return ACLRule(**data).model_dump()  # type: ignore[no-any-return]
@@ -77,6 +123,7 @@ async def create_acl_rule(
     name: str,
     action: str,
     settings: Settings,
+    type: str = "IPV4",
     enabled: bool = True,
     source_type: str | None = None,
     source_id: str | None = None,
@@ -87,30 +134,39 @@ async def create_acl_rule(
     protocol: str | None = None,
     src_port: int | None = None,
     dst_port: int | None = None,
-    priority: int = 100,
+    priority: int | None = None,
     description: str | None = None,
     confirm: bool | str = False,
     dry_run: bool | str = False,
 ) -> dict:
     """Create a new ACL rule.
 
+    The UniFi integration API accepts only a minimal shape for ACL rule
+    creation: ``{name, action, type, enabled}``. The legacy source/destination
+    filter parameters (``source_*``, ``destination_*``, ``protocol``,
+    ``src_port``, ``dst_port``, ``priority``, ``description``) are kept in the
+    signature for backwards compatibility but are ignored by the API and are
+    not sent in the request body. A warning is logged if any are passed.
+
     Args:
         site_id: Site identifier
         name: Rule name
-        action: Action to take (allow/deny)
+        action: ALLOW or BLOCK (case-insensitive). DROP/REJECT/DENY are not
+            accepted by the integration API.
         settings: Application settings
-        enabled: Whether the rule is enabled
-        source_type: Source type (network/device/ip/any)
-        source_id: Source identifier
-        source_network: Source network CIDR
-        destination_type: Destination type
-        destination_id: Destination identifier
-        destination_network: Destination network CIDR
-        protocol: Protocol (tcp/udp/icmp/all)
-        src_port: Source port
-        dst_port: Destination port
-        priority: Rule priority (lower = higher priority)
-        description: Rule description
+        type: Rule type — IPV4 or MAC. Defaults to IPV4.
+        enabled: Whether the rule is enabled (defaults to True)
+        source_type: DEPRECATED — not accepted by the integration API.
+        source_id: DEPRECATED — not accepted by the integration API.
+        source_network: DEPRECATED — not accepted by the integration API.
+        destination_type: DEPRECATED — not accepted by the integration API.
+        destination_id: DEPRECATED — not accepted by the integration API.
+        destination_network: DEPRECATED — not accepted by the integration API.
+        protocol: DEPRECATED — not accepted by the integration API.
+        src_port: DEPRECATED — not accepted by the integration API.
+        dst_port: DEPRECATED — not accepted by the integration API.
+        priority: DEPRECATED — not accepted by the integration API.
+        description: DEPRECATED — not accepted by the integration API.
         confirm: Confirmation flag (required)
         dry_run: If True, validate but don't execute
 
@@ -119,46 +175,52 @@ async def create_acl_rule(
     """
     validate_confirmation(confirm, "create ACL rule", dry_run)
 
+    normalised_action = _normalise_action(action)
+    normalised_type = _normalise_type(type)
+
+    _warn_deprecated(
+        "create_acl_rule",
+        {
+            "source_type": source_type,
+            "source_id": source_id,
+            "source_network": source_network,
+            "destination_type": destination_type,
+            "destination_id": destination_id,
+            "destination_network": destination_network,
+            "protocol": protocol,
+            "src_port": src_port,
+            "dst_port": dst_port,
+            "priority": priority,
+            "description": description,
+        },
+    )
+
     async with UniFiClient(settings) as client:
         logger.info(sanitize_log_message(f"Creating ACL rule '{name}' for site {site_id}"))
 
         if not client.is_authenticated:
             await client.authenticate()
 
-        # Build request payload
-        payload = {
+        payload: dict[str, Any] = {
             "name": name,
             "enabled": enabled,
-            "action": action,
-            "priority": priority,
+            "action": normalised_action,
+            "type": normalised_type,
         }
 
-        if description:
-            payload["description"] = description
-        if source_type:
-            payload["sourceType"] = source_type
-        if source_id:
-            payload["sourceId"] = source_id
-        if source_network:
-            payload["sourceNetwork"] = source_network
-        if destination_type:
-            payload["destinationType"] = destination_type
-        if destination_id:
-            payload["destinationId"] = destination_id
-        if destination_network:
-            payload["destinationNetwork"] = destination_network
-        if protocol:
-            payload["protocol"] = protocol
-        if src_port is not None:
-            payload["srcPort"] = src_port
-        if dst_port is not None:
-            payload["dstPort"] = dst_port
-
         if dry_run:
-            logger.info(sanitize_log_message(f"[DRY RUN] Would create ACL rule '{name}' for site {site_id}"))
+            logger.info(
+                sanitize_log_message(
+                    f"[DRY RUN] Would create ACL rule '{name}' for site {site_id}"
+                )
+            )
             return {"dry_run": True, "payload": payload}
 
-        response = await client.post(f"/integration/v1/sites/{site_id}/acls", json_data=payload)
+        resolved_site_id = await client.resolve_site_id(site_id)
+        response = await client.post(
+            settings.get_integration_path(f"sites/{resolved_site_id}/acl-rules"),
+            json_data=payload,
+        )
         data = response.get("data", response)
 
         # Audit the action
@@ -166,9 +228,9 @@ async def create_acl_rule(
             settings,
             action_type="create_acl_rule",
             resource_type="acl_rule",
-            resource_id=data.get("_id", "unknown"),
+            resource_id=data.get("_id", data.get("id", "unknown")),
             site_id=site_id,
-            details={"name": name, "action": action},
+            details={"name": name, "action": normalised_action, "type": normalised_type},
         )
 
         return ACLRule(**data).model_dump()  # type: ignore[no-any-return]
@@ -180,6 +242,7 @@ async def update_acl_rule(
     settings: Settings,
     name: str | None = None,
     action: str | None = None,
+    type: str | None = None,
     enabled: bool | None = None,
     source_type: str | None = None,
     source_id: str | None = None,
@@ -197,24 +260,29 @@ async def update_acl_rule(
 ) -> dict:
     """Update an existing ACL rule.
 
+    The UniFi integration API accepts only ``name``, ``action`` (ALLOW/BLOCK),
+    ``type`` (IPV4/MAC) and ``enabled`` on ACL rule updates. Legacy filter
+    fields are ignored — see :func:`create_acl_rule` for details.
+
     Args:
         site_id: Site identifier
         acl_rule_id: ACL rule identifier
         settings: Application settings
         name: Rule name
-        action: Action to take
+        action: ALLOW or BLOCK (case-insensitive)
+        type: Rule type — IPV4 or MAC
         enabled: Whether the rule is enabled
-        source_type: Source type
-        source_id: Source identifier
-        source_network: Source network CIDR
-        destination_type: Destination type
-        destination_id: Destination identifier
-        destination_network: Destination network CIDR
-        protocol: Protocol
-        src_port: Source port
-        dst_port: Destination port
-        priority: Rule priority
-        description: Rule description
+        source_type: DEPRECATED — not accepted by the integration API.
+        source_id: DEPRECATED — not accepted by the integration API.
+        source_network: DEPRECATED — not accepted by the integration API.
+        destination_type: DEPRECATED — not accepted by the integration API.
+        destination_id: DEPRECATED — not accepted by the integration API.
+        destination_network: DEPRECATED — not accepted by the integration API.
+        protocol: DEPRECATED — not accepted by the integration API.
+        src_port: DEPRECATED — not accepted by the integration API.
+        dst_port: DEPRECATED — not accepted by the integration API.
+        priority: DEPRECATED — not accepted by the integration API.
+        description: DEPRECATED — not accepted by the integration API.
         confirm: Confirmation flag (required)
         dry_run: If True, validate but don't execute
 
@@ -223,49 +291,56 @@ async def update_acl_rule(
     """
     validate_confirmation(confirm, "update ACL rule", dry_run)
 
+    normalised_action = _normalise_action(action) if action is not None else None
+    normalised_type = _normalise_type(type) if type is not None else None
+
+    _warn_deprecated(
+        "update_acl_rule",
+        {
+            "source_type": source_type,
+            "source_id": source_id,
+            "source_network": source_network,
+            "destination_type": destination_type,
+            "destination_id": destination_id,
+            "destination_network": destination_network,
+            "protocol": protocol,
+            "src_port": src_port,
+            "dst_port": dst_port,
+            "priority": priority,
+            "description": description,
+        },
+    )
+
     async with UniFiClient(settings) as client:
         logger.info(sanitize_log_message(f"Updating ACL rule {acl_rule_id} for site {site_id}"))
 
         if not client.is_authenticated:
             await client.authenticate()
 
-        # Build request payload with only provided fields
         payload: dict[str, Any] = {}
         if name is not None:
             payload["name"] = name
-        if action is not None:
-            payload["action"] = action
+        if normalised_action is not None:
+            payload["action"] = normalised_action
+        if normalised_type is not None:
+            payload["type"] = normalised_type
         if enabled is not None:
             payload["enabled"] = enabled
-        if priority is not None:
-            payload["priority"] = priority
-        if description is not None:
-            payload["description"] = description
-        if source_type is not None:
-            payload["sourceType"] = source_type
-        if source_id is not None:
-            payload["sourceId"] = source_id
-        if source_network is not None:
-            payload["sourceNetwork"] = source_network
-        if destination_type is not None:
-            payload["destinationType"] = destination_type
-        if destination_id is not None:
-            payload["destinationId"] = destination_id
-        if destination_network is not None:
-            payload["destinationNetwork"] = destination_network
-        if protocol is not None:
-            payload["protocol"] = protocol
-        if src_port is not None:
-            payload["srcPort"] = src_port
-        if dst_port is not None:
-            payload["dstPort"] = dst_port
 
         if dry_run:
-            logger.info(sanitize_log_message(f"[DRY RUN] Would update ACL rule {acl_rule_id} for site {site_id}"))
+            logger.info(
+                sanitize_log_message(
+                    f"[DRY RUN] Would update ACL rule {acl_rule_id} for site {site_id}"
+                )
+            )
             return {"dry_run": True, "payload": payload}
 
+        resolved_site_id = await client.resolve_site_id(site_id)
         response = await client.put(
-            f"/integration/v1/sites/{site_id}/acls/{acl_rule_id}", json_data=payload
+            settings.get_integration_path(
+                f"sites/{resolved_site_id}/acl-rules/{acl_rule_id}"
+            ),
+            json_data=payload,
         )
         data = response.get("data", response)
 
@@ -313,7 +388,12 @@ async def delete_acl_rule(
             logger.info(sanitize_log_message(f"[DRY RUN] Would delete ACL rule {acl_rule_id}"))
             return {"dry_run": True, "acl_rule_id": acl_rule_id}
 
-        await client.delete(f"/integration/v1/sites/{site_id}/acls/{acl_rule_id}")
+        resolved_site_id = await client.resolve_site_id(site_id)
+        await client.delete(
+            settings.get_integration_path(
+                f"sites/{resolved_site_id}/acl-rules/{acl_rule_id}"
+            )
+        )
 
         # Audit the action
         await audit_action(

--- a/src/tools/devices.py
+++ b/src/tools/devices.py
@@ -6,6 +6,7 @@ from ..api import UniFiClient
 from ..config import Settings
 from ..models import Device
 from ..utils import (
+    APIError,
     ResourceNotFoundError,
     audit_action,
     get_logger,
@@ -20,9 +21,14 @@ from ..utils import (
 async def get_device_details(site_id: str, device_id: str, settings: Settings) -> dict[str, Any]:
     """Get detailed information for a specific device.
 
+    Uses the integration API so ``device_id`` matches the UUIDs returned by
+    ``get_network_topology`` and other integration tools. Also accepts the
+    legacy internal-stats MongoDB ObjectId (``_id``) as a fallback, so callers
+    that already store the legacy ID continue to work.
+
     Args:
         site_id: Site identifier
-        device_id: Device identifier
+        device_id: Device integration-API UUID (or legacy ``_id``)
         settings: Application settings
 
     Returns:
@@ -38,15 +44,61 @@ async def get_device_details(site_id: str, device_id: str, settings: Settings) -
     async with UniFiClient(settings) as client:
         await client.authenticate()
 
-        # Get all devices and find the specific one
-        response = await client.get(f"/ea/sites/{site_id}/devices")
-        devices_data = response.get("data", []) if isinstance(response, dict) else response
+        resolved_site_id = await client.resolve_site_id(site_id)
 
-        for device_data in devices_data:
-            if device_data.get("_id") == device_id:
-                device = Device(**device_data)
-                logger.info(sanitize_log_message(f"Retrieved device details for {device_id}"))
-                return device.model_dump()  # type: ignore[no-any-return]
+        # Fast path: direct lookup on the integration API.
+        try:
+            response = await client.get(
+                settings.get_integration_path(
+                    f"sites/{resolved_site_id}/devices/{device_id}"
+                )
+            )
+            if isinstance(response, dict):
+                device_data = response.get("data", response)
+                # Direct lookup returns a single device object; a list means
+                # we hit a collection endpoint (mocked or otherwise) — fall
+                # through to the list scan below.
+                if isinstance(device_data, dict) and device_data:
+                    logger.info(
+                        sanitize_log_message(f"Retrieved device details for {device_id}")
+                    )
+                    return Device(**device_data).model_dump()  # type: ignore[no-any-return]
+        except (ResourceNotFoundError, APIError) as e:
+            # Direct lookup is a best-effort fast path. A 404 / missing-resource
+            # response just means we should fall through to the paginated list
+            # scan below. Any other exception (auth, network, pydantic) should
+            # propagate — we intentionally don't swallow it.
+            logger.debug(
+                sanitize_log_message(
+                    f"Direct device lookup returned no match, falling back to list scan: {e}"
+                )
+            )
+
+        # Fallback: page through the integration devices list and match on
+        # either ``id`` (integration UUID) or ``_id`` (legacy ObjectId).
+        offset = 0
+        while True:
+            response = await client.get(
+                settings.get_integration_path(f"sites/{resolved_site_id}/devices"),
+                params={"offset": offset, "limit": 100},
+            )
+            devices_data = (
+                response if isinstance(response, list) else response.get("data", [])
+            )
+            if not devices_data:
+                break
+            for device_data in devices_data:
+                if (
+                    device_data.get("id") == device_id
+                    or device_data.get("_id") == device_id
+                ):
+                    logger.info(
+                        sanitize_log_message(f"Retrieved device details for {device_id}")
+                    )
+                    return Device(**device_data).model_dump()  # type: ignore[no-any-return]
+            if len(devices_data) < 100:
+                break
+            offset += len(devices_data)
 
         raise ResourceNotFoundError("device", device_id)
 

--- a/src/tools/firewall_zones.py
+++ b/src/tools/firewall_zones.py
@@ -89,15 +89,22 @@ async def create_firewall_zone(
         if not client.is_authenticated:
             await client.authenticate()
 
-        # Build request payload
-        # Note: networkIds is required by API (even if empty list)
+        # Build request payload. `networkIds` is required by the integration
+        # API even when empty. `description` is silently rejected by the API
+        # (`api.request.unknown-property`) so we accept it in the signature for
+        # backwards compatibility but log a warning and omit it from the body.
+        if description:
+            logger.warning(
+                sanitize_log_message(
+                    "create_firewall_zone: 'description' is not supported by the "
+                    "UniFi integration API and will be ignored."
+                )
+            )
+
         payload: dict[str, Any] = {
             "name": name,
             "networkIds": network_ids if network_ids else [],
         }
-
-        if description:
-            payload["description"] = description
 
         if dry_run:
             logger.info(sanitize_log_message(f"[DRY RUN] Would create firewall zone '{name}' for site {site_id}"))
@@ -171,15 +178,23 @@ async def update_firewall_zone(
         current_zone = current_zone_response.get("data", current_zone_response)
         current_network_ids = current_zone.get("networkIds", [])
 
-        # Build request payload - networkIds is required by API
+        # Build request payload - networkIds is required by API. `description`
+        # is silently rejected by the integration API (`api.request.unknown-property`);
+        # see create_firewall_zone for details.
+        if description is not None:
+            logger.warning(
+                sanitize_log_message(
+                    "update_firewall_zone: 'description' is not supported by the "
+                    "UniFi integration API and will be ignored."
+                )
+            )
+
         payload: dict[str, Any] = {
             "networkIds": network_ids if network_ids is not None else current_network_ids
         }
 
         if name is not None:
             payload["name"] = name
-        if description is not None:
-            payload["description"] = description
 
         if dry_run:
             logger.info(sanitize_log_message(f"[DRY RUN] Would update firewall zone {firewall_zone_id} for site {site_id}"))

--- a/src/tools/traffic_flows.py
+++ b/src/tools/traffic_flows.py
@@ -73,10 +73,14 @@ async def get_traffic_flows(
             params["offset"] = offset
 
         try:
+            resolved_site_id = await client.resolve_site_id(site_id)
             response = await client.get(
-                f"/integration/v1/sites/{site_id}/traffic/flows", params=params
+                settings.get_integration_path(
+                    f"sites/{resolved_site_id}/traffic/flows"
+                ),
+                params=params,
             )
-            data = response.get("data", [])
+            data = response.get("data", []) if isinstance(response, dict) else response
         except Exception as e:
             logger.warning(sanitize_log_message(f"Traffic flows endpoint not available: {e}"))
             return []
@@ -102,11 +106,24 @@ async def get_flow_statistics(site_id: str, settings: Settings, time_range: str 
             await client.authenticate()
 
         try:
+            resolved_site_id = await client.resolve_site_id(site_id)
             response = await client.get(
-                f"/integration/v1/sites/{site_id}/traffic/flows/statistics",
+                settings.get_integration_path(
+                    f"sites/{resolved_site_id}/traffic/flows/statistics"
+                ),
                 params={"time_range": time_range},
             )
-            data = response.get("data", response)
+            # UniFiClient normalises `{"data": [...]}` → raw list and
+            # `{"data": {...}}` → inner dict, but some firmware returns
+            # wrapped payloads untouched. Handle all three shapes.
+            if isinstance(response, list):
+                data = response[0] if response else {}
+            elif isinstance(response, dict):
+                data = response.get("data", response)
+                if isinstance(data, list):
+                    data = data[0] if data else {}
+            else:
+                data = {}
         except Exception as e:
             logger.warning(sanitize_log_message(f"Flow statistics endpoint not available: {e}"))
             # Return empty statistics
@@ -160,7 +177,12 @@ async def get_traffic_flow_details(site_id: str, flow_id: str, settings: Setting
             await client.authenticate()
 
         try:
-            response = await client.get(f"/integration/v1/sites/{site_id}/traffic/flows/{flow_id}")
+            resolved_site_id = await client.resolve_site_id(site_id)
+            response = await client.get(
+                settings.get_integration_path(
+                    f"sites/{resolved_site_id}/traffic/flows/{flow_id}"
+                )
+            )
             data = response.get("data", response)
         except Exception as e:
             logger.warning(sanitize_log_message(f"Traffic flow details endpoint not available: {e}"))
@@ -195,11 +217,14 @@ async def get_top_flows(
             await client.authenticate()
 
         try:
+            resolved_site_id = await client.resolve_site_id(site_id)
             response = await client.get(
-                f"/integration/v1/sites/{site_id}/traffic/flows/top",
+                settings.get_integration_path(
+                    f"sites/{resolved_site_id}/traffic/flows/top"
+                ),
                 params={"limit": limit, "time_range": time_range, "sort_by": sort_by},
             )
-            data = response.get("data", [])
+            data = response.get("data", []) if isinstance(response, dict) else response
         except Exception:
             # Fallback: get all flows and sort manually
             logger.info("Top flows endpoint not available, fetching all flows")
@@ -243,10 +268,14 @@ async def get_flow_risks(
             params["min_risk_level"] = min_risk_level
 
         try:
+            resolved_site_id = await client.resolve_site_id(site_id)
             response = await client.get(
-                f"/integration/v1/sites/{site_id}/traffic/flows/risks", params=params
+                settings.get_integration_path(
+                    f"sites/{resolved_site_id}/traffic/flows/risks"
+                ),
+                params=params,
             )
-            data = response.get("data", [])
+            data = response.get("data", []) if isinstance(response, dict) else response
         except Exception:
             logger.warning("Flow risks endpoint not available")
             return []
@@ -278,11 +307,14 @@ async def get_flow_trends(
             await client.authenticate()
 
         try:
+            resolved_site_id = await client.resolve_site_id(site_id)
             response = await client.get(
-                f"/integration/v1/sites/{site_id}/traffic/flows/trends",
+                settings.get_integration_path(
+                    f"sites/{resolved_site_id}/traffic/flows/trends"
+                ),
                 params={"time_range": time_range, "interval": interval},
             )
-            data = response.get("data", [])
+            data = response.get("data", []) if isinstance(response, dict) else response
         except Exception:
             logger.warning("Flow trends endpoint not available")
             return []
@@ -322,10 +354,14 @@ async def filter_traffic_flows(
             params["limit"] = limit
 
         try:
+            resolved_site_id = await client.resolve_site_id(site_id)
             response = await client.get(
-                f"/integration/v1/sites/{site_id}/traffic/flows", params=params
+                settings.get_integration_path(
+                    f"sites/{resolved_site_id}/traffic/flows"
+                ),
+                params=params,
             )
-            data = response.get("data", [])
+            data = response.get("data", []) if isinstance(response, dict) else response
         except Exception:
             logger.warning("Filtered flows endpoint not available, using basic filtering")
             # Fallback to basic filtering
@@ -376,10 +412,14 @@ async def stream_traffic_flows(
                 if filter_expression:
                     params["filter"] = filter_expression
 
+                resolved_site_id = await client.resolve_site_id(site_id)
                 response = await client.get(
-                    f"/integration/v1/sites/{site_id}/traffic/flows", params=params
+                    settings.get_integration_path(
+                        f"sites/{resolved_site_id}/traffic/flows"
+                    ),
+                    params=params,
                 )
-                data = response.get("data", [])
+                data = response.get("data", []) if isinstance(response, dict) else response
 
                 current_time = datetime.now(timezone.utc).isoformat()
 

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -98,26 +98,40 @@ def validate_site_id(site_id: str) -> str:
     return site_id
 
 
+_OBJECT_ID_RE = re.compile(r"^[a-f0-9]{24}$")
+_UUID_RE = re.compile(
+    r"^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+)
+
+
 def validate_device_id(device_id: str) -> str:
     """Validate device ID format.
 
+    Accepts two ID spaces:
+
+    * 24-character hex MongoDB ObjectIds (the legacy internal stats API)
+    * RFC-style UUIDs (the UniFi integration API — what
+      ``get_network_topology`` and the v1 ``/devices`` endpoint return)
+
     Args:
-        device_id: Device identifier
+        device_id: Device identifier (UUID or legacy ObjectId)
 
     Returns:
-        Validated device ID
+        Validated, lowercased device ID
 
     Raises:
-        ValidationError: If device ID is invalid
+        ValidationError: If device ID matches neither format
     """
     if not device_id or not isinstance(device_id, str):
         raise ValidationError("Device ID cannot be empty")
 
-    # Device IDs are typically 24-character hex strings (MongoDB ObjectId)
-    if not re.match(r"^[a-f0-9]{24}$", device_id.lower()):
-        raise ValidationError(f"Invalid device ID format: {device_id}")
+    lowered = device_id.lower()
+    if not (_OBJECT_ID_RE.match(lowered) or _UUID_RE.match(lowered)):
+        raise ValidationError(
+            f"Invalid device ID format: {device_id} (expected 24-hex ObjectId or UUID)"
+        )
 
-    return device_id.lower()
+    return lowered
 
 
 def coerce_bool(value: bool | str | None) -> bool:

--- a/tests/unit/tools/test_acls_tools.py
+++ b/tests/unit/tools/test_acls_tools.py
@@ -28,7 +28,16 @@ def mock_settings():
     settings.request_timeout = 30.0
     settings.site_manager_enabled = False
     settings.get_headers = MagicMock(return_value={"X-API-Key": "test-key"})
+    settings.get_integration_path = MagicMock(
+        side_effect=lambda endpoint: f"/integration/v1/{endpoint}"
+    )
     return settings
+
+
+def _prepare_client(mock_client: AsyncMock) -> AsyncMock:
+    """Mock resolve_site_id so tests can assert literal paths."""
+    mock_client.resolve_site_id = AsyncMock(side_effect=lambda s: s)
+    return mock_client
 
 
 @pytest.mark.asyncio
@@ -182,7 +191,7 @@ async def test_get_acl_rule_success(mock_settings):
     }
 
     with patch("src.tools.acls.UniFiClient") as mock_client_class:
-        mock_client = AsyncMock()
+        mock_client = _prepare_client(AsyncMock())
         mock_client.is_authenticated = False
         mock_client.authenticate = AsyncMock()
         mock_client.get = AsyncMock(return_value=mock_response)
@@ -196,7 +205,7 @@ async def test_get_acl_rule_success(mock_settings):
         assert result["name"] == "Block IoT"
         assert result["description"] == "Isolate IoT devices"
         assert result["byte_count"] == 1024000
-        mock_client.get.assert_called_once_with("/integration/v1/sites/default/acls/acl-1")
+        mock_client.get.assert_called_once_with("/integration/v1/sites/default/acl-rules/acl-1")
 
 
 @pytest.mark.asyncio
@@ -264,16 +273,18 @@ async def test_create_acl_rule_success(mock_settings):
 @pytest.mark.asyncio
 async def test_create_acl_rule_dry_run(mock_settings):
     with patch("src.tools.acls.UniFiClient") as mock_client_class:
-        mock_client = AsyncMock()
+        mock_client = _prepare_client(AsyncMock())
         mock_client.is_authenticated = True
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock()
         mock_client_class.return_value = mock_client
 
+        # Legacy source/destination/port kwargs are accepted but silently
+        # dropped from the payload (the integration API rejects them).
         result = await create_acl_rule(
             "default",
             "Test Rule",
-            "deny",
+            "BLOCK",
             mock_settings,
             source_type="network",
             source_network="10.0.0.0/24",
@@ -287,10 +298,11 @@ async def test_create_acl_rule_dry_run(mock_settings):
 
         assert result["dry_run"] is True
         assert result["payload"]["name"] == "Test Rule"
-        assert result["payload"]["action"] == "deny"
-        assert result["payload"]["sourceType"] == "network"
-        assert result["payload"]["sourceNetwork"] == "10.0.0.0/24"
-        assert result["payload"]["dstPort"] == 443
+        assert result["payload"]["action"] == "BLOCK"
+        assert result["payload"]["type"] == "IPV4"
+        assert result["payload"]["enabled"] is True
+        assert "sourceType" not in result["payload"]
+        assert "dstPort" not in result["payload"]
         mock_client.post.assert_not_called()
 
 
@@ -308,31 +320,23 @@ async def test_create_acl_rule_no_confirm(mock_settings):
 
 
 @pytest.mark.asyncio
-async def test_create_acl_rule_full_options(mock_settings):
+async def test_create_acl_rule_legacy_params_ignored(mock_settings):
+    """Legacy source/destination/port filters are accepted for backwards
+    compatibility but dropped from the payload — the UniFi integration API
+    rejects them as unknown properties."""
     mock_response = {
         "data": {
             "_id": "acl-full",
-            "site_id": "default",
             "name": "Full Options Rule",
             "enabled": False,
-            "action": "deny",
-            "source_type": "network",
-            "source_id": "net-1",
-            "source_network": "10.0.0.0/8",
-            "destination_type": "network",
-            "destination_id": "net-2",
-            "destination_network": "192.168.0.0/16",
-            "protocol": "tcp",
-            "src_port": 1024,
-            "dst_port": 443,
-            "priority": 5,
-            "description": "Full test rule",
+            "action": "BLOCK",
+            "type": "IPV4",
         }
     }
 
     with patch("src.tools.acls.UniFiClient") as mock_client_class:
         with patch("src.tools.acls.audit_action", new_callable=AsyncMock):
-            mock_client = AsyncMock()
+            mock_client = _prepare_client(AsyncMock())
             mock_client.is_authenticated = True
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -342,7 +346,7 @@ async def test_create_acl_rule_full_options(mock_settings):
             result = await create_acl_rule(
                 "default",
                 "Full Options Rule",
-                "deny",
+                "block",
                 mock_settings,
                 enabled=False,
                 source_type="network",
@@ -362,14 +366,11 @@ async def test_create_acl_rule_full_options(mock_settings):
             assert result["name"] == "Full Options Rule"
             call_args = mock_client.post.call_args
             payload = call_args[1]["json_data"]
+            # Payload contains only the 4 fields the integration API accepts.
+            assert set(payload.keys()) == {"name", "enabled", "action", "type"}
+            assert payload["action"] == "BLOCK"
+            assert payload["type"] == "IPV4"
             assert payload["enabled"] is False
-            assert payload["sourceType"] == "network"
-            assert payload["destinationType"] == "network"
-            assert payload["protocol"] == "tcp"
-            assert payload["srcPort"] == 1024
-            assert payload["dstPort"] == 443
-            assert payload["priority"] == 5
-            assert payload["description"] == "Full test rule"
 
 
 @pytest.mark.asyncio
@@ -411,7 +412,7 @@ async def test_update_acl_rule_success(mock_settings):
 @pytest.mark.asyncio
 async def test_update_acl_rule_dry_run(mock_settings):
     with patch("src.tools.acls.UniFiClient") as mock_client_class:
-        mock_client = AsyncMock()
+        mock_client = _prepare_client(AsyncMock())
         mock_client.is_authenticated = True
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock()
@@ -423,15 +424,15 @@ async def test_update_acl_rule_dry_run(mock_settings):
             mock_settings,
             name="Preview Name",
             action="allow",
-            priority=50,
+            priority=50,  # legacy kwarg — ignored
             confirm=True,
             dry_run=True,
         )
 
         assert result["dry_run"] is True
         assert result["payload"]["name"] == "Preview Name"
-        assert result["payload"]["action"] == "allow"
-        assert result["payload"]["priority"] == 50
+        assert result["payload"]["action"] == "ALLOW"
+        assert "priority" not in result["payload"]
         mock_client.put.assert_not_called()
 
 
@@ -453,18 +454,16 @@ async def test_update_acl_rule_partial_fields(mock_settings):
     mock_response = {
         "data": {
             "_id": "acl-1",
-            "site_id": "default",
             "name": "Existing Name",
-            "enabled": True,
-            "action": "deny",
-            "protocol": "udp",
-            "priority": 100,
+            "enabled": False,
+            "action": "BLOCK",
+            "type": "IPV4",
         }
     }
 
     with patch("src.tools.acls.UniFiClient") as mock_client_class:
         with patch("src.tools.acls.audit_action", new_callable=AsyncMock):
-            mock_client = AsyncMock()
+            mock_client = _prepare_client(AsyncMock())
             mock_client.is_authenticated = True
             mock_client.put = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -475,22 +474,21 @@ async def test_update_acl_rule_partial_fields(mock_settings):
                 "default",
                 "acl-1",
                 mock_settings,
-                protocol="udp",
+                enabled=False,
                 confirm=True,
             )
 
-            assert result["protocol"] == "udp"
+            assert result["enabled"] is False
             call_args = mock_client.put.call_args
             payload = call_args[1]["json_data"]
-            assert "protocol" in payload
-            assert "name" not in payload
+            assert payload == {"enabled": False}
 
 
 @pytest.mark.asyncio
 async def test_delete_acl_rule_success(mock_settings):
     with patch("src.tools.acls.UniFiClient") as mock_client_class:
         with patch("src.tools.acls.audit_action", new_callable=AsyncMock):
-            mock_client = AsyncMock()
+            mock_client = _prepare_client(AsyncMock())
             mock_client.is_authenticated = False
             mock_client.authenticate = AsyncMock()
             mock_client.delete = AsyncMock(return_value={})
@@ -507,7 +505,9 @@ async def test_delete_acl_rule_success(mock_settings):
 
             assert result["success"] is True
             assert "acl-1" in result["message"]
-            mock_client.delete.assert_called_once_with("/integration/v1/sites/default/acls/acl-1")
+            mock_client.delete.assert_called_once_with(
+                "/integration/v1/sites/default/acl-rules/acl-1"
+            )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tools/test_traffic_flows_tools.py
+++ b/tests/unit/tools/test_traffic_flows_tools.py
@@ -21,6 +21,9 @@ def mock_settings():
     settings.local_port = 443
     settings.local_verify_ssl = False
     settings.log_level = "INFO"
+    settings.get_integration_path = MagicMock(
+        side_effect=lambda endpoint: f"/proxy/network/integration/v1/{endpoint}"
+    )
     return settings
 
 
@@ -599,6 +602,7 @@ class TestApiEndpoints:
             mock_client.return_value.__aenter__.return_value = mock_instance
             mock_instance.is_authenticated = False
             mock_instance.authenticate = AsyncMock()
+            mock_instance.resolve_site_id = AsyncMock(side_effect=lambda s: s)
             mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
 
             await get_traffic_flows("test-site", mock_settings)
@@ -618,6 +622,7 @@ class TestApiEndpoints:
             mock_client.return_value.__aenter__.return_value = mock_instance
             mock_instance.is_authenticated = False
             mock_instance.authenticate = AsyncMock()
+            mock_instance.resolve_site_id = AsyncMock(side_effect=lambda s: s)
             mock_instance.get = AsyncMock(return_value={"data": sample_flow_statistics})
 
             await get_flow_statistics("test-site", mock_settings)
@@ -637,6 +642,7 @@ class TestApiEndpoints:
             mock_client.return_value.__aenter__.return_value = mock_instance
             mock_instance.is_authenticated = False
             mock_instance.authenticate = AsyncMock()
+            mock_instance.resolve_site_id = AsyncMock(side_effect=lambda s: s)
             mock_instance.get = AsyncMock(return_value={"data": sample_flow_risks})
 
             await get_flow_risks("test-site", mock_settings)

--- a/tests/unit/utils/test_validators.py
+++ b/tests/unit/utils/test_validators.py
@@ -177,6 +177,20 @@ class TestValidateDeviceId:
         with pytest.raises(ValidationError, match="Invalid device ID"):
             validate_device_id("507f1f77bcf86cd79943901g")
 
+    def test_valid_uuid(self):
+        """Integration API device IDs are RFC-style UUIDs."""
+        result = validate_device_id("10f4daa4-b87a-3c19-ac11-4697f945cb59")
+        assert result == "10f4daa4-b87a-3c19-ac11-4697f945cb59"
+
+    def test_valid_uuid_uppercase(self):
+        result = validate_device_id("10F4DAA4-B87A-3C19-AC11-4697F945CB59")
+        assert result == "10f4daa4-b87a-3c19-ac11-4697f945cb59"
+
+    def test_invalid_uuid_format(self):
+        # UUID-shaped but wrong segment lengths
+        with pytest.raises(ValidationError, match="Invalid device ID"):
+            validate_device_id("10f4daa4-b87a-3c19-ac1-4697f945cb59")
+
 
 class TestCoerceBool:
     def test_bool_true(self):


### PR DESCRIPTION
Five bugs that broke several MCP tools against current UniFi integration API. Each verified live on a UDM Pro (Network 9.x) by direct curl probes to the endpoints in question.

## Bugs

1. **ACL rules completely broken.** `create`/`update`/`list`/`get`/`delete_acl_rule` hit `/integration/v1/sites/{id}/acls` — real endpoint is `acl-rules` (404 otherwise). Also bypassed `get_integration_path()` / `resolve_site_id()` so local mode missed the `/proxy/network/` prefix. `create` / `update` additionally: (a) missing required `$.type` field (`IPV4`/`MAC`) — API 400s, (b) accepted `action="deny"` but API only accepts uppercase `ALLOW`/`BLOCK`, (c) sent `sourceType`/`sourceId`/`sourceNetwork`/`destinationType`/`destinationId`/`destinationNetwork`/`protocol`/`srcPort`/`dstPort`/`priority`/`description` — all rejected as `api.request.unknown-property`. Legacy params kept in the signature for backwards compatibility, logged as deprecated, dropped from payload. Minimal shape the API accepts: `{name, action, type, enabled}`.

2. **`ACLRule.site_id` required** but the integration API never returns it. Every response fails Pydantic validation. Made optional.

3. **`create_firewall_zone` / `update_firewall_zone`** still send `description` — API rejects it with `api.request.unknown-property`. Parameter kept, deprecation-logged, dropped from body.

4. **`get_device_details` ID space mismatch.** Matches on `_id` (legacy ObjectId) against `/ea/sites/.../devices`, but `get_network_topology` returns `id` (integration UUID). Any topology→details workflow always raises `ResourceNotFoundError`. Now uses the integration API directly; tries direct lookup first, falls back to list scan matching either `id` or `_id` for back-compat.

5. **`traffic_flows.py` — 8 hardcoded paths** bypass `get_integration_path()`. In local mode the translator is skipped and requests hit `https://<gateway>/integration/v1/...` (no `/proxy/network/` prefix → 404). The `except Exception: return []` silently hid the failure as "no data". Fixed all 8 sites + added `resolve_site_id()`.

## Type of Change

- [x] Bug fix (non-breaking — legacy params preserved as deprecated pass-throughs)

## Testing

- 1136 unit tests passing (1 pre-existing unrelated failure in `test_security.py::test_diskcache_not_installed`)
- Updated tests: 6 in `test_acls_tools.py`, 3 endpoint assertions in `test_traffic_flows_tools.py`, mock fixtures gained `get_integration_path` / `resolve_site_id` mocks
- All `sanitize_log_message()` calls from #53 preserved
- Live validation on UDM Pro / Network 9.x: create/update/delete ACL rules (IPV4 + MAC), create zone without description, `get_device_details` with topology UUID (previously threw), traffic flow endpoints now hit correct path

## Checklist

- [x] Self-reviewed
- [x] Tests updated
- [x] No new warnings
- [x] Unit tests pass locally