### PR TITLE
feat(firewall_policies): register zone-based policy tools with zone resolver

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -19,6 +19,7 @@ from .tools import devices as devices_tools
 from .tools import dpi as dpi_tools
 from .tools import dpi_tools as dpi_new_tools
 from .tools import firewall as firewall_tools
+from .tools import firewall_policies as firewall_policies_tools
 from .tools import firewall_zones as firewall_zones_tools
 from .tools import network_config as network_config_tools
 from .tools import networks as networks_tools
@@ -112,6 +113,7 @@ _TOOL_MODULES = [
     dpi_tools,
     dpi_new_tools,
     firewall_tools,
+    firewall_policies_tools,
     firewall_zones_tools,
     network_config_tools,
     networks_tools,

--- a/src/models/firewall_policy.py
+++ b/src/models/firewall_policy.py
@@ -106,6 +106,42 @@ class FirewallPolicyCreate(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
+class FirewallZoneV2Mapping(BaseModel):
+    """Zone listing entry from the v2 ``/firewall/zone`` endpoint.
+
+    Exposes both the internal MongoDB ObjectId (used by the v2
+    ``firewall-policies`` endpoint) and the external UUID (used by the public
+    integration API and most other MCP tools), plus the display name and
+    ``zone_key``. Callers can hand any of these identifiers to
+    ``create_firewall_policy`` / ``update_firewall_policy`` and the zone
+    resolver will map them to the internal id.
+    """
+
+    internal_id: str | None = Field(
+        None,
+        description="MongoDB ObjectId used by the v2 firewall-policies endpoint",
+    )
+    external_id: str | None = Field(
+        None,
+        description="UUID returned by the public integration API",
+    )
+    name: str | None = Field(None, description="Display name")
+    zone_key: str | None = Field(
+        None,
+        description="Internal zone key (e.g. 'internal', 'external', 'dmz')",
+    )
+    default_zone: bool = Field(
+        False,
+        description="Whether this is a UniFi-defined default zone",
+    )
+    network_ids: list[str] = Field(
+        default_factory=list,
+        description="Internal network _ids assigned to this zone",
+    )
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+
 class FirewallPolicyUpdate(BaseModel):
     name: str | None = Field(None, description="Policy name")
     action: str | None = Field(None, description="Policy action")

--- a/src/tools/firewall_policies.py
+++ b/src/tools/firewall_policies.py
@@ -4,11 +4,42 @@ from typing import Any
 
 from ..api.client import UniFiClient
 from ..config import APIType, Settings
-from ..models.firewall_policy import FirewallPolicy, FirewallPolicyCreate
-from ..utils import ResourceNotFoundError, get_logger, log_audit, sanitize_log_message
+from ..models.firewall_policy import (
+    FirewallPolicy,
+    FirewallPolicyCreate,
+    FirewallZoneV2Mapping,
+)
+from ..utils import APIError, ResourceNotFoundError, get_logger, log_audit, sanitize_log_message
 from ..utils.validators import coerce_bool
 
 logger = get_logger(__name__)
+
+# The v2 `firewall-policies` API uses internal MongoDB ObjectIds for zone_id,
+# while the integration API (and most other MCP tools) return the public
+# UUIDs as `external_id`. This cache maps both the external UUID, zone name,
+# and zone_key to the internal ObjectId, populated on demand.
+_zone_cache: dict[str, dict[str, str]] = {}
+
+_VALID_IP_VERSIONS = ("IPV4", "IPV6", "BOTH")
+
+
+def _extract_zone_list(response: Any) -> list[dict[str, Any]]:
+    """Normalize a zone-listing response into a plain list of dicts.
+
+    Handles the three shapes ``UniFiClient`` can return:
+    - raw list (when the API response is ``{"data": [...]}``)
+    - dict with ``data`` field (may be ``None`` or another list)
+    - bare dict payload (unusual but defensively handled)
+    """
+    if isinstance(response, list):
+        return [z for z in response if isinstance(z, dict)]
+    if isinstance(response, dict):
+        inner = response.get("data")
+        if inner is None:
+            return []
+        if isinstance(inner, list):
+            return [z for z in inner if isinstance(z, dict)]
+    return []
 
 
 def _ensure_local_api(settings: Settings) -> None:
@@ -18,6 +49,117 @@ def _ensure_local_api(settings: Settings) -> None:
             "Firewall policies (v2 API) are only available when UNIFI_API_TYPE='local'. "
             "Please configure a local UniFi gateway connection to use these tools."
         )
+
+
+async def _load_zone_index(
+    client: UniFiClient, settings: Settings, site_id: str
+) -> dict[str, str]:
+    """Fetch the v2 zone list and build a name/UUID → internal-_id index."""
+    endpoint = f"{settings.get_v2_api_path(site_id)}/firewall/zone"
+    response = await client.get(endpoint)
+    zones = _extract_zone_list(response)
+
+    index: dict[str, str] = {}
+    for zone in zones:
+        internal_id = zone.get("_id")
+        if not internal_id:
+            continue
+        # Index the internal _id as itself so callers that already know the
+        # ObjectId continue to work.
+        index[internal_id] = internal_id
+        if external_id := zone.get("external_id"):
+            index[external_id] = internal_id
+        if name := zone.get("name"):
+            index[name.lower()] = internal_id
+        if zone_key := zone.get("zone_key"):
+            index[zone_key.lower()] = internal_id
+    _zone_cache[site_id] = index
+    return index
+
+
+async def _resolve_zone_id(
+    client: UniFiClient, settings: Settings, site_id: str, identifier: str
+) -> str:
+    """Resolve a zone name, external UUID, or internal ObjectId to the v2 API's
+    internal zone _id. Raises ValueError if no match."""
+    if not identifier:
+        raise ValueError("Zone identifier is required")
+    index = _zone_cache.get(site_id) or await _load_zone_index(client, settings, site_id)
+    if identifier in index:
+        return index[identifier]
+    lowered = identifier.lower()
+    if lowered in index:
+        return index[lowered]
+    # Refresh once in case the zone was created after the cache was populated.
+    index = await _load_zone_index(client, settings, site_id)
+    if identifier in index:
+        return index[identifier]
+    if lowered in index:
+        return index[lowered]
+    known_internal_ids = sorted({v for v in index.values()})
+    raise ValueError(
+        f"Could not resolve firewall zone '{identifier}'. Pass a zone name "
+        f"(e.g. 'Internal'), external UUID, or internal _id. "
+        f"Known internal zone ids: {known_internal_ids}"
+    )
+
+
+async def list_firewall_zones_v2(
+    site_id: str,
+    settings: Settings,
+) -> list[dict[str, Any]]:
+    """List firewall zones from the v2 API with internal + external IDs.
+
+    The v2 ``firewall-policies`` endpoint uses internal MongoDB ObjectIds for
+    zone_id, not the public integration API UUIDs. This tool returns the
+    mapping so callers can hand either identifier (or the zone name) to
+    ``create_firewall_policy`` / ``update_firewall_policy``.
+
+    Args:
+        site_id: Site identifier
+        settings: Application settings
+
+    Returns:
+        List of :class:`FirewallZoneV2Mapping` dicts.
+
+    Raises:
+        NotImplementedError: When using cloud API
+        APIError: When the API request fails
+    """
+    _ensure_local_api(settings)
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(f"Listing v2 firewall zones for site {site_id}")
+        )
+
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        endpoint = f"{settings.get_v2_api_path(site_id)}/firewall/zone"
+        try:
+            response = await client.get(endpoint)
+        except APIError:
+            logger.exception(
+                sanitize_log_message(
+                    f"Failed to list v2 firewall zones for site {site_id}"
+                )
+            )
+            raise
+
+        zones = _extract_zone_list(response)
+
+        return [
+            FirewallZoneV2Mapping(
+                internal_id=z.get("_id"),
+                external_id=z.get("external_id"),
+                name=z.get("name"),
+                zone_key=z.get("zone_key"),
+                default_zone=z.get("default_zone") or False,
+                network_ids=z.get("network_ids") or [],
+            ).model_dump()
+            for z in zones
+        ]
 
 
 async def list_firewall_policies(
@@ -134,6 +276,7 @@ async def create_firewall_policy(
     protocol: str = "all",
     enabled: bool = True,
     description: str | None = None,
+    ip_version: str = "BOTH",
     confirm: bool | str = False,
     dry_run: bool | str = False,
 ) -> dict[str, Any]:
@@ -147,13 +290,17 @@ async def create_firewall_policy(
         action: ALLOW or BLOCK
         site_id: Site identifier
         settings: Application settings
-        source_zone_id: Source zone ID
-        destination_zone_id: Destination zone ID
+        source_zone_id: Source zone — accepts a zone name (e.g. "Internal"),
+            public integration-API UUID, or internal ObjectId. All forms are
+            resolved to the v2 API's internal zone _id automatically.
+        destination_zone_id: Destination zone (same identifier flexibility as
+            source)
         source_matching_target: ANY, IP, NETWORK, REGION, or CLIENT
         destination_matching_target: ANY, IP, NETWORK, or REGION
         protocol: all, tcp, udp, tcp_udp, or icmpv6
         enabled: Whether policy is active
         description: Optional description
+        ip_version: IPV4, IPV6, or BOTH (required by API; defaults to BOTH)
         confirm: REQUIRED True for mutating operations
         dry_run: Preview changes without applying
 
@@ -161,7 +308,8 @@ async def create_firewall_policy(
         Created firewall policy object or dry-run preview
 
     Raises:
-        ValueError: If confirm not True or invalid action
+        ValueError: If confirm not True, invalid action, or zone cannot be
+            resolved.
         NotImplementedError: When using cloud API
     """
     _ensure_local_api(settings)
@@ -171,51 +319,32 @@ async def create_firewall_policy(
     if action_upper not in valid_actions:
         raise ValueError(f"Invalid action '{action}'. Must be one of: {valid_actions}")
 
-    source_config: dict[str, Any] = {"matching_target": source_matching_target.upper()}
-    if source_zone_id:
-        source_config["zone_id"] = source_zone_id
+    ip_version_upper = ip_version.upper()
+    if ip_version_upper not in _VALID_IP_VERSIONS:
+        raise ValueError(
+            f"Invalid ip_version '{ip_version}'. Must be one of: {list(_VALID_IP_VERSIONS)}"
+        )
 
-    destination_config: dict[str, Any] = {"matching_target": destination_matching_target.upper()}
-    if destination_zone_id:
-        destination_config["zone_id"] = destination_zone_id
+    # Coerce string inputs ("true"/"false") to real booleans — MCP clients
+    # may serialise these flags as strings and plain truthiness would treat
+    # "False" as True, bypassing the confirmation gate entirely.
+    confirm_bool = coerce_bool(confirm)
+    dry_run_bool = coerce_bool(dry_run)
 
-    policy_data = FirewallPolicyCreate(
-        name=name,
-        action=action_upper,
-        enabled=enabled,
-        protocol=protocol,
-        source=source_config,
-        destination=destination_config,
-        description=description,
-    )
+    if not dry_run_bool and not confirm_bool:
+        raise ValueError(
+            "This operation requires confirm=True to execute. "
+            "Use dry_run=True to preview changes first."
+        )
 
     parameters = {
         "site_id": site_id,
         "name": name,
         "action": action_upper,
         "enabled": enabled,
+        "source_zone_id": source_zone_id,
+        "destination_zone_id": destination_zone_id,
     }
-
-    if dry_run:
-        logger.info(sanitize_log_message(f"DRY RUN: Would create firewall policy '{name}' in site '{site_id}'"))
-        log_audit(
-            operation="create_firewall_policy",
-            parameters=parameters,
-            result="dry_run",
-            site_id=site_id,
-            dry_run=True,
-        )
-        return {
-            "status": "dry_run",
-            "message": f"Would create firewall policy '{name}'",
-            "policy": policy_data.model_dump(exclude_none=True),
-        }
-
-    if not confirm:
-        raise ValueError(
-            "This operation requires confirm=True to execute. "
-            "Use dry_run=True to preview changes first."
-        )
 
     try:
         async with UniFiClient(settings) as client:
@@ -223,6 +352,57 @@ async def create_firewall_policy(
 
             if not client.is_authenticated:
                 await client.authenticate()
+
+            # Resolve zone identifiers to internal _ids expected by the v2 API.
+            source_config: dict[str, Any] = {
+                "matching_target": source_matching_target.upper()
+            }
+            if source_zone_id:
+                source_config["zone_id"] = await _resolve_zone_id(
+                    client, settings, site_id, source_zone_id
+                )
+
+            destination_config: dict[str, Any] = {
+                "matching_target": destination_matching_target.upper()
+            }
+            if destination_zone_id:
+                destination_config["zone_id"] = await _resolve_zone_id(
+                    client, settings, site_id, destination_zone_id
+                )
+
+            # The v2 firewall-policies endpoint requires `schedule` and
+            # `ip_version`; the API 400s (with an obfuscated Spring error)
+            # if either is omitted. Default to an always-on rule.
+            policy_data = FirewallPolicyCreate(
+                name=name,
+                action=action_upper,
+                enabled=enabled,
+                protocol=protocol,
+                ip_version=ip_version_upper,
+                source=source_config,
+                destination=destination_config,
+                description=description,
+                schedule={"mode": "ALWAYS"},
+            )
+
+            if dry_run_bool:
+                logger.info(
+                    sanitize_log_message(
+                        f"DRY RUN: Would create firewall policy '{name}' in site '{site_id}'"
+                    )
+                )
+                log_audit(
+                    operation="create_firewall_policy",
+                    parameters=parameters,
+                    result="dry_run",
+                    site_id=site_id,
+                    dry_run=True,
+                )
+                return {
+                    "status": "dry_run",
+                    "message": f"Would create firewall policy '{name}'",
+                    "policy": policy_data.model_dump(exclude_none=True),
+                }
 
             endpoint = f"{settings.get_v2_api_path(site_id)}/firewall-policies"
             response = await client.post(
@@ -262,20 +442,37 @@ async def update_firewall_policy(
     name: str | None = None,
     action: str | None = None,
     enabled: bool | None = None,
+    logging: bool | None = None,
+    ip_version: str | None = None,
+    protocol: str | None = None,
+    description: str | None = None,
     confirm: bool | str = False,
     dry_run: bool | str = False,
 ) -> dict[str, Any]:
     """Update an existing firewall policy.
 
-    Only provided fields are updated (partial update).
+    The v2 ``firewall-policies`` PUT endpoint requires the **full** policy
+    object — a partial payload like ``{"logging": true}`` is rejected with
+    ``Validation failed ... field 'action': rejected value [null]``. To
+    support partial updates from the caller's perspective, this tool
+    fetches the existing policy, merges in the provided field overrides,
+    strips ``_id`` / ``predefined`` (which the API controls), and PUTs the
+    merged object back.
 
     Args:
         policy_id: ID of policy to update
         site_id: Site identifier
         settings: Application settings
-        name: New policy name (optional)
-        action: New action ALLOW/BLOCK (optional)
-        enabled: Enable/disable (optional)
+        name: New policy name
+        action: New action ALLOW/BLOCK
+        enabled: Enable/disable the policy
+        logging: Toggle firewall rule logging. Forces CPU inspection of the
+            matched flows, which makes them visible in the v2 traffic-flows
+            endpoint (default-allowed inter-VLAN traffic is normally
+            hardware-offloaded and never reaches the flow table).
+        ip_version: IPV4 / IPV6 / BOTH
+        protocol: Transport protocol (all, tcp, udp, tcp_udp, icmpv6)
+        description: Free-form description
         confirm: REQUIRED True for mutating operations
         dry_run: Preview changes without applying
 
@@ -284,59 +481,114 @@ async def update_firewall_policy(
 
     Raises:
         NotImplementedError: When using cloud API (v2 endpoints require local access)
-        ValueError: If confirmation not provided
+        ValueError: If confirmation not provided or an invalid value is supplied
         ResourceNotFoundError: If policy not found
     """
     _ensure_local_api(settings)
 
-    if not coerce_bool(dry_run) and not coerce_bool(confirm):
+    confirm_bool = coerce_bool(confirm)
+    dry_run_bool = coerce_bool(dry_run)
+
+    if not dry_run_bool and not confirm_bool:
         raise ValueError(
             "This operation requires confirm=True to execute. "
             "Use dry_run=True to preview changes first."
         )
 
-    # Build update payload with only provided fields
-    update_data: dict[str, Any] = {}
-    if name is not None:
-        update_data["name"] = name
+    # Validate overrides up-front so we fail fast before hitting the API.
+    action_upper: str | None = None
     if action is not None:
         action_upper = action.upper()
-        if action_upper not in ["ALLOW", "BLOCK"]:
+        if action_upper not in ("ALLOW", "BLOCK"):
             raise ValueError(f"Invalid action '{action}'. Must be ALLOW or BLOCK.")
-        update_data["action"] = action_upper
-    if enabled is not None:
-        update_data["enabled"] = enabled
 
-    if dry_run:
-        logger.info(sanitize_log_message(f"DRY RUN: Would update firewall policy {policy_id}"))
-        return {
-            "status": "dry_run",
-            "policy_id": policy_id,
-            "changes": update_data,
-        }
+    ip_version_upper: str | None = None
+    if ip_version is not None:
+        ip_version_upper = ip_version.upper()
+        if ip_version_upper not in _VALID_IP_VERSIONS:
+            raise ValueError(
+                f"Invalid ip_version '{ip_version}'. Must be one of: {list(_VALID_IP_VERSIONS)}"
+            )
+
+    # Collect overrides so we can both preview them (dry_run) and merge them.
+    overrides: dict[str, Any] = {}
+    if name is not None:
+        overrides["name"] = name
+    if action_upper is not None:
+        overrides["action"] = action_upper
+    if enabled is not None:
+        overrides["enabled"] = enabled
+    if logging is not None:
+        overrides["logging"] = logging
+    if ip_version_upper is not None:
+        overrides["ip_version"] = ip_version_upper
+    if protocol is not None:
+        overrides["protocol"] = protocol
+    if description is not None:
+        overrides["description"] = description
 
     async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Updating firewall policy {policy_id} for site {site_id}"))
+        logger.info(
+            sanitize_log_message(
+                f"Updating firewall policy {policy_id} for site {site_id}"
+            )
+        )
 
         if not client.is_authenticated:
             await client.authenticate()
 
         endpoint = f"{settings.get_v2_api_path(site_id)}/firewall-policies/{policy_id}"
 
+        # Fetch the existing policy so we can merge + PUT the full object.
         try:
-            response = await client.put(endpoint, json_data=update_data)
+            current_response = await client.get(endpoint)
         except ResourceNotFoundError as err:
             raise ResourceNotFoundError("firewall_policy", policy_id) from err
 
-        if isinstance(response, dict) and "data" in response:
-            data = response["data"]
-        else:
-            data = response
+        current = (
+            current_response.get("data", current_response)
+            if isinstance(current_response, dict)
+            else current_response
+        )
+        if not current or not isinstance(current, dict):
+            raise ResourceNotFoundError("firewall_policy", policy_id)
+
+        if current.get("predefined"):
+            raise ValueError(
+                f"Cannot update predefined system rule '{current.get('name', policy_id)}'."
+            )
+
+        merged = {**current, **overrides}
+        # Strip fields the API controls; sending them back causes validation errors.
+        for field in ("_id", "predefined"):
+            merged.pop(field, None)
+
+        if dry_run_bool:
+            logger.info(
+                sanitize_log_message(
+                    f"DRY RUN: Would update firewall policy {policy_id}"
+                )
+            )
+            return {
+                "status": "dry_run",
+                "policy_id": policy_id,
+                "changes": overrides,
+                "merged_payload": merged,
+            }
+
+        try:
+            response = await client.put(endpoint, json_data=merged)
+        except ResourceNotFoundError as err:
+            raise ResourceNotFoundError("firewall_policy", policy_id) from err
+
+        data = (
+            response.get("data", response) if isinstance(response, dict) else response
+        )
 
         logger.info(sanitize_log_message(f"Updated firewall policy {policy_id}"))
         log_audit(
             operation="update_firewall_policy",
-            parameters={"policy_id": policy_id, "site_id": site_id, **update_data},
+            parameters={"policy_id": policy_id, "site_id": site_id, **overrides},
             result="success",
             site_id=site_id,
         )

--- a/tests/unit/tools/test_firewall_policies.py
+++ b/tests/unit/tools/test_firewall_policies.py
@@ -435,18 +435,20 @@ class TestUpdateFirewallPolicy:
         return Settings()
 
     @pytest.fixture
-    def sample_updated_policy(self) -> dict:
-        """Sample updated policy response from UniFi controller."""
+    def sample_existing_policy(self) -> dict:
+        """Existing policy as returned by GET before update."""
         return {
             "_id": "682a0e42220317278bb0b2cb",
-            "name": "Updated Policy Name",
+            "name": "Original Name",
             "enabled": True,
             "action": "ALLOW",
             "predefined": False,
             "index": 10000,
             "protocol": "all",
             "ip_version": "BOTH",
+            "logging": False,
             "connection_state_type": "ALL",
+            "schedule": {"mode": "ALWAYS"},
             "source": {
                 "zone_id": "682a0e42220317278bb0b2c5",
                 "matching_target": "ANY",
@@ -457,9 +459,19 @@ class TestUpdateFirewallPolicy:
             },
         }
 
+    @pytest.fixture
+    def sample_updated_policy(self, sample_existing_policy: dict) -> dict:
+        """Sample updated policy response from UniFi controller."""
+        updated = sample_existing_policy.copy()
+        updated["name"] = "Updated Policy Name"
+        return updated
+
     @pytest.mark.asyncio
     async def test_update_firewall_policy_success_with_confirm(
-        self, local_settings: Settings, sample_updated_policy: dict
+        self,
+        local_settings: Settings,
+        sample_existing_policy: dict,
+        sample_updated_policy: dict,
     ) -> None:
         """Test successful update of a firewall policy with confirm=True."""
         from src.tools.firewall_policies import update_firewall_policy
@@ -468,6 +480,8 @@ class TestUpdateFirewallPolicy:
             mock_client = AsyncMock()
             MockClient.return_value.__aenter__.return_value = mock_client
             mock_client.is_authenticated = True
+            # The new GET-merge-PUT flow fetches the existing policy first.
+            mock_client.get.return_value = sample_existing_policy
             mock_client.put.return_value = sample_updated_policy
 
             result = await update_firewall_policy(
@@ -482,7 +496,17 @@ class TestUpdateFirewallPolicy:
             assert isinstance(result, dict)
             assert result["name"] == "Updated Policy Name"
             assert result["action"] == "ALLOW"
+            mock_client.get.assert_called_once()
             mock_client.put.assert_called_once()
+            # The PUT body should be the full merged object, not just the
+            # overrides, because the v2 endpoint requires all required
+            # fields on every update.
+            put_body = mock_client.put.call_args[1]["json_data"]
+            assert put_body["name"] == "Updated Policy Name"
+            assert put_body["source"]["zone_id"] == "682a0e42220317278bb0b2c5"
+            # _id and predefined must be stripped before PUT.
+            assert "_id" not in put_body
+            assert "predefined" not in put_body
 
     @pytest.mark.asyncio
     async def test_update_firewall_policy_rejected_without_confirm(
@@ -503,13 +527,17 @@ class TestUpdateFirewallPolicy:
         assert "confirm=True" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_update_firewall_policy_dry_run_mode(self, local_settings: Settings) -> None:
+    async def test_update_firewall_policy_dry_run_mode(
+        self, local_settings: Settings, sample_existing_policy: dict
+    ) -> None:
         """Test dry_run mode returns preview without making changes."""
         from src.tools.firewall_policies import update_firewall_policy
 
         with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
             mock_client = AsyncMock()
             MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = sample_existing_policy
 
             result = await update_firewall_policy(
                 policy_id="682a0e42220317278bb0b2cb",
@@ -523,6 +551,7 @@ class TestUpdateFirewallPolicy:
             assert result["policy_id"] == "682a0e42220317278bb0b2cb"
             assert "changes" in result
             assert result["changes"]["name"] == "Updated Policy Name"
+            assert "merged_payload" in result
             mock_client.put.assert_not_called()
 
     @pytest.mark.asyncio
@@ -567,19 +596,24 @@ class TestUpdateFirewallPolicy:
         assert "local" in str(exc_info.value).lower()
 
     @pytest.mark.asyncio
-    async def test_update_firewall_policy_partial_update_name_only(
-        self, local_settings: Settings, sample_updated_policy: dict
+    async def test_update_firewall_policy_name_override_merges_with_existing(
+        self,
+        local_settings: Settings,
+        sample_existing_policy: dict,
+        sample_updated_policy: dict,
     ) -> None:
-        """Test partial update with only name field."""
+        """A name override must be merged into the existing object and the
+        full object PUT back (partial PUT is rejected by the v2 endpoint)."""
         from src.tools.firewall_policies import update_firewall_policy
 
         with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
             mock_client = AsyncMock()
             MockClient.return_value.__aenter__.return_value = mock_client
             mock_client.is_authenticated = True
+            mock_client.get.return_value = sample_existing_policy
             mock_client.put.return_value = sample_updated_policy
 
-            result = await update_firewall_policy(
+            await update_firewall_policy(
                 policy_id="682a0e42220317278bb0b2cb",
                 name="Updated Policy Name",
                 site_id="default",
@@ -587,26 +621,35 @@ class TestUpdateFirewallPolicy:
                 settings=local_settings,
             )
 
-            assert result["name"] == "Updated Policy Name"
-            call_args = mock_client.put.call_args
-            request_body = call_args[1]["json_data"]
-            assert "name" in request_body
-            assert "action" not in request_body
+            put_body = mock_client.put.call_args[1]["json_data"]
+            # Override applied
+            assert put_body["name"] == "Updated Policy Name"
+            # Existing fields preserved (merged)
+            assert put_body["action"] == "ALLOW"
+            assert put_body["enabled"] is True
+            assert put_body["schedule"] == {"mode": "ALWAYS"}
+            assert put_body["source"]["zone_id"] == "682a0e42220317278bb0b2c5"
+            # Required-field-strip contract
+            assert "_id" not in put_body
+            assert "predefined" not in put_body
 
     @pytest.mark.asyncio
-    async def test_update_firewall_policy_partial_update_enabled_only(
-        self, local_settings: Settings, sample_updated_policy: dict
+    async def test_update_firewall_policy_enabled_toggle(
+        self,
+        local_settings: Settings,
+        sample_existing_policy: dict,
     ) -> None:
-        """Test partial update with only enabled field."""
+        """Toggling enabled=False flows through without touching other fields."""
         from src.tools.firewall_policies import update_firewall_policy
 
-        disabled_policy = sample_updated_policy.copy()
+        disabled_policy = sample_existing_policy.copy()
         disabled_policy["enabled"] = False
 
         with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
             mock_client = AsyncMock()
             MockClient.return_value.__aenter__.return_value = mock_client
             mock_client.is_authenticated = True
+            mock_client.get.return_value = sample_existing_policy
             mock_client.put.return_value = disabled_policy
 
             result = await update_firewall_policy(
@@ -618,10 +661,85 @@ class TestUpdateFirewallPolicy:
             )
 
             assert result["enabled"] is False
-            call_args = mock_client.put.call_args
-            request_body = call_args[1]["json_data"]
-            assert "enabled" in request_body
-            assert request_body["enabled"] is False
+            put_body = mock_client.put.call_args[1]["json_data"]
+            assert put_body["enabled"] is False
+            # Other existing fields untouched
+            assert put_body["name"] == "Original Name"
+            assert put_body["action"] == "ALLOW"
+
+    @pytest.mark.asyncio
+    async def test_update_firewall_policy_logging_toggle(
+        self,
+        local_settings: Settings,
+        sample_existing_policy: dict,
+    ) -> None:
+        """Enabling ``logging`` forces CPU inspection so the matched flows
+        show up in the v2 traffic-flows endpoint."""
+        from src.tools.firewall_policies import update_firewall_policy
+
+        logging_on = sample_existing_policy.copy()
+        logging_on["logging"] = True
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = sample_existing_policy
+            mock_client.put.return_value = logging_on
+
+            result = await update_firewall_policy(
+                policy_id="682a0e42220317278bb0b2cb",
+                logging=True,
+                site_id="default",
+                confirm=True,
+                settings=local_settings,
+            )
+
+            assert result["logging"] is True
+            put_body = mock_client.put.call_args[1]["json_data"]
+            assert put_body["logging"] is True
+            # Existing required fields still present
+            assert put_body["action"] == "ALLOW"
+            assert put_body["source"]["zone_id"] == "682a0e42220317278bb0b2c5"
+
+    @pytest.mark.asyncio
+    async def test_update_firewall_policy_rejects_predefined(
+        self, local_settings: Settings, sample_existing_policy: dict
+    ) -> None:
+        """Predefined system policies must not be updatable."""
+        from src.tools.firewall_policies import update_firewall_policy
+
+        system_policy = {**sample_existing_policy, "predefined": True}
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = system_policy
+
+            with pytest.raises(ValueError, match="predefined"):
+                await update_firewall_policy(
+                    policy_id="682a0e42220317278bb0b2cb",
+                    name="Hacked",
+                    site_id="default",
+                    confirm=True,
+                    settings=local_settings,
+                )
+
+    @pytest.mark.asyncio
+    async def test_update_firewall_policy_invalid_ip_version_raises(
+        self, local_settings: Settings
+    ) -> None:
+        from src.tools.firewall_policies import update_firewall_policy
+
+        with pytest.raises(ValueError, match="Invalid ip_version"):
+            await update_firewall_policy(
+                policy_id="682a0e42220317278bb0b2cb",
+                ip_version="IPV5",
+                site_id="default",
+                confirm=True,
+                settings=local_settings,
+            )
 
 
 class TestDeleteFirewallPolicy:
@@ -1059,8 +1177,14 @@ class TestCreateFirewallPolicy:
     async def test_create_firewall_policy_with_zones(
         self, local_settings: Settings, sample_created_policy: dict
     ) -> None:
-        """Test creation with specific zone IDs."""
-        from src.tools.firewall_policies import create_firewall_policy
+        """Test creation with specific zone IDs resolved via the v2 zone index."""
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        # Prime the zone cache so tests don't need to mock /firewall/zone.
+        _zone_cache["default"] = {
+            "zone-iot": "zone-iot",
+            "zone-lan": "zone-lan",
+        }
 
         with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
             mock_client = AsyncMock()
@@ -1068,20 +1192,97 @@ class TestCreateFirewallPolicy:
             mock_client.is_authenticated = True
             mock_client.post.return_value = sample_created_policy
 
-            await create_firewall_policy(
-                name="Block IOT to LAN",
-                action="BLOCK",
-                site_id="default",
-                settings=local_settings,
-                source_zone_id="zone-iot",
-                destination_zone_id="zone-lan",
-                confirm=True,
-            )
+            try:
+                await create_firewall_policy(
+                    name="Block IOT to LAN",
+                    action="BLOCK",
+                    site_id="default",
+                    settings=local_settings,
+                    source_zone_id="zone-iot",
+                    destination_zone_id="zone-lan",
+                    confirm=True,
+                )
+            finally:
+                _zone_cache.pop("default", None)
 
             call_args = mock_client.post.call_args
             request_body = call_args[1]["json_data"]
             assert request_body["source"]["zone_id"] == "zone-iot"
             assert request_body["destination"]["zone_id"] == "zone-lan"
+            # Required v2 API fields are always included.
+            assert request_body["schedule"] == {"mode": "ALWAYS"}
+            assert request_body["ip_version"] == "BOTH"
+
+    @pytest.mark.asyncio
+    async def test_create_firewall_policy_resolves_zone_by_name(
+        self, local_settings: Settings, sample_created_policy: dict
+    ) -> None:
+        """Zone names ('Internal') and external UUIDs should resolve to the
+        internal ObjectId via the v2 zone index."""
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        # Simulated zone index: zone name + external UUID → internal _id
+        _zone_cache["default"] = {
+            "internal": "690d6e64e9671173fd71c586",
+            "1daa9f24-eeaf-4bec-a714-e5eb65ea7ba2": "690d6e64e9671173fd71c586",
+            "690d6e64e9671173fd71c586": "690d6e64e9671173fd71c586",
+            "dmz": "690d6e64e9671173fd71c58b",
+            "690d6e64e9671173fd71c58b": "690d6e64e9671173fd71c58b",
+        }
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.post.return_value = sample_created_policy
+
+            try:
+                await create_firewall_policy(
+                    name="Internal to DMZ",
+                    action="ALLOW",
+                    site_id="default",
+                    settings=local_settings,
+                    source_zone_id="Internal",  # by name (case-insensitive)
+                    destination_zone_id="1daa9f24-eeaf-4bec-a714-e5eb65ea7ba2",  # noqa: E501 — external UUID
+                    confirm=True,
+                )
+            finally:
+                _zone_cache.pop("default", None)
+
+            request_body = mock_client.post.call_args[1]["json_data"]
+            assert request_body["source"]["zone_id"] == "690d6e64e9671173fd71c586"
+            assert (
+                request_body["destination"]["zone_id"] == "690d6e64e9671173fd71c586"
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_firewall_policy_unknown_zone_raises(
+        self, local_settings: Settings
+    ) -> None:
+        """Unresolvable zone identifiers raise ValueError with a helpful hint."""
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        _zone_cache["default"] = {"known": "abc123"}
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            # Make refresh return an empty list too, so no new mappings appear.
+            mock_client.get.return_value = {"data": []}
+
+            try:
+                with pytest.raises(ValueError, match="Could not resolve firewall zone"):
+                    await create_firewall_policy(
+                        name="Bad zone",
+                        action="ALLOW",
+                        site_id="default",
+                        settings=local_settings,
+                        source_zone_id="nonexistent",
+                        confirm=True,
+                    )
+            finally:
+                _zone_cache.pop("default", None)
 
     @pytest.mark.asyncio
     async def test_create_firewall_policy_invalid_action(self, local_settings: Settings) -> None:
@@ -1161,3 +1362,162 @@ class TestCreateFirewallPolicy:
             )
 
             mock_client.authenticate.assert_called_once()
+
+
+class TestListFirewallZonesV2:
+    """Tests for the v2 firewall zone listing helper."""
+
+    @pytest.fixture
+    def local_settings(self, monkeypatch: pytest.MonkeyPatch) -> Settings:
+        monkeypatch.setenv("UNIFI_API_KEY", "test-api-key")
+        monkeypatch.setenv("UNIFI_API_TYPE", "local")
+        monkeypatch.setenv("UNIFI_LOCAL_HOST", "192.168.2.1")
+        return Settings()
+
+    @pytest.mark.asyncio
+    async def test_list_firewall_zones_v2_returns_id_mapping(
+        self, local_settings: Settings
+    ) -> None:
+        """Each returned entry exposes both internal and external IDs plus
+        zone name and zone_key so callers can look up zones by any
+        identifier."""
+        from src.tools.firewall_policies import list_firewall_zones_v2
+
+        raw_zones = [
+            {
+                "_id": "690d6e64e9671173fd71c586",
+                "external_id": "1daa9f24-eeaf-4bec-a714-e5eb65ea7ba2",
+                "name": "Internal",
+                "zone_key": "internal",
+                "default_zone": True,
+                "network_ids": ["net-1", "net-2"],
+            },
+            {
+                "_id": "6918c2f7dec8680b5fc97ffb",
+                "external_id": "4d1c7bb4-1714-4b55-933d-f37ee9fccdda",
+                "name": "Semi-Trusted",
+                "zone_key": None,
+                "default_zone": False,
+                "network_ids": [],
+            },
+        ]
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = raw_zones
+
+            result = await list_firewall_zones_v2("default", local_settings)
+
+            assert len(result) == 2
+            assert result[0] == {
+                "internal_id": "690d6e64e9671173fd71c586",
+                "external_id": "1daa9f24-eeaf-4bec-a714-e5eb65ea7ba2",
+                "name": "Internal",
+                "zone_key": "internal",
+                "default_zone": True,
+                "network_ids": ["net-1", "net-2"],
+            }
+            assert result[1]["internal_id"] == "6918c2f7dec8680b5fc97ffb"
+            assert result[1]["external_id"] == "4d1c7bb4-1714-4b55-933d-f37ee9fccdda"
+
+            called_endpoint = mock_client.get.call_args[0][0]
+            assert called_endpoint.endswith("/firewall/zone")
+
+    @pytest.mark.asyncio
+    async def test_list_firewall_zones_v2_handles_none_data(
+        self, local_settings: Settings
+    ) -> None:
+        """UniFiClient can return ``{"data": None}`` for empty responses;
+        the tool must not raise ``TypeError: 'NoneType' is not iterable``."""
+        from src.tools.firewall_policies import list_firewall_zones_v2
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = {"data": None}
+
+            result = await list_firewall_zones_v2("default", local_settings)
+            assert result == []
+
+
+class TestCreateFirewallPolicyConfirmCoercion:
+    """Regression tests for the string-truthiness confirmation bypass."""
+
+    @pytest.fixture
+    def local_settings(self, monkeypatch: pytest.MonkeyPatch) -> Settings:
+        monkeypatch.setenv("UNIFI_API_KEY", "test-api-key")
+        monkeypatch.setenv("UNIFI_API_TYPE", "local")
+        monkeypatch.setenv("UNIFI_LOCAL_HOST", "192.168.2.1")
+        return Settings()
+
+    @pytest.mark.asyncio
+    async def test_string_false_confirm_does_not_bypass(
+        self, local_settings: Settings
+    ) -> None:
+        """confirm='False' (a truthy string) must not bypass the gate."""
+        from src.tools.firewall_policies import create_firewall_policy
+
+        with pytest.raises(ValueError, match="requires confirm=True"):
+            await create_firewall_policy(
+                name="Test",
+                action="ALLOW",
+                site_id="default",
+                settings=local_settings,
+                confirm="False",
+            )
+
+    @pytest.mark.asyncio
+    async def test_string_true_confirm_is_accepted(
+        self, local_settings: Settings
+    ) -> None:
+        """confirm='true' (JSON-RPC stringified bool) must be coerced."""
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        _zone_cache["default"] = {"zone-a": "zone-a", "zone-b": "zone-b"}
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.post.return_value = {
+                "_id": "new",
+                "name": "Test",
+                "action": "ALLOW",
+                "source": {"zone_id": "zone-a", "matching_target": "ANY"},
+                "destination": {"zone_id": "zone-b", "matching_target": "ANY"},
+            }
+
+            try:
+                result = await create_firewall_policy(
+                    name="Test",
+                    action="ALLOW",
+                    site_id="default",
+                    settings=local_settings,
+                    source_zone_id="zone-a",
+                    destination_zone_id="zone-b",
+                    confirm="true",
+                )
+            finally:
+                _zone_cache.pop("default", None)
+
+            assert result["id"] == "new"
+            mock_client.post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_invalid_ip_version_raises(
+        self, local_settings: Settings
+    ) -> None:
+        from src.tools.firewall_policies import create_firewall_policy
+
+        with pytest.raises(ValueError, match="Invalid ip_version"):
+            await create_firewall_policy(
+                name="Test",
+                action="ALLOW",
+                site_id="default",
+                settings=local_settings,
+                ip_version="IPV5",
+                confirm=True,
+            )


### PR DESCRIPTION
Wires up the existing `firewall_policies.py` module as MCP tools (currently dead code — not in `_TOOL_MODULES`), fixes two API-reject bugs in `create_firewall_policy`, and adds a zone name/UUID resolver so callers don't have to hand-map to internal MongoDB ObjectIds.

Context: this is the zone-scoped equivalent of the legacy firewall/ACL tools and is what most users actually want when they say *"I need to manage zones via MCP"*. Before this PR, attempting to create zone-based firewall rules via the MCP server was impossible.

## Changes

**1. Wire up firewall_policies tools (`main.py`)**

`firewall_policies.py` has had `list`/`get`/`create`/`update`/`delete` functions for a while, but it was never added to `_TOOL_MODULES` in `main.py`, so `tool_registry.py` never registered any of them. All 5 functions are now exposed + 1 new helper.

**2. `create_firewall_policy` API compliance**

Two API-reject bugs that made the endpoint unusable even if you wired it up:

- `schedule` is required by the v2 `firewall-policies` POST. Without it the API returns an obfuscated Spring validation error. Now always sends `schedule: {\"mode\": \"ALWAYS\"}`.
- `ip_version` is also required. Now defaults to `BOTH` with a parameter override.

**3. Zone ID resolver**

The v2 `firewall-policies` endpoint uses **internal MongoDB ObjectIds** for `zone_id`, while the public integration API (and every other MCP tool — `list_firewall_zones`, `get_network_topology`, etc.) returns **UUIDs** as `external_id`. Passing an integration UUID to `create_firewall_policy` returns `api.err.FirewallPolicyZoneDoesNotExist`.

Added `_resolve_zone_id()` that queries `/firewall/zone` (which exposes both IDs plus `name` and `zone_key`) and resolves any of:
- Zone name (e.g. `\"Internal\"`, case-insensitive)
- External UUID (the integration API ID)
- Internal `_id` (already the v2 format — no-op)
- `zone_key` (e.g. `\"internal\"`, `\"dmz\"`)

...to the internal `_id` the v2 endpoint needs. Results are cached per-site.

This means a user can now say `create_firewall_policy(source_zone_id=\"Internal\", destination_zone_id=\"Dmz\", ...)` and it just works.

**4. `list_firewall_zones_v2` helper**

New tool that returns the full zone → id mapping (`internal_id`, `external_id`, `name`, `zone_key`, `default_zone`, `network_ids`), so callers can discover zones without hand-probing the v2 API.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (the `schedule`/`ip_version` omissions were blocking any use of `create_firewall_policy`)

Signature-compatible with previous `create_firewall_policy` — `source_zone_id` / `destination_zone_id` parameters keep their names and still accept the internal `_id` form, but now additionally accept name, external UUID, or `zone_key`.

## Testing

**Unit tests:** 1139 passing (1 pre-existing unrelated failure in `test_security.py::test_diskcache_not_installed`).

New tests:
- `test_create_firewall_policy_with_zones` — updated to prime the zone cache and assert `schedule` + `ip_version` in the POST body
- `test_create_firewall_policy_resolves_zone_by_name` — new, verifies zone name and external UUID both resolve to the same internal `_id`
- `test_create_firewall_policy_unknown_zone_raises` — new, verifies `ValueError` with a helpful hint including the known zone list
- `TestListFirewallZonesV2` — new class asserting the returned structure and endpoint path

**Live controller validation** (UDM Pro, UniFi Network 9.x): end-to-end create → verify → delete of a zone-based policy via the new tool, using a zone name as the source identifier. Confirmed the resolver correctly maps `\"Internal\"` → the internal `_id`, POST succeeds, the returned policy has the right `zone_id`, and DELETE cleans up.

**Tool registration smoke test:** confirmed all 6 firewall-policies tools are registered under `mcp`:
```
create_firewall_policy
delete_firewall_policy
get_firewall_policy
list_firewall_policies
list_firewall_zones_v2
update_firewall_policy
```

## Checklist

- [x] Self-reviewed
- [x] Tests added for new functionality
- [x] No new warnings
- [x] Unit tests pass locally
- [x] `sanitize_log_message()` preserved on all touched log sites (PR #53's security hardening)