### PR TITLE
feat(traffic_flows): rewrite against local v2 endpoint, add rule-reference tool

### DIFF
--- a/src/models/traffic_flow.py
+++ b/src/models/traffic_flow.py
@@ -1,137 +1,285 @@
-"""Traffic flow models."""
+from __future__ import annotations
 
-from typing import Literal
+"""Traffic flow models.
 
-from pydantic import BaseModel, Field
+These map the UniFi local v2 API ``/firewall-policies/../traffic-flows``
+response shape, which is what the live controller returns.  The integration
+API does not expose traffic flows at all, so there is no cloud-mode
+equivalent for these models.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TrafficFlowEndpoint(BaseModel):
+    """Source or destination side of a traffic flow.
+
+    Matches the nested object the v2 ``traffic-flows`` endpoint returns.
+    Most fields are optional because UniFi omits them when they aren't
+    relevant (e.g. ``client_name``/``mac`` only appear on the source side
+    for LAN endpoints, ``region``/``domains`` only on the external
+    destination side).
+    """
+
+    id: str | None = Field(None, description="Endpoint identifier (MAC or IP)")
+    ip: str | None = Field(None, description="IP address")
+    port: int | None = Field(None, description="Port number")
+    mac: str | None = Field(None, description="MAC address (LAN endpoints only)")
+    client_name: str | None = Field(None, description="Client display name")
+    client_oui: str | None = Field(None, description="Client OUI / vendor string")
+    network_id: str | None = Field(None, description="Network (VLAN) internal id")
+    network_name: str | None = Field(None, description="Network (VLAN) display name")
+    subnet: str | None = Field(None, description="Network subnet in CIDR form")
+    zone_id: str | None = Field(None, description="Firewall zone internal id")
+    zone_name: str | None = Field(None, description="Firewall zone display name")
+    region: str | None = Field(None, description="ISO country code (external endpoints)")
+    domains: list[str] = Field(
+        default_factory=list, description="Resolved domains for this endpoint"
+    )
+    client_fingerprint: dict[str, Any] | None = Field(
+        None, description="Device fingerprint (category, vendor, OS)"
+    )
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+
+class TrafficFlowData(BaseModel):
+    """Byte / packet counters for a flow."""
+
+    bytes_tx: int = Field(0, description="Bytes transmitted from source to destination")
+    bytes_rx: int = Field(0, description="Bytes received from destination back to source")
+    bytes_total: int = Field(0, description="Total bytes transferred")
+    packets_tx: int = Field(0, description="Packets transmitted from source")
+    packets_rx: int = Field(0, description="Packets received back from destination")
+    packets_total: int = Field(0, description="Total packets transferred")
+
+    model_config = ConfigDict(extra="allow")
+
+
+class TrafficFlowPolicy(BaseModel):
+    """Reference to the firewall policy that matched a flow."""
+
+    type: str | None = Field(None, description="Policy category, e.g. 'FIREWALL'")
+    internal_type: str | None = Field(
+        None, description="Internal match type, e.g. 'CONNTRACK'"
+    )
+    id: str | None = Field(None, description="Policy id (when available)")
+
+    model_config = ConfigDict(extra="allow")
 
 
 class TrafficFlow(BaseModel):
-    """Individual traffic flow record."""
+    """Individual traffic flow record from the v2 ``traffic-flows`` endpoint.
 
-    flow_id: str = Field(..., description="Flow identifier")
-    site_id: str = Field(..., description="Site identifier")
-    source_ip: str = Field(..., description="Source IP address")
-    source_port: int | None = Field(None, description="Source port")
-    destination_ip: str = Field(..., description="Destination IP address")
-    destination_port: int | None = Field(None, description="Destination port")
-    protocol: str = Field(..., description="Protocol (tcp/udp/icmp)")
-    application_id: str | None = Field(None, description="DPI application identifier")
-    application_name: str | None = Field(None, description="Application name")
-    bytes_sent: int = Field(0, description="Bytes sent")
-    bytes_received: int = Field(0, description="Bytes received")
-    packets_sent: int = Field(0, description="Packets sent")
-    packets_received: int = Field(0, description="Packets received")
-    start_time: str = Field(..., description="Flow start timestamp (ISO)")
-    end_time: str | None = Field(None, description="Flow end timestamp (ISO)")
-    duration: int | None = Field(None, description="Flow duration in seconds")
-    client_mac: str | None = Field(None, description="Client MAC address")
-    device_id: str | None = Field(None, description="Device identifier")
+    Every flow carries both sides of the connection (``source``,
+    ``destination``), the transport protocol, the action the firewall took,
+    the matched policies, byte / packet counters, and start/end timestamps.
+    """
+
+    id: str = Field(..., description="Flow identifier")
+    action: Literal["allowed", "blocked"] | str = Field(
+        ..., description="Firewall action taken on this flow"
+    )
+    count: int = Field(1, description="Number of identical flows aggregated")
+    direction: Literal["outgoing", "incoming"] | str = Field(
+        ..., description="Flow direction relative to the controller"
+    )
+    protocol: str = Field(..., description="Transport protocol (TCP/UDP/ICMP/...)")
+    service: str | None = Field(None, description="Identified service, e.g. 'DNS', 'OTHER'")
+    risk: str | None = Field(None, description="Risk classification (low/medium/high)")
+    source: TrafficFlowEndpoint = Field(
+        ..., description="Source endpoint (usually LAN client)"
+    )
+    destination: TrafficFlowEndpoint = Field(
+        ..., description="Destination endpoint (external IP or LAN peer)"
+    )
+    traffic_data: TrafficFlowData = Field(
+        default_factory=TrafficFlowData, description="Byte and packet counters"
+    )
+    policies: list[TrafficFlowPolicy] = Field(
+        default_factory=list, description="Firewall policies that matched this flow"
+    )
+    duration_milliseconds: int | None = Field(
+        None, description="Flow duration in milliseconds"
+    )
+    flow_start_time: int | None = Field(
+        None, description="Flow start timestamp (epoch ms)"
+    )
+    flow_end_time: int | None = Field(
+        None, description="Flow end timestamp (epoch ms)"
+    )
+    time: int | None = Field(None, description="Flow record timestamp (epoch ms)")
+    in_network: dict[str, Any] | None = Field(
+        None,
+        alias="in",
+        description="Ingress network metadata (raw v2 'in' field)",
+    )
+    out_network: dict[str, Any] | None = Field(
+        None,
+        alias="out",
+        description="Egress network metadata (raw v2 'out' field)",
+    )
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
 
 
 class FlowStatistics(BaseModel):
-    """Aggregated flow statistics."""
+    """Aggregated statistics over a sample of traffic flows.
+
+    The v2 endpoint returns up to 50 most-recent flows per call, so these
+    aggregates describe the rolling snapshot, not a time range.
+    """
 
     site_id: str = Field(..., description="Site identifier")
-    time_range: str = Field(..., description="Time range for statistics")
-    total_flows: int = Field(0, description="Total number of flows")
-    total_bytes_sent: int = Field(0, description="Total bytes sent")
-    total_bytes_received: int = Field(0, description="Total bytes received")
-    total_bytes: int = Field(0, description="Total bytes")
-    total_packets_sent: int = Field(0, description="Total packets sent")
-    total_packets_received: int = Field(0, description="Total packets received")
-    unique_sources: int = Field(0, description="Number of unique source IPs")
-    unique_destinations: int = Field(0, description="Number of unique destination IPs")
-    top_applications: list[dict] = Field(
-        default_factory=list, description="Top applications by bandwidth"
+    sample_size: int = Field(
+        0, description="Number of flows aggregated (capped at 50 per API call)"
+    )
+    total_flows: int = Field(0, description="Total flow records seen")
+    total_bytes: int = Field(0, description="Total bytes across all flows in the sample")
+    total_bytes_tx: int = Field(0, description="Total bytes transmitted from sources")
+    total_bytes_rx: int = Field(0, description="Total bytes received by sources")
+    total_packets: int = Field(0, description="Total packets across all flows")
+    unique_sources: int = Field(0, description="Distinct source endpoints (by id)")
+    unique_destinations: int = Field(
+        0, description="Distinct destination endpoints (by ip)"
+    )
+    protocol_breakdown: dict[str, int] = Field(
+        default_factory=dict, description="Flow count per protocol"
+    )
+    action_breakdown: dict[str, int] = Field(
+        default_factory=dict, description="Flow count per firewall action"
+    )
+    top_destinations: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Top destination endpoints by total bytes",
     )
 
+    model_config = ConfigDict(extra="allow")
 
-class FlowRisk(BaseModel):
-    """Risk assessment data for a flow."""
+
+class FlowRuleReferenceMatch(BaseModel):
+    """A flow that matches a proposed firewall rule intent.
+
+    Used by :func:`find_flows_for_rule_reference` so the caller can show
+    the LLM the concrete traffic a draft rule would have affected before
+    the rule is created.
+    """
 
     flow_id: str = Field(..., description="Flow identifier")
-    risk_score: float = Field(..., description="Risk score (0-100)")
-    risk_level: Literal["low", "medium", "high", "critical"] = Field(..., description="Risk level")
-    indicators: list[str] = Field(default_factory=list, description="List of risk indicators")
-    threat_type: str | None = Field(None, description="Type of threat detected")
-    description: str | None = Field(None, description="Risk description")
-
-
-class FlowView(BaseModel):
-    """Saved flow view configuration."""
-
-    view_id: str = Field(..., description="View identifier")
-    site_id: str = Field(..., description="Site identifier")
-    name: str = Field(..., description="View name")
-    description: str | None = Field(None, description="View description")
-    filter_expression: str | None = Field(None, description="Filter expression")
-    time_range: str = Field("24h", description="Time range")
-    created_at: str = Field(..., description="Creation timestamp (ISO)")
-
-
-class FlowStreamUpdate(BaseModel):
-    """Real-time flow update for streaming."""
-
-    update_type: Literal["new", "update", "closed"] = Field(..., description="Update type")
-    flow: TrafficFlow = Field(..., description="Flow data")
-    timestamp: str = Field(..., description="Update timestamp (ISO)")
-    bandwidth_rate: dict[str, float] | None = Field(
-        None, description="Current bandwidth rates (bps)"
+    source_label: str = Field(..., description="Human-readable source label")
+    destination_label: str = Field(..., description="Human-readable destination label")
+    protocol: str = Field(..., description="Protocol")
+    destination_port: int | None = Field(None, description="Destination port")
+    bytes_total: int = Field(0, description="Total bytes for this flow")
+    action: str = Field(..., description="Current firewall action for the flow")
+    source_zone_name: str | None = Field(None, description="Source zone name")
+    destination_zone_name: str | None = Field(None, description="Destination zone name")
+    source_network_name: str | None = Field(None, description="Source VLAN name")
+    flow_start_time: int | None = Field(
+        None, description="Flow start timestamp (epoch ms)"
     )
 
-
-class ConnectionState(BaseModel):
-    """Connection state tracking."""
-
-    flow_id: str = Field(..., description="Flow identifier")
-    state: Literal["active", "closed", "timed_out"] = Field(..., description="Connection state")
-    last_seen: str = Field(..., description="Last activity timestamp (ISO)")
-    total_duration: int | None = Field(None, description="Total duration in seconds")
-    termination_reason: str | None = Field(None, description="Reason for connection closure")
-
-
-class ClientFlowAggregation(BaseModel):
-    """Client traffic aggregation with enhanced metrics."""
-
-    client_mac: str = Field(..., description="Client MAC address")
-    client_ip: str | None = Field(None, description="Client IP address")
-    site_id: str = Field(..., description="Site identifier")
-    total_flows: int = Field(0, description="Total number of flows")
-    total_bytes: int = Field(0, description="Total bytes transferred")
-    total_packets: int = Field(0, description="Total packets transferred")
-    active_flows: int = Field(0, description="Currently active flows")
-    closed_flows: int = Field(0, description="Closed flows")
-    auth_failures: int = Field(0, description="Authentication failure count")
-    top_applications: list[dict] = Field(
-        default_factory=list, description="Top applications by bandwidth"
-    )
-    top_destinations: list[dict] = Field(default_factory=list, description="Top destination IPs")
-
-
-class FlowExportConfig(BaseModel):
-    """Configuration for flow export."""
-
-    export_format: Literal["csv", "json", "pcap"] = Field(..., description="Export format")
-    time_range: str = Field(..., description="Time range for export")
-    include_fields: list[str] | None = Field(
-        None, description="Specific fields to include (None = all)"
-    )
-    filter_expression: str | None = Field(None, description="Filter expression")
-    max_records: int | None = Field(None, description="Maximum number of records")
+    model_config = ConfigDict(extra="allow")
 
 
 class BlockFlowAction(BaseModel):
-    """Result of a flow block action."""
+    """Result of a flow block action (creates a firewall rule)."""
 
     action_id: str = Field(..., description="Block action identifier")
     block_type: Literal["source_ip", "destination_ip", "application"] = Field(
         ..., description="Type of block"
     )
-    blocked_target: str = Field(..., description="Blocked IP or application ID")
-    rule_id: str | None = Field(None, description="Created firewall rule ID")
-    zone_id: str | None = Field(None, description="Zone ID if using ZBF")
+    blocked_target: str = Field(..., description="Blocked IP or application id")
+    rule_id: str | None = Field(None, description="Created firewall rule id")
+    zone_id: str | None = Field(None, description="Zone id if using ZBF")
     duration: Literal["permanent", "temporary"] | None = Field(
         None, description="Block duration type"
     )
-    expires_at: str | None = Field(None, description="Expiration timestamp for temporary blocks")
+    expires_at: str | None = Field(
+        None, description="Expiration timestamp for temporary blocks"
+    )
     created_at: str = Field(..., description="Creation timestamp (ISO)")
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ClientFlowAggregation(BaseModel):
+    """Client-level aggregation computed from the flow sample."""
+
+    client_mac: str = Field(..., description="Client MAC address")
+    client_name: str | None = Field(None, description="Client display name")
+    client_ip: str | None = Field(None, description="Client IP address")
+    site_id: str = Field(..., description="Site identifier")
+    sample_size: int = Field(0, description="Number of flows aggregated for this client")
+    total_bytes: int = Field(0, description="Total bytes across the client's flows")
+    total_packets: int = Field(0, description="Total packets across the client's flows")
+    top_destinations: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Top destination endpoints for this client",
+    )
+    protocol_breakdown: dict[str, int] = Field(
+        default_factory=dict, description="Protocol distribution"
+    )
+
+    model_config = ConfigDict(extra="allow")
+
+
+class FlowExportConfig(BaseModel):
+    """Configuration for flow export."""
+
+    export_format: Literal["csv", "json"] = Field(..., description="Export format")
+    include_fields: list[str] | None = Field(
+        None, description="Specific fields to include (None = all)"
+    )
+    max_records: int | None = Field(None, description="Maximum number of records")
+
+    model_config = ConfigDict(extra="allow")
+
+
+# --- Backwards-compat placeholders -------------------------------------------------
+#
+# The following models exist only to preserve import compatibility for the
+# ``get_flow_trends``, ``stream_traffic_flows``, and ``get_connection_states``
+# functions in ``traffic_flows.py`` which now raise ``NotImplementedError``.
+# They can be removed once all call sites migrate.
+
+
+class FlowRisk(BaseModel):
+    """Stub — the v2 endpoint returns ``risk`` inline on each flow record."""
+
+    flow_id: str = Field(..., description="Flow identifier")
+    risk_level: str = Field(..., description="Risk level")
+
+    model_config = ConfigDict(extra="allow")
+
+
+class FlowStreamUpdate(BaseModel):
+    """Stub — streaming is no longer supported (50-flow rolling cap)."""
+
+    update_type: Literal["new", "update", "closed"] = Field(..., description="Update type")
+    flow: TrafficFlow = Field(..., description="Flow data")
+    timestamp: str = Field(..., description="Update timestamp (ISO)")
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ConnectionState(BaseModel):
+    """Stub — the v2 endpoint does not report explicit connection state."""
+
+    flow_id: str = Field(..., description="Flow identifier")
+    state: Literal["active", "closed", "timed_out"] = Field(..., description="State")
+    last_seen: str = Field(..., description="Last activity timestamp (ISO)")
+
+    model_config = ConfigDict(extra="allow")
+
+
+class FlowView(BaseModel):
+    """Stub — saved flow views are no longer supported."""
+
+    view_id: str = Field(..., description="View identifier")
+    site_id: str = Field(..., description="Site identifier")
+    name: str = Field(..., description="View name")
+
+    model_config = ConfigDict(extra="allow")

--- a/src/tools/traffic_flows.py
+++ b/src/tools/traffic_flows.py
@@ -1,257 +1,720 @@
-"""Traffic flow monitoring tools."""
+from __future__ import annotations
 
-import asyncio
+"""Traffic flow monitoring tools (local v2 API).
+
+The UniFi Integration API (``/proxy/network/integration/v1/...``) does **not**
+expose traffic flow data on any documented endpoint or firmware. Flow data is
+only available via the local private v2 endpoint
+``POST /proxy/network/v2/api/site/{site_id}/traffic-flows``, which is the
+endpoint the UniFi Network web UI uses internally. It returns up to 50 of the
+most recently-completed flows with full source/destination metadata, matched
+firewall policies, byte counters, and risk classification.
+
+Key constraints of the v2 endpoint, verified live against a UDM Pro running
+UniFi Network 10.2.x:
+
+* Hard cap at 50 flows per call; ``limit`` / ``offset`` / ``page_size`` /
+  ``duration`` / ``start`` parameters are accepted but ignored.
+* The response is a rolling snapshot of the latest completed flows, so
+  repeated calls return different IDs as new flows arrive.
+* Server-side filter keys (``source_zone_ids``, ``protocols``, ``actions``,
+  ``risks``, etc.) are accepted but **non-functional** — they pass syntax
+  validation but do not actually narrow the result set. All filtering must
+  therefore be performed client-side after fetching the sample.
+
+Because this endpoint is only reachable via the local gateway proxy, every
+function in this module calls :func:`_ensure_local_api` and raises
+``NotImplementedError`` when the MCP is configured for cloud-only API access.
+"""
+
 import csv
 import json
-from collections.abc import AsyncGenerator
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from io import StringIO
-from typing import Any, Literal
+from typing import Any
 from uuid import uuid4
 
 from ..api.client import UniFiClient
-from ..config import Settings
+from ..config import APIType, Settings
 from ..models.traffic_flow import (
     BlockFlowAction,
     ClientFlowAggregation,
-    ConnectionState,
-    FlowRisk,
+    FlowRuleReferenceMatch,
     FlowStatistics,
-    FlowStreamUpdate,
     TrafficFlow,
 )
-from ..utils import audit_action, get_logger, sanitize_log_message, validate_confirmation
+from ..utils import (
+    APIError,
+    ResourceNotFoundError,
+    audit_action,
+    get_logger,
+    sanitize_log_message,
+    validate_confirmation,
+)
 
 logger = get_logger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Low-level helpers                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def _ensure_local_api(settings: Settings) -> None:
+    """Flow endpoints are only reachable via the local gateway proxy."""
+    if settings.api_type != APIType.LOCAL:
+        raise NotImplementedError(
+            "Traffic flow tools require UNIFI_API_TYPE='local'. The UniFi "
+            "Integration API does not expose flow data; it is only available "
+            "through the local gateway's v2 endpoint at "
+            "/proxy/network/v2/api/site/{site}/traffic-flows."
+        )
+
+
+async def _fetch_raw_flows(
+    client: UniFiClient, settings: Settings, site_id: str
+) -> list[dict[str, Any]]:
+    """Hit the v2 traffic-flows endpoint and return the raw flow dicts.
+
+    The endpoint ignores pagination/filter params so we always send an empty
+    body and apply filtering client-side in the public wrappers below.
+    """
+    endpoint = f"{settings.get_v2_api_path(site_id)}/traffic-flows"
+    response = await client.post(endpoint, json_data={})
+    if isinstance(response, list):
+        return [f for f in response if isinstance(f, dict)]
+    if isinstance(response, dict):
+        inner = response.get("data")
+        if isinstance(inner, list):
+            return [f for f in inner if isinstance(f, dict)]
+    return []
+
+
+def _parse_flow(raw: dict[str, Any]) -> TrafficFlow:
+    """Parse a raw v2 flow dict into a ``TrafficFlow`` pydantic model."""
+    return TrafficFlow(**raw)
+
+
+def _flow_matches(
+    flow: TrafficFlow,
+    *,
+    source_mac: str | None = None,
+    source_ip: str | None = None,
+    source_zone_name: str | None = None,
+    source_network_name: str | None = None,
+    destination_ip: str | None = None,
+    destination_port: int | None = None,
+    destination_zone_name: str | None = None,
+    destination_network_name: str | None = None,
+    protocol: str | None = None,
+    action: str | None = None,
+    direction: str | None = None,
+    risk: str | None = None,
+    min_bytes: int | None = None,
+    client_name_contains: str | None = None,
+) -> bool:
+    """Client-side filter predicate used by every public fetch function.
+
+    Note on inter-VLAN filtering: UniFi labels the ``destination.zone_name``
+    of any inter-VLAN flow as ``"Gateway"`` rather than the target VLAN's
+    zone — the flow engine sees it as "entered the gateway's routing
+    table", which is literally true since routing happens on the gateway.
+    To find flows crossing VLAN boundaries, filter by
+    ``destination_network_name`` (the target VLAN's display name) rather
+    than ``destination_zone_name``. The ``destination_zone_name`` filter
+    only returns useful results for egress flows to ``External``.
+    """
+    src = flow.source
+    dst = flow.destination
+
+    if source_mac is not None:
+        candidate = (src.mac or src.id or "").lower()
+        if candidate != source_mac.lower():
+            return False
+    if source_ip is not None and src.ip != source_ip:
+        return False
+    if source_zone_name is not None and (
+        (src.zone_name or "").lower() != source_zone_name.lower()
+    ):
+        return False
+    if source_network_name is not None and (
+        (src.network_name or "").lower() != source_network_name.lower()
+    ):
+        return False
+    if destination_ip is not None and dst.ip != destination_ip:
+        return False
+    if destination_port is not None and dst.port != destination_port:
+        return False
+    if destination_zone_name is not None and (
+        (dst.zone_name or "").lower() != destination_zone_name.lower()
+    ):
+        return False
+    if destination_network_name is not None and (
+        (dst.network_name or "").lower() != destination_network_name.lower()
+    ):
+        return False
+    if protocol is not None and (flow.protocol or "").upper() != protocol.upper():
+        return False
+    if action is not None and (flow.action or "").lower() != action.lower():
+        return False
+    if direction is not None and (flow.direction or "").lower() != direction.lower():
+        return False
+    if risk is not None and (flow.risk or "").lower() != risk.lower():
+        return False
+    if min_bytes is not None and flow.traffic_data.bytes_total < min_bytes:
+        return False
+    if client_name_contains is not None and client_name_contains.lower() not in (
+        (src.client_name or "").lower()
+    ):
+        return False
+    return True
+
+
+async def _get_filtered_flows(
+    site_id: str,
+    settings: Settings,
+    **filters: Any,
+) -> list[TrafficFlow]:
+    """Fetch the latest 50 flows and apply client-side filters."""
+    _ensure_local_api(settings)
+
+    async with UniFiClient(settings) as client:
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            raw_flows = await _fetch_raw_flows(client, settings, site_id)
+        except APIError:
+            logger.exception(
+                sanitize_log_message(
+                    f"Failed to fetch traffic flows for site {site_id}"
+                )
+            )
+            raise
+
+        flows: list[TrafficFlow] = []
+        for raw in raw_flows:
+            try:
+                flow = _parse_flow(raw)
+            except Exception as exc:
+                logger.debug(
+                    sanitize_log_message(
+                        f"Skipping unparseable flow record: {exc}"
+                    )
+                )
+                continue
+            if _flow_matches(flow, **filters):
+                flows.append(flow)
+        return flows
+
+
+# --------------------------------------------------------------------------- #
+# Public fetch tools                                                          #
+# --------------------------------------------------------------------------- #
 
 
 async def get_traffic_flows(
     site_id: str,
     settings: Settings,
+    source_mac: str | None = None,
     source_ip: str | None = None,
+    source_zone_name: str | None = None,
+    source_network_name: str | None = None,
     destination_ip: str | None = None,
+    destination_port: int | None = None,
+    destination_zone_name: str | None = None,
+    destination_network_name: str | None = None,
     protocol: str | None = None,
-    application_id: str | None = None,
-    time_range: str = "24h",
+    action: str | None = None,
+    direction: str | None = None,
+    risk: str | None = None,
+    min_bytes: int | None = None,
+    client_name_contains: str | None = None,
     limit: int | None = None,
-    offset: int | None = None,
-) -> list[dict]:
-    """Retrieve real-time traffic flows.
+) -> list[dict[str, Any]]:
+    """Retrieve recent traffic flows from the UniFi controller.
+
+    Fetches up to 50 most-recent completed flows from the local v2 endpoint
+    and applies client-side filters. All filter parameters are optional; pass
+    any combination to narrow the result set.
 
     Args:
         site_id: Site identifier
-        settings: Application settings
+        settings: Application settings (must be configured for local API)
+        source_mac: Filter by source MAC address (case-insensitive)
         source_ip: Filter by source IP
+        source_zone_name: Filter by source firewall zone name (e.g. "Internal")
+        source_network_name: Filter by source VLAN display name (e.g. "Internal - Data")
         destination_ip: Filter by destination IP
-        protocol: Filter by protocol (tcp/udp/icmp)
-        application_id: Filter by DPI application ID
-        time_range: Time range for flows (1h, 6h, 12h, 24h, 7d, 30d)
-        limit: Maximum number of flows to return
-        offset: Number of flows to skip
+        destination_port: Filter by destination port
+        destination_zone_name: Filter by destination zone name. **Warning:**
+            UniFi labels inter-VLAN destination zones as ``"Gateway"`` rather
+            than the target VLAN's zone, so this filter is only useful for
+            egress flows to ``"External"``. For inter-VLAN flows, use
+            ``destination_network_name`` instead.
+        destination_network_name: Filter by destination VLAN display name
+            (e.g. ``"Server - Data"``). This is the correct filter for
+            discovering inter-VLAN traffic.
+        protocol: Filter by transport protocol ("TCP", "UDP", "ICMP", ...)
+        action: Filter by firewall action ("allowed", "blocked")
+        direction: Filter by flow direction ("outgoing", "incoming")
+        risk: Filter by risk classification ("low", "medium", "high", ...)
+        min_bytes: Only include flows with at least this many total bytes
+        client_name_contains: Substring match against source client_name
+        limit: Cap on the number of returned flows (after filtering)
 
     Returns:
-        List of traffic flows
+        List of flow dictionaries. Each dict has the full v2 schema —
+        ``source``, ``destination``, ``traffic_data``, ``policies``, etc.
     """
-    async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Retrieving traffic flows for site {site_id}"))
+    flows = await _get_filtered_flows(
+        site_id,
+        settings,
+        source_mac=source_mac,
+        source_ip=source_ip,
+        source_zone_name=source_zone_name,
+        source_network_name=source_network_name,
+        destination_ip=destination_ip,
+        destination_port=destination_port,
+        destination_zone_name=destination_zone_name,
+        destination_network_name=destination_network_name,
+        protocol=protocol,
+        action=action,
+        direction=direction,
+        risk=risk,
+        min_bytes=min_bytes,
+        client_name_contains=client_name_contains,
+    )
 
+    logger.info(
+        sanitize_log_message(
+            f"Retrieved {len(flows)} traffic flows for site {site_id}"
+        )
+    )
+
+    results = [flow.model_dump(by_alias=True) for flow in flows]
+    if limit is not None:
+        return results[:limit]
+    return results
+
+
+async def get_flow_statistics(
+    site_id: str,
+    settings: Settings,
+    source_mac: str | None = None,
+    source_zone_name: str | None = None,
+    destination_zone_name: str | None = None,
+    protocol: str | None = None,
+    action: str | None = None,
+) -> dict[str, Any]:
+    """Aggregate statistics over the current flow sample.
+
+    The result describes the rolling 50-flow snapshot (optionally narrowed
+    by the same client-side filters as :func:`get_traffic_flows`). There is
+    no "time range" — the v2 endpoint does not support historical windows.
+    """
+    flows = await _get_filtered_flows(
+        site_id,
+        settings,
+        source_mac=source_mac,
+        source_zone_name=source_zone_name,
+        destination_zone_name=destination_zone_name,
+        protocol=protocol,
+        action=action,
+    )
+
+    total_bytes_tx = sum(f.traffic_data.bytes_tx for f in flows)
+    total_bytes_rx = sum(f.traffic_data.bytes_rx for f in flows)
+    total_bytes = sum(f.traffic_data.bytes_total for f in flows)
+    total_packets = sum(f.traffic_data.packets_total for f in flows)
+
+    unique_sources = {
+        f.source.id or f.source.mac or f.source.ip for f in flows if _has_any_identifier(f.source)
+    }
+    unique_destinations = {f.destination.ip for f in flows if f.destination.ip}
+
+    protocol_breakdown: dict[str, int] = {}
+    action_breakdown: dict[str, int] = {}
+    for flow in flows:
+        protocol_breakdown[flow.protocol] = protocol_breakdown.get(flow.protocol, 0) + 1
+        action_breakdown[flow.action] = action_breakdown.get(flow.action, 0) + 1
+
+    top_destinations = _rank_destinations(flows, limit=5)
+
+    stats = FlowStatistics(
+        site_id=site_id,
+        sample_size=len(flows),
+        total_flows=len(flows),
+        total_bytes=total_bytes,
+        total_bytes_tx=total_bytes_tx,
+        total_bytes_rx=total_bytes_rx,
+        total_packets=total_packets,
+        unique_sources=len(unique_sources),
+        unique_destinations=len(unique_destinations),
+        protocol_breakdown=protocol_breakdown,
+        action_breakdown=action_breakdown,
+        top_destinations=top_destinations,
+    )
+    return stats.model_dump()
+
+
+async def get_traffic_flow_details(
+    site_id: str,
+    flow_id: str,
+    settings: Settings,
+) -> dict[str, Any]:
+    """Find a specific flow in the current 50-flow snapshot.
+
+    Raises :class:`ResourceNotFoundError` if the flow has rolled out of the
+    window (the v2 endpoint has no "fetch by id" lookup).
+    """
+    _ensure_local_api(settings)
+
+    async with UniFiClient(settings) as client:
         if not client.is_authenticated:
             await client.authenticate()
 
-        params: dict[str, Any] = {"time_range": time_range}
-        if source_ip:
-            params["source_ip"] = source_ip
-        if destination_ip:
-            params["destination_ip"] = destination_ip
-        if protocol:
-            params["protocol"] = protocol
-        if application_id:
-            params["application_id"] = application_id
-        if limit:
-            params["limit"] = limit
-        if offset:
-            params["offset"] = offset
+        raw_flows = await _fetch_raw_flows(client, settings, site_id)
+        for raw in raw_flows:
+            if raw.get("id") == flow_id:
+                return _parse_flow(raw).model_dump(by_alias=True)
 
-        try:
-            response = await client.get(
-                f"/integration/v1/sites/{site_id}/traffic/flows", params=params
-            )
-            data = response.get("data", [])
-        except Exception as e:
-            logger.warning(sanitize_log_message(f"Traffic flows endpoint not available: {e}"))
-            return []
-
-        return [TrafficFlow(**flow).model_dump() for flow in data]
-
-
-async def get_flow_statistics(site_id: str, settings: Settings, time_range: str = "24h") -> dict:
-    """Get aggregate flow statistics.
-
-    Args:
-        site_id: Site identifier
-        settings: Application settings
-        time_range: Time range for statistics (1h, 6h, 12h, 24h, 7d, 30d)
-
-    Returns:
-        Flow statistics
-    """
-    async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Retrieving flow statistics for site {site_id}"))
-
-        if not client.is_authenticated:
-            await client.authenticate()
-
-        try:
-            response = await client.get(
-                f"/integration/v1/sites/{site_id}/traffic/flows/statistics",
-                params={"time_range": time_range},
-            )
-            data = response.get("data", response)
-        except Exception as e:
-            logger.warning(sanitize_log_message(f"Flow statistics endpoint not available: {e}"))
-            # Return empty statistics
-            return FlowStatistics(  # type: ignore[no-any-return]
-                site_id=site_id,
-                time_range=time_range,
-                total_flows=0,
-                total_bytes_sent=0,
-                total_bytes_received=0,
-                total_bytes=0,
-                total_packets_sent=0,
-                total_packets_received=0,
-                unique_sources=0,
-                unique_destinations=0,
-            ).model_dump()
-
-        # Handle empty response (no traffic data)
-        if not data or data == {}:
-            logger.info(sanitize_log_message(f"No flow statistics available for site {site_id}"))
-            return FlowStatistics(  # type: ignore[no-any-return]
-                site_id=site_id,
-                time_range=time_range,
-                total_flows=0,
-                total_bytes_sent=0,
-                total_bytes_received=0,
-                total_bytes=0,
-                total_packets_sent=0,
-                total_packets_received=0,
-                unique_sources=0,
-                unique_destinations=0,
-            ).model_dump()
-
-        return FlowStatistics(**data).model_dump()  # type: ignore[no-any-return]
-
-
-async def get_traffic_flow_details(site_id: str, flow_id: str, settings: Settings) -> dict:
-    """Get details for a specific traffic flow.
-
-    Args:
-        site_id: Site identifier
-        flow_id: Flow identifier
-        settings: Application settings
-
-    Returns:
-        Traffic flow details
-    """
-    async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Retrieving traffic flow {flow_id} for site {site_id}"))
-
-        if not client.is_authenticated:
-            await client.authenticate()
-
-        try:
-            response = await client.get(f"/integration/v1/sites/{site_id}/traffic/flows/{flow_id}")
-            data = response.get("data", response)
-        except Exception as e:
-            logger.warning(sanitize_log_message(f"Traffic flow details endpoint not available: {e}"))
-            raise
-
-        return TrafficFlow(**data).model_dump()  # type: ignore[no-any-return]
+        raise ResourceNotFoundError("traffic_flow", flow_id)
 
 
 async def get_top_flows(
     site_id: str,
     settings: Settings,
     limit: int = 10,
-    time_range: str = "24h",
     sort_by: str = "bytes",
-) -> list[dict]:
-    """Get top bandwidth-consuming flows.
+) -> list[dict[str, Any]]:
+    """Return the top N flows in the current sample, sorted by volume.
 
     Args:
-        site_id: Site identifier
-        settings: Application settings
-        limit: Number of top flows to return
-        time_range: Time range for flows
-        sort_by: Sort by field (bytes, packets, duration)
-
-    Returns:
-        List of top flows
+        sort_by: ``"bytes"`` (default), ``"packets"``, or ``"duration"``.
     """
-    async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Retrieving top flows for site {site_id}"))
+    flows = await _get_filtered_flows(site_id, settings)
 
-        if not client.is_authenticated:
-            await client.authenticate()
+    def _key(flow: TrafficFlow) -> int:
+        if sort_by == "packets":
+            return flow.traffic_data.packets_total
+        if sort_by == "duration":
+            return flow.duration_milliseconds or 0
+        return flow.traffic_data.bytes_total
 
-        try:
-            response = await client.get(
-                f"/integration/v1/sites/{site_id}/traffic/flows/top",
-                params={"limit": limit, "time_range": time_range, "sort_by": sort_by},
-            )
-            data = response.get("data", [])
-        except Exception:
-            # Fallback: get all flows and sort manually
-            logger.info("Top flows endpoint not available, fetching all flows")
-            flows = await get_traffic_flows(site_id, settings, time_range=time_range)
-            # Sort by total bytes
-            sorted_flows = sorted(
-                flows,
-                key=lambda x: x.get("bytes_sent", 0) + x.get("bytes_received", 0),
-                reverse=True,
-            )
-            return sorted_flows[:limit]
-
-        return [TrafficFlow(**flow).model_dump() for flow in data]
+    sorted_flows = sorted(flows, key=_key, reverse=True)[:limit]
+    return [flow.model_dump(by_alias=True) for flow in sorted_flows]
 
 
 async def get_flow_risks(
     site_id: str,
     settings: Settings,
-    time_range: str = "24h",
     min_risk_level: str | None = None,
-) -> list[dict]:
-    """Get risk assessment for flows.
+) -> list[dict[str, Any]]:
+    """Return flows filtered by risk classification.
+
+    The v2 endpoint reports risk inline on each flow (``low``/``medium``/
+    ``high``/``critical``). ``min_risk_level`` keeps everything at or above
+    the given level.
+    """
+    order = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+    threshold = order.get((min_risk_level or "").lower(), 0)
+
+    flows = await _get_filtered_flows(site_id, settings)
+    matching = [
+        flow
+        for flow in flows
+        if order.get((flow.risk or "").lower(), 0) >= threshold
+    ]
+    return [flow.model_dump(by_alias=True) for flow in matching]
+
+
+async def filter_traffic_flows(
+    site_id: str,
+    settings: Settings,
+    filter_expression: str,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Client-side filter by a simple ``key=value`` expression list.
+
+    Accepts comma-separated ``key=value`` pairs, for example
+    ``"protocol=UDP,destination_zone_name=External,min_bytes=1000"``. Any
+    key recognised by :func:`get_traffic_flows` may be used.
+    """
+    parsed: dict[str, Any] = {}
+    for chunk in (part.strip() for part in filter_expression.split(",")):
+        if not chunk or "=" not in chunk:
+            continue
+        key, value = chunk.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if key in {"destination_port", "min_bytes"}:
+            try:
+                parsed[key] = int(value)
+            except ValueError:
+                continue
+        else:
+            parsed[key] = value
+
+    return await get_traffic_flows(site_id, settings, limit=limit, **parsed)
+
+
+async def get_client_flow_aggregation(
+    site_id: str,
+    client_mac: str,
+    settings: Settings,
+) -> dict[str, Any]:
+    """Aggregate the current flow sample for a specific client MAC."""
+    flows = await _get_filtered_flows(
+        site_id, settings, source_mac=client_mac
+    )
+
+    if not flows:
+        return ClientFlowAggregation(
+            client_mac=client_mac,
+            site_id=site_id,
+            sample_size=0,
+        ).model_dump()
+
+    client_ip = flows[0].source.ip
+    client_name = flows[0].source.client_name
+    total_bytes = sum(f.traffic_data.bytes_total for f in flows)
+    total_packets = sum(f.traffic_data.packets_total for f in flows)
+
+    protocol_breakdown: dict[str, int] = {}
+    for flow in flows:
+        protocol_breakdown[flow.protocol] = protocol_breakdown.get(flow.protocol, 0) + 1
+
+    return ClientFlowAggregation(
+        client_mac=client_mac,
+        client_name=client_name,
+        client_ip=client_ip,
+        site_id=site_id,
+        sample_size=len(flows),
+        total_bytes=total_bytes,
+        total_packets=total_packets,
+        top_destinations=_rank_destinations(flows, limit=5),
+        protocol_breakdown=protocol_breakdown,
+    ).model_dump()
+
+
+async def get_flow_analytics(
+    site_id: str,
+    settings: Settings,
+) -> dict[str, Any]:
+    """High-level analytics over the current flow sample.
+
+    Returns counts, totals, protocol / action / risk breakdowns, and top
+    destinations in a single call. Thin wrapper over
+    :func:`get_flow_statistics` with an additional risk breakdown.
+    """
+    stats = await get_flow_statistics(site_id, settings)
+    flows = await _get_filtered_flows(site_id, settings)
+
+    risk_breakdown: dict[str, int] = {}
+    for flow in flows:
+        level = (flow.risk or "unknown").lower()
+        risk_breakdown[level] = risk_breakdown.get(level, 0) + 1
+
+    stats["risk_breakdown"] = risk_breakdown
+    return stats
+
+
+async def export_traffic_flows(
+    site_id: str,
+    settings: Settings,
+    export_format: str = "json",
+    max_records: int | None = None,
+) -> str:
+    """Serialise the current flow sample to JSON or CSV."""
+    if export_format not in {"json", "csv"}:
+        raise ValueError("export_format must be 'json' or 'csv'")
+
+    flows = await _get_filtered_flows(site_id, settings)
+    if max_records is not None:
+        flows = flows[:max_records]
+
+    if export_format == "json":
+        return json.dumps([f.model_dump(by_alias=True) for f in flows], indent=2)
+
+    buf = StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(
+        [
+            "flow_id",
+            "action",
+            "protocol",
+            "direction",
+            "source_mac",
+            "source_ip",
+            "source_port",
+            "source_zone",
+            "destination_ip",
+            "destination_port",
+            "destination_zone",
+            "bytes_total",
+            "packets_total",
+            "duration_ms",
+            "risk",
+        ]
+    )
+    for f in flows:
+        writer.writerow(
+            [
+                f.id,
+                f.action,
+                f.protocol,
+                f.direction,
+                f.source.mac or f.source.id or "",
+                f.source.ip or "",
+                f.source.port or "",
+                f.source.zone_name or "",
+                f.destination.ip or "",
+                f.destination.port or "",
+                f.destination.zone_name or "",
+                f.traffic_data.bytes_total,
+                f.traffic_data.packets_total,
+                f.duration_milliseconds or 0,
+                f.risk or "",
+            ]
+        )
+    return buf.getvalue()
+
+
+async def find_flows_for_rule_reference(
+    site_id: str,
+    settings: Settings,
+    source_zone_name: str | None = None,
+    destination_zone_name: str | None = None,
+    source_network_name: str | None = None,
+    destination_network_name: str | None = None,
+    source_mac: str | None = None,
+    protocol: str | None = None,
+    destination_port: int | None = None,
+    destination_ip: str | None = None,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """Find flows matching a *draft* firewall rule intent.
+
+    Designed for the "should I create this rule?" workflow: given the
+    proposed match criteria for a new zone-based firewall policy or ACL
+    rule, this tool returns the real flows from the current snapshot that
+    the rule *would* have matched. The LLM can then inspect the concrete
+    traffic before committing to the rule.
+
+    Each result is a :class:`FlowRuleReferenceMatch` — trimmed to the
+    fields relevant for rule evaluation (zone/network/port/bytes/action).
+
+    **Inter-VLAN rule authoring note:** UniFi labels the destination zone
+    of inter-VLAN flows as ``"Gateway"`` rather than the target VLAN's
+    zone. To reference a rule intent like "Internal → Servers VLAN", pass
+    ``source_network_name`` / ``destination_network_name`` (the actual
+    VLAN display names) instead of the zone names. Zone names work for
+    egress flows to External but not for inter-VLAN traffic.
 
     Args:
         site_id: Site identifier
         settings: Application settings
-        time_range: Time range for flows
-        min_risk_level: Minimum risk level to include (low/medium/high/critical)
+        source_zone_name: Proposed source zone
+        destination_zone_name: Proposed destination zone (only useful for
+            ``External``; see the inter-VLAN note above)
+        source_network_name: Proposed source VLAN display name
+        destination_network_name: Proposed destination VLAN display name —
+            **use this for inter-VLAN rules**
+        source_mac: Proposed source client MAC
+        protocol: Proposed protocol
+        destination_port: Proposed destination port
+        destination_ip: Proposed destination IP
+        limit: Max matches to return (default 20, capped at 50 by the API)
 
     Returns:
-        List of flows with risk assessments
+        List of lightweight match records suitable for rendering to the user.
     """
-    async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Retrieving flow risks for site {site_id}"))
+    flows = await _get_filtered_flows(
+        site_id,
+        settings,
+        source_zone_name=source_zone_name,
+        destination_network_name=destination_network_name,
+        destination_zone_name=destination_zone_name,
+        source_network_name=source_network_name,
+        source_mac=source_mac,
+        protocol=protocol,
+        destination_port=destination_port,
+        destination_ip=destination_ip,
+    )
 
-        if not client.is_authenticated:
-            await client.authenticate()
+    matches = [_flow_to_reference_match(flow) for flow in flows[:limit]]
+    return [m.model_dump() for m in matches]
 
-        params = {"time_range": time_range}
-        if min_risk_level:
-            params["min_risk_level"] = min_risk_level
 
-        try:
-            response = await client.get(
-                f"/integration/v1/sites/{site_id}/traffic/flows/risks", params=params
-            )
-            data = response.get("data", [])
-        except Exception:
-            logger.warning("Flow risks endpoint not available")
-            return []
+# --------------------------------------------------------------------------- #
+# Helpers for aggregation                                                     #
+# --------------------------------------------------------------------------- #
 
-        return [FlowRisk(**risk).model_dump() for risk in data]
+
+def _has_any_identifier(endpoint: Any) -> bool:
+    return bool(getattr(endpoint, "id", None) or getattr(endpoint, "mac", None) or getattr(endpoint, "ip", None))
+
+
+def _rank_destinations(
+    flows: Iterable[TrafficFlow], *, limit: int
+) -> list[dict[str, Any]]:
+    """Return the top destinations by total bytes in a flow sample."""
+    tally: dict[str, dict[str, Any]] = {}
+    for flow in flows:
+        ip = flow.destination.ip
+        if not ip:
+            continue
+        entry = tally.setdefault(
+            ip,
+            {
+                "ip": ip,
+                "port": flow.destination.port,
+                "zone_name": flow.destination.zone_name,
+                "region": flow.destination.region,
+                "bytes_total": 0,
+                "flow_count": 0,
+            },
+        )
+        entry["bytes_total"] += flow.traffic_data.bytes_total
+        entry["flow_count"] += 1
+    ranked = sorted(tally.values(), key=lambda e: e["bytes_total"], reverse=True)
+    return ranked[:limit]
+
+
+def _flow_to_reference_match(flow: TrafficFlow) -> FlowRuleReferenceMatch:
+    src_label = (
+        flow.source.client_name
+        or flow.source.mac
+        or flow.source.ip
+        or flow.source.id
+        or "unknown"
+    )
+    dst_label_parts = [
+        flow.destination.ip or flow.destination.id or "?",
+    ]
+    if flow.destination.zone_name:
+        dst_label_parts.append(f"({flow.destination.zone_name})")
+    dst_label = " ".join(dst_label_parts)
+    return FlowRuleReferenceMatch(
+        flow_id=flow.id,
+        source_label=str(src_label),
+        destination_label=dst_label,
+        protocol=flow.protocol,
+        destination_port=flow.destination.port,
+        bytes_total=flow.traffic_data.bytes_total,
+        action=flow.action,
+        source_zone_name=flow.source.zone_name,
+        destination_zone_name=flow.destination.zone_name,
+        source_network_name=flow.source.network_name,
+        flow_start_time=flow.flow_start_time,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Unsupported on the v2 endpoint                                              #
+# --------------------------------------------------------------------------- #
 
 
 async def get_flow_trends(
@@ -259,81 +722,19 @@ async def get_flow_trends(
     settings: Settings,
     time_range: str = "7d",
     interval: str = "1h",
-) -> list[dict]:
-    """Get historical flow trends.
+) -> list[dict[str, Any]]:
+    """Historical trends — **not supported** on the v2 endpoint.
 
-    Args:
-        site_id: Site identifier
-        settings: Application settings
-        time_range: Time range for trends (default: 7d)
-        interval: Time interval for data points (1h, 6h, 1d)
-
-    Returns:
-        List of trend data points
+    The v2 ``traffic-flows`` endpoint returns a rolling snapshot of the 50
+    most-recent completed flows; there is no historical query capability.
+    For aggregated time-series over longer windows, use the ``stat/report/*``
+    endpoints via other MCP tools (e.g. client bandwidth history).
     """
-    async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Retrieving flow trends for site {site_id}"))
-
-        if not client.is_authenticated:
-            await client.authenticate()
-
-        try:
-            response = await client.get(
-                f"/integration/v1/sites/{site_id}/traffic/flows/trends",
-                params={"time_range": time_range, "interval": interval},
-            )
-            data = response.get("data", [])
-        except Exception:
-            logger.warning("Flow trends endpoint not available")
-            return []
-
-        return data  # type: ignore[no-any-return]
-
-
-async def filter_traffic_flows(
-    site_id: str,
-    settings: Settings,
-    filter_expression: str,
-    time_range: str = "24h",
-    limit: int | None = None,
-) -> list[dict]:
-    """Filter flows using a complex filter expression.
-
-    Args:
-        site_id: Site identifier
-        settings: Application settings
-        filter_expression: Filter expression (e.g., "bytes > 1000000 AND protocol = 'tcp'")
-        time_range: Time range for flows
-        limit: Maximum number of flows to return
-
-    Returns:
-        List of filtered traffic flows
-    """
-    async with UniFiClient(settings) as client:
-        logger.info(
-            f"Filtering traffic flows for site {site_id} with expression: {filter_expression}"
-        )
-
-        if not client.is_authenticated:
-            await client.authenticate()
-
-        params: dict[str, Any] = {"filter": filter_expression, "time_range": time_range}
-        if limit:
-            params["limit"] = limit
-
-        try:
-            response = await client.get(
-                f"/integration/v1/sites/{site_id}/traffic/flows", params=params
-            )
-            data = response.get("data", [])
-        except Exception:
-            logger.warning("Filtered flows endpoint not available, using basic filtering")
-            # Fallback to basic filtering
-            flows = await get_traffic_flows(site_id, settings, time_range=time_range)
-            # Simple filtering - in production, would use a proper query parser
-            return flows[:limit] if limit else flows
-
-        return [TrafficFlow(**flow).model_dump() for flow in data]
+    raise NotImplementedError(
+        "get_flow_trends is not supported: the v2 traffic-flows endpoint "
+        "does not expose historical time-series data. Use stat/report-based "
+        "tools for bandwidth trends."
+    )
 
 
 async def stream_traffic_flows(
@@ -341,260 +742,39 @@ async def stream_traffic_flows(
     settings: Settings,
     interval_seconds: int = 15,
     filter_expression: str | None = None,
-) -> AsyncGenerator[dict, None]:
-    """Stream real-time traffic flow updates.
+) -> Any:
+    """Streaming — **not supported** on the v2 endpoint.
 
-    This function attempts to use WebSocket for real-time updates,
-    falling back to polling if WebSocket is unavailable.
-
-    Args:
-        site_id: Site identifier
-        settings: Application settings
-        interval_seconds: Update interval in seconds (default: 15)
-        filter_expression: Optional filter expression
-
-    Yields:
-        Flow stream updates with bandwidth rates
+    With the hard 50-flow cap the endpoint can't be used as a streaming
+    source — fast networks roll through that window in well under a second.
+    Use :func:`get_traffic_flows` on a poll schedule instead.
     """
-    async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Starting traffic flow stream for site {site_id}"))
-
-        if not client.is_authenticated:
-            await client.authenticate()
-
-        # Track previous flows for rate calculation
-        previous_flows: dict[str, TrafficFlow] = {}
-
-        # Try WebSocket first (if available in future)
-        # For now, use polling fallback
-        logger.info(sanitize_log_message(f"Using polling fallback with {interval_seconds}s interval"))
-
-        while True:
-            try:
-                # Get current flows
-                params: dict[str, Any] = {}
-                if filter_expression:
-                    params["filter"] = filter_expression
-
-                response = await client.get(
-                    f"/integration/v1/sites/{site_id}/traffic/flows", params=params
-                )
-                data = response.get("data", [])
-
-                current_time = datetime.now(timezone.utc).isoformat()
-
-                for flow_data in data:
-                    flow = TrafficFlow(**flow_data)
-                    flow_id = flow.flow_id
-
-                    # Determine update type
-                    if flow_id in previous_flows:
-                        update_type_str: Literal["new", "update", "closed"] = "update"
-                        # Calculate bandwidth rate
-                        prev_flow = previous_flows[flow_id]
-                        bytes_diff = (flow.bytes_sent + flow.bytes_received) - (
-                            prev_flow.bytes_sent + prev_flow.bytes_received
-                        )
-                        bandwidth_rate = {
-                            "bps": bytes_diff * 8 / interval_seconds,
-                            "upload_bps": (flow.bytes_sent - prev_flow.bytes_sent)
-                            * 8
-                            / interval_seconds,
-                            "download_bps": (flow.bytes_received - prev_flow.bytes_received)
-                            * 8
-                            / interval_seconds,
-                        }
-                    else:
-                        update_type_str = "new"
-                        bandwidth_rate = None
-
-                    # Create stream update
-                    update = FlowStreamUpdate(
-                        update_type=update_type_str,
-                        flow=flow,
-                        timestamp=current_time,
-                        bandwidth_rate=bandwidth_rate,
-                    )
-
-                    yield update.model_dump()
-
-                    # Update tracking
-                    previous_flows[flow_id] = flow
-
-                # Check for closed flows
-                current_flow_ids = {flow.flow_id for flow in data}
-                for prev_flow_id in list(previous_flows.keys()):
-                    if prev_flow_id not in current_flow_ids:
-                        closed_flow = previous_flows.pop(prev_flow_id)
-                        closed_update_type: Literal["new", "update", "closed"] = "closed"
-                        update = FlowStreamUpdate(
-                            update_type=closed_update_type,
-                            flow=closed_flow,
-                            timestamp=current_time,
-                            bandwidth_rate=None,
-                        )
-                        yield update.model_dump()
-
-                # Wait for next interval
-                await asyncio.sleep(interval_seconds)
-
-            except Exception as e:
-                logger.error(sanitize_log_message(f"Error in flow streaming: {e}"))
-                await asyncio.sleep(interval_seconds)
+    raise NotImplementedError(
+        "stream_traffic_flows is not supported: the v2 traffic-flows endpoint "
+        "caps responses at 50 flows with no pagination, so a streaming view "
+        "drops flows on busy networks. Poll get_traffic_flows instead."
+    )
 
 
 async def get_connection_states(
     site_id: str,
     settings: Settings,
-    time_range: str = "1h",
-) -> list[dict]:
-    """Get connection states for all flows.
+) -> list[dict[str, Any]]:
+    """Connection-state tracking — **not supported** on the v2 endpoint.
 
-    Args:
-        site_id: Site identifier
-        settings: Application settings
-        time_range: Time range for flows
-
-    Returns:
-        List of connection states
+    The v2 ``traffic-flows`` endpoint reports already-completed flows with
+    start/end timestamps, not a live connection table.
     """
-    async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Retrieving connection states for site {site_id}"))
-
-        if not client.is_authenticated:
-            await client.authenticate()
-
-        # Get flows
-        flows = await get_traffic_flows(site_id, settings, time_range=time_range)
-
-        # Determine connection states
-        states = []
-        current_time = datetime.now(timezone.utc)
-
-        for flow in flows:
-            flow_obj = TrafficFlow(**flow)
-
-            # Determine state based on end_time
-            if flow_obj.end_time:
-                state_val: Literal["active", "closed", "timed_out"] = "closed"
-                termination_reason = "normal_closure"
-            else:
-                # Check if flow is timed out (no activity in last 5 minutes)
-                last_seen = datetime.fromisoformat(flow_obj.start_time.replace("Z", "+00:00"))
-                if (current_time - last_seen).total_seconds() > 300:
-                    state_val = "timed_out"
-                    termination_reason = "timeout"
-                else:
-                    state_val = "active"
-                    termination_reason = None
-
-            connection_state = ConnectionState(
-                flow_id=flow_obj.flow_id,
-                state=state_val,
-                last_seen=flow_obj.end_time or flow_obj.start_time,
-                total_duration=flow_obj.duration,
-                termination_reason=termination_reason,
-            )
-
-            states.append(connection_state.model_dump())
-
-        return states
+    raise NotImplementedError(
+        "get_connection_states is not supported: the v2 traffic-flows "
+        "endpoint does not report explicit connection states. It returns "
+        "completed flows with start/end timestamps only."
+    )
 
 
-async def get_client_flow_aggregation(
-    site_id: str,
-    client_mac: str,
-    settings: Settings,
-    time_range: str = "24h",
-) -> dict:
-    """Get aggregated flow data for a specific client.
-
-    Args:
-        site_id: Site identifier
-        client_mac: Client MAC address
-        settings: Application settings
-        time_range: Time range for aggregation
-
-    Returns:
-        Client flow aggregation data
-    """
-    async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Retrieving flow aggregation for client {client_mac}"))
-
-        if not client.is_authenticated:
-            await client.authenticate()
-
-        # Get flows for this client
-        flows = await get_traffic_flows(site_id, settings, time_range=time_range)
-        client_flows = [f for f in flows if f.get("client_mac") == client_mac]
-
-        # Get connection states
-        states = await get_connection_states(site_id, settings, time_range=time_range)
-        client_states = [
-            s for s in states if any(f["flow_id"] == s["flow_id"] for f in client_flows)
-        ]
-
-        # Aggregate statistics
-        total_bytes = sum(f.get("bytes_sent", 0) + f.get("bytes_received", 0) for f in client_flows)
-        total_packets = sum(
-            f.get("packets_sent", 0) + f.get("packets_received", 0) for f in client_flows
-        )
-
-        active_flows = len([s for s in client_states if s["state"] == "active"])
-        closed_flows = len([s for s in client_states if s["state"] == "closed"])
-
-        # Top applications
-        app_bytes: dict[str, int] = {}
-        for flow in client_flows:
-            app_name = flow.get("application_name", "Unknown")
-            app_bytes[app_name] = (
-                app_bytes.get(app_name, 0)
-                + flow.get("bytes_sent", 0)
-                + flow.get("bytes_received", 0)
-            )
-
-        top_applications = [
-            {"application": app, "bytes": bytes_val}
-            for app, bytes_val in sorted(app_bytes.items(), key=lambda x: x[1], reverse=True)[:10]
-        ]
-
-        # Top destinations
-        dest_bytes: dict[str, int] = {}
-        for flow in client_flows:
-            dest_ip = flow.get("destination_ip", "Unknown")
-            dest_bytes[dest_ip] = (
-                dest_bytes.get(dest_ip, 0)
-                + flow.get("bytes_sent", 0)
-                + flow.get("bytes_received", 0)
-            )
-
-        top_destinations = [
-            {"destination_ip": dest, "bytes": bytes_val}
-            for dest, bytes_val in sorted(dest_bytes.items(), key=lambda x: x[1], reverse=True)[:10]
-        ]
-
-        # Get client IP from first flow
-        client_ip = client_flows[0].get("source_ip") if client_flows else None
-
-        # Auth failures would come from a separate endpoint
-        # For now, set to 0 as placeholder
-        auth_failures = 0
-
-        aggregation = ClientFlowAggregation(
-            client_mac=client_mac,
-            client_ip=client_ip,
-            site_id=site_id,
-            total_flows=len(client_flows),
-            total_bytes=total_bytes,
-            total_packets=total_packets,
-            active_flows=active_flows,
-            closed_flows=closed_flows,
-            auth_failures=auth_failures,
-            top_applications=top_applications,
-            top_destinations=top_destinations,
-        )
-
-        return aggregation.model_dump()  # type: ignore[no-any-return]
+# --------------------------------------------------------------------------- #
+# Block-flow actions (create firewall rules)                                  #
+# --------------------------------------------------------------------------- #
 
 
 async def block_flow_source_ip(
@@ -605,97 +785,25 @@ async def block_flow_source_ip(
     expires_in_hours: int | None = None,
     confirm: bool | str = False,
     dry_run: bool | str = False,
-) -> dict:
-    """Block source IP address from a traffic flow.
-
-    Args:
-        site_id: Site identifier
-        flow_id: Flow identifier to block
-        settings: Application settings
-        duration: Block duration ("permanent" or "temporary")
-        expires_in_hours: Hours until expiration (for temporary blocks)
-        confirm: Confirmation flag (required)
-        dry_run: If True, validate but don't execute
-
-    Returns:
-        Block action result
-    """
+) -> dict[str, Any]:
+    """Create a firewall rule blocking the source IP of a specific flow."""
     validate_confirmation(confirm, "block flow source IP", dry_run)
 
-    async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Blocking source IP from flow {flow_id}"))
+    flow_dict = await get_traffic_flow_details(site_id, flow_id, settings)
+    source_ip = (flow_dict.get("source") or {}).get("ip")
+    if not source_ip:
+        raise ValueError(f"No source IP found for flow {flow_id}")
 
-        if not client.is_authenticated:
-            await client.authenticate()
-
-        # Get flow details
-        flow_data = await get_traffic_flow_details(site_id, flow_id, settings)
-        source_ip = flow_data.get("source_ip")
-
-        if not source_ip:
-            raise ValueError(f"No source IP found for flow {flow_id}")
-
-        # Calculate expiration
-        expires_at = None
-        if duration == "temporary" and expires_in_hours:
-            expires_at = (
-                datetime.now(timezone.utc) + timedelta(hours=expires_in_hours)
-            ).isoformat()
-
-        # Create firewall rule to block this IP
-        from .firewall import create_firewall_rule
-
-        rule_name = f"Block_{source_ip}_{flow_id[:8]}"
-
-        if dry_run:
-            logger.info(sanitize_log_message(f"[DRY RUN] Would block source IP {source_ip}"))
-            action_id = str(uuid4())
-            return BlockFlowAction(  # type: ignore[no-any-return]
-                action_id=action_id,
-                block_type="source_ip",
-                blocked_target=source_ip,
-                rule_id=None,
-                zone_id=None,
-                duration=duration,
-                expires_at=expires_at,
-                created_at=datetime.now(timezone.utc).isoformat(),
-            ).model_dump()
-
-        # Create blocking rule
-        rule_result = await create_firewall_rule(
-            site_id=site_id,
-            name=rule_name,
-            action="drop",
-            protocol="all",
-            settings=settings,
-            source=source_ip,
-            enabled=True,
-            confirm=True,
-        )
-
-        rule_id = rule_result.get("_id")
-        action_id = str(uuid4())
-
-        # Audit the action
-        await audit_action(
-            settings,
-            action_type="block_flow_source_ip",
-            resource_type="flow_block_action",
-            resource_id=action_id,
-            site_id=site_id,
-            details={"flow_id": flow_id, "source_ip": source_ip, "rule_id": rule_id},
-        )
-
-        return BlockFlowAction(  # type: ignore[no-any-return]
-            action_id=action_id,
-            block_type="source_ip",
-            blocked_target=source_ip,
-            rule_id=rule_id,
-            zone_id=None,
-            duration=duration,
-            expires_at=expires_at,
-            created_at=datetime.now(timezone.utc).isoformat(),
-        ).model_dump()
+    return await _create_block_action(
+        site_id=site_id,
+        settings=settings,
+        block_type="source_ip",
+        blocked_target=source_ip,
+        rule_name_prefix="BlockSrc",
+        duration=duration,
+        expires_in_hours=expires_in_hours,
+        dry_run=dry_run,
+    )
 
 
 async def block_flow_destination_ip(
@@ -706,357 +814,134 @@ async def block_flow_destination_ip(
     expires_in_hours: int | None = None,
     confirm: bool | str = False,
     dry_run: bool | str = False,
-) -> dict:
-    """Block destination IP address from a traffic flow.
-
-    Args:
-        site_id: Site identifier
-        flow_id: Flow identifier to block
-        settings: Application settings
-        duration: Block duration ("permanent" or "temporary")
-        expires_in_hours: Hours until expiration (for temporary blocks)
-        confirm: Confirmation flag (required)
-        dry_run: If True, validate but don't execute
-
-    Returns:
-        Block action result
-    """
+) -> dict[str, Any]:
+    """Create a firewall rule blocking the destination IP of a specific flow."""
     validate_confirmation(confirm, "block flow destination IP", dry_run)
 
-    async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Blocking destination IP from flow {flow_id}"))
+    flow_dict = await get_traffic_flow_details(site_id, flow_id, settings)
+    destination_ip = (flow_dict.get("destination") or {}).get("ip")
+    if not destination_ip:
+        raise ValueError(f"No destination IP found for flow {flow_id}")
 
-        if not client.is_authenticated:
-            await client.authenticate()
-
-        # Get flow details
-        flow_data = await get_traffic_flow_details(site_id, flow_id, settings)
-        destination_ip = flow_data.get("destination_ip")
-
-        if not destination_ip:
-            raise ValueError(f"No destination IP found for flow {flow_id}")
-
-        # Calculate expiration
-        expires_at = None
-        if duration == "temporary" and expires_in_hours:
-            expires_at = (
-                datetime.now(timezone.utc) + timedelta(hours=expires_in_hours)
-            ).isoformat()
-
-        # Create firewall rule to block this IP
-        from .firewall import create_firewall_rule
-
-        rule_name = f"Block_{destination_ip}_{flow_id[:8]}"
-
-        if dry_run:
-            logger.info(sanitize_log_message(f"[DRY RUN] Would block destination IP {destination_ip}"))
-            action_id = str(uuid4())
-            return BlockFlowAction(  # type: ignore[no-any-return]
-                action_id=action_id,
-                block_type="destination_ip",
-                blocked_target=destination_ip,
-                rule_id=None,
-                zone_id=None,
-                duration=duration,
-                expires_at=expires_at,
-                created_at=datetime.now(timezone.utc).isoformat(),
-            ).model_dump()
-
-        # Create blocking rule
-        rule_result = await create_firewall_rule(
-            site_id=site_id,
-            name=rule_name,
-            action="drop",
-            protocol="all",
-            settings=settings,
-            destination=destination_ip,
-            enabled=True,
-            confirm=True,
-        )
-
-        rule_id = rule_result.get("_id")
-        action_id = str(uuid4())
-
-        # Audit the action
-        await audit_action(
-            settings,
-            action_type="block_flow_destination_ip",
-            resource_type="flow_block_action",
-            resource_id=action_id,
-            site_id=site_id,
-            details={"flow_id": flow_id, "destination_ip": destination_ip, "rule_id": rule_id},
-        )
-
-        return BlockFlowAction(  # type: ignore[no-any-return]
-            action_id=action_id,
-            block_type="destination_ip",
-            blocked_target=destination_ip,
-            rule_id=rule_id,
-            zone_id=None,
-            duration=duration,
-            expires_at=expires_at,
-            created_at=datetime.now(timezone.utc).isoformat(),
-        ).model_dump()
+    return await _create_block_action(
+        site_id=site_id,
+        settings=settings,
+        block_type="destination_ip",
+        blocked_target=destination_ip,
+        rule_name_prefix="BlockDst",
+        duration=duration,
+        expires_in_hours=expires_in_hours,
+        dry_run=dry_run,
+    )
 
 
 async def block_flow_application(
     site_id: str,
     flow_id: str,
     settings: Settings,
-    use_zbf: bool = True,
-    zone_id: str | None = None,
+    duration: str = "permanent",
+    expires_in_hours: int | None = None,
     confirm: bool | str = False,
     dry_run: bool | str = False,
-) -> dict:
-    """Block application identified in a traffic flow.
+) -> dict[str, Any]:
+    """Block a flow's identified application.
 
-    Args:
-        site_id: Site identifier
-        flow_id: Flow identifier to block
-        settings: Application settings
-        use_zbf: Use Zone-Based Firewall if available (default: True)
-        zone_id: Zone ID for ZBF blocking (optional)
-        confirm: Confirmation flag (required)
-        dry_run: If True, validate but don't execute
-
-    Returns:
-        Block action result
+    The v2 ``traffic-flows`` endpoint reports a coarse ``service`` field
+    ("DNS", "OTHER", etc.) rather than a DPI application id, so this tool
+    falls back to blocking the destination IP when no distinct application
+    can be inferred.
     """
     validate_confirmation(confirm, "block flow application", dry_run)
 
-    async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Blocking application from flow {flow_id}"))
+    flow_dict = await get_traffic_flow_details(site_id, flow_id, settings)
+    destination_ip = (flow_dict.get("destination") or {}).get("ip")
+    if not destination_ip:
+        raise ValueError(f"Flow {flow_id} has no destination IP to block")
+    # The v2 endpoint reports a coarse `service` field ("DNS", "OTHER",
+    # etc.) rather than a DPI application id, so we always fall back to
+    # blocking the destination IP. The service name is included in the
+    # block-action metadata for audit purposes but NOT in the firewall
+    # rule target (which must be a valid IP/CIDR).
+    target = destination_ip
 
-        if not client.is_authenticated:
-            await client.authenticate()
+    return await _create_block_action(
+        site_id=site_id,
+        settings=settings,
+        block_type="application",
+        blocked_target=target,
+        rule_name_prefix="BlockApp",
+        duration=duration,
+        expires_in_hours=expires_in_hours,
+        dry_run=dry_run,
+    )
 
-        # Get flow details
-        flow_data = await get_traffic_flow_details(site_id, flow_id, settings)
-        application_id = flow_data.get("application_id")
-        application_name = flow_data.get("application_name", "Unknown")
 
-        if not application_id:
-            raise ValueError(f"No application ID found for flow {flow_id}")
+async def _create_block_action(
+    *,
+    site_id: str,
+    settings: Settings,
+    block_type: str,
+    blocked_target: str,
+    rule_name_prefix: str,
+    duration: str,
+    expires_in_hours: int | None,
+    dry_run: bool | str,
+) -> dict[str, Any]:
+    """Shared block-action implementation used by the three block_flow_* tools."""
+    from .firewall import create_firewall_rule
 
-        action_id = str(uuid4())
-        created_at = datetime.now(timezone.utc).isoformat()
+    rule_name = f"{rule_name_prefix}_{blocked_target.replace(':', '_')[:24]}"
+    action_id = str(uuid4())
+    created_at = datetime.now(timezone.utc).isoformat()
+    expires_at = None
+    if duration == "temporary" and expires_in_hours:
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(hours=expires_in_hours)
+        ).isoformat()
 
-        if dry_run:
-            logger.info(sanitize_log_message(f"[DRY RUN] Would block application {application_name} ({application_id})"))
-            return BlockFlowAction(  # type: ignore[no-any-return]
-                action_id=action_id,
-                block_type="application",
-                blocked_target=application_id,
-                rule_id=None,
-                zone_id=zone_id if use_zbf else None,
-                duration="permanent",
-                expires_at=None,
-                created_at=created_at,
-            ).model_dump()
-
-        rule_id = None
-        result_zone_id = None
-
-        # Try ZBF blocking first if requested
-        if use_zbf:
-            try:
-                from .zbf_matrix import block_application_by_zone
-
-                # If no zone specified, try to get a default zone
-                if not zone_id:
-                    from .firewall_zones import list_firewall_zones
-
-                    zones = await list_firewall_zones(site_id, settings)
-                    if zones:
-                        zone_id = zones[0].get("id")
-
-                if zone_id:
-                    await block_application_by_zone(
-                        site_id=site_id,
-                        zone_id=zone_id,
-                        application_id=application_id,
-                        settings=settings,
-                        action="block",
-                        confirm=True,
-                    )
-                    result_zone_id = zone_id
-                    logger.info(sanitize_log_message(f"Blocked application using ZBF in zone {zone_id}"))
-            except Exception as e:
-                logger.warning(sanitize_log_message(f"ZBF blocking failed, falling back to traditional firewall: {e}"))
-                use_zbf = False
-
-        # Fallback to traditional firewall rule
-        if not use_zbf or not zone_id:
-            from .firewall import create_firewall_rule
-
-            rule_name = f"Block_App_{application_name}_{flow_id[:8]}"
-
-            rule_result = await create_firewall_rule(
-                site_id=site_id,
-                name=rule_name,
-                action="drop",
-                protocol="all",
-                settings=settings,
-                enabled=True,
-                confirm=True,
+    if dry_run:
+        logger.info(
+            sanitize_log_message(
+                f"[DRY RUN] Would block {block_type}={blocked_target}"
             )
-            rule_id = rule_result.get("_id")
-
-        # Audit the action
-        await audit_action(
-            settings,
-            action_type="block_flow_application",
-            resource_type="flow_block_action",
-            resource_id=action_id,
-            site_id=site_id,
-            details={
-                "flow_id": flow_id,
-                "application_id": application_id,
-                "application_name": application_name,
-                "rule_id": rule_id,
-                "zone_id": result_zone_id,
-            },
         )
-
-        return BlockFlowAction(  # type: ignore[no-any-return]
+        return BlockFlowAction(
             action_id=action_id,
-            block_type="application",
-            blocked_target=application_id,
-            rule_id=rule_id,
-            zone_id=result_zone_id,
-            duration="permanent",
-            expires_at=None,
+            block_type=block_type,  # type: ignore[arg-type]
+            blocked_target=blocked_target,
+            rule_id=None,
+            zone_id=None,
+            duration=duration,  # type: ignore[arg-type]
+            expires_at=expires_at,
             created_at=created_at,
         ).model_dump()
 
+    rule_result = await create_firewall_rule(
+        site_id=site_id,
+        name=rule_name,
+        action="drop",
+        settings=settings,
+        src_address=blocked_target if block_type == "source_ip" else None,
+        dst_address=blocked_target if block_type != "source_ip" else None,
+        confirm=True,
+    )
 
-async def export_traffic_flows(
-    site_id: str,
-    settings: Settings,
-    export_format: str = "json",
-    time_range: str = "24h",
-    include_fields: list[str] | None = None,
-    filter_expression: str | None = None,
-    max_records: int | None = None,
-) -> str:
-    """Export traffic flows to a file format.
+    await audit_action(
+        settings,
+        action_type=f"block_flow_{block_type}",
+        resource_type="firewall_rule",
+        resource_id=rule_result.get("_id", rule_result.get("id", "unknown")),
+        site_id=site_id,
+        details={"blocked_target": blocked_target, "duration": duration},
+    )
 
-    Args:
-        site_id: Site identifier
-        settings: Application settings
-        export_format: Export format ("json", "csv")
-        time_range: Time range for export
-        include_fields: Specific fields to include (None = all)
-        filter_expression: Filter expression
-        max_records: Maximum number of records
-
-    Returns:
-        Exported data as string
-    """
-    async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Exporting traffic flows in {export_format} format"))
-
-        if not client.is_authenticated:
-            await client.authenticate()
-
-        # Get flows based on filter
-        if filter_expression:
-            flows = await filter_traffic_flows(
-                site_id, settings, filter_expression, time_range, max_records
-            )
-        else:
-            flows = await get_traffic_flows(site_id, settings, time_range=time_range)
-            if max_records:
-                flows = flows[:max_records]
-
-        # Filter fields if specified
-        if include_fields:
-            flows = [
-                {field: flow.get(field) for field in include_fields if field in flow}
-                for flow in flows
-            ]
-
-        # Export to requested format
-        if export_format == "json":
-            return json.dumps(flows, indent=2)
-
-        elif export_format == "csv":
-            if not flows:
-                return ""
-
-            output = StringIO()
-            # Get all unique fields
-            all_fields: set[str] = set()
-            for flow in flows:
-                all_fields.update(flow.keys())
-
-            fieldnames = sorted(all_fields)
-            writer = csv.DictWriter(output, fieldnames=fieldnames)
-            writer.writeheader()
-            writer.writerows(flows)
-
-            return output.getvalue()
-
-        else:
-            raise ValueError(f"Unsupported export format: {export_format}")
-
-
-async def get_flow_analytics(
-    site_id: str,
-    settings: Settings,
-    time_range: str = "24h",
-) -> dict:
-    """Get comprehensive flow analytics.
-
-    Args:
-        site_id: Site identifier
-        settings: Application settings
-        time_range: Time range for analytics
-
-    Returns:
-        Comprehensive analytics data
-    """
-    async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Generating flow analytics for site {site_id}"))
-
-        if not client.is_authenticated:
-            await client.authenticate()
-
-        # Get flows and statistics
-        flows = await get_traffic_flows(site_id, settings, time_range=time_range)
-        statistics = await get_flow_statistics(site_id, settings, time_range)
-        states = await get_connection_states(site_id, settings, time_range)
-
-        # Additional analytics
-        protocols: dict[str, int] = {}
-        applications: dict[str, dict[str, int]] = {}
-
-        for flow in flows:
-            # Protocol distribution
-            protocol = flow.get("protocol", "unknown")
-            protocols[protocol] = protocols.get(protocol, 0) + 1
-
-            # Application distribution
-            app = flow.get("application_name", "Unknown")
-            total_bytes = flow.get("bytes_sent", 0) + flow.get("bytes_received", 0)
-            if app not in applications:
-                applications[app] = {"count": 0, "bytes": 0}
-            applications[app]["count"] += 1
-            applications[app]["bytes"] += total_bytes
-
-        # State distribution
-        state_distribution: dict[str, int] = {}
-        for state in states:
-            state_type = state.get("state", "unknown")
-            state_distribution[state_type] = state_distribution.get(state_type, 0) + 1
-
-        return {
-            "site_id": site_id,
-            "time_range": time_range,
-            "statistics": statistics,
-            "protocol_distribution": protocols,
-            "application_distribution": applications,
-            "state_distribution": state_distribution,
-            "total_flows": len(flows),
-            "total_states": len(states),
-        }
+    return BlockFlowAction(
+        action_id=action_id,
+        block_type=block_type,  # type: ignore[arg-type]
+        blocked_target=blocked_target,
+        rule_id=str(rule_result.get("_id", rule_result.get("id", ""))) or None,
+        zone_id=None,
+        duration=duration,  # type: ignore[arg-type]
+        expires_at=expires_at,
+        created_at=created_at,
+    ).model_dump()

--- a/tests/unit/tools/test_traffic_flows_tools.py
+++ b/tests/unit/tools/test_traffic_flows_tools.py
@@ -1,1540 +1,841 @@
-"""Unit tests for traffic flows tools.
+"""Unit tests for the v2-local traffic flow tools.
 
-TDD: Tests for src/tools/traffic_flows.py
-Based on traffic flow monitoring functionality.
+The current ``traffic_flows`` module talks to
+``POST /proxy/network/v2/api/site/{site}/traffic-flows``, which is the only
+endpoint on current UniFi firmware that actually exposes flow data. The
+Integration API (``/integration/v1/sites/.../traffic/flows``) returns 404
+on any firmware — Ubiquiti has never exposed flow data through that
+surface. These tests mock the v2 POST response with a realistic sample
+captured from a live UDM Pro (with IPs/MACs redacted).
 """
 
+from __future__ import annotations
+
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from src.config import Settings
+from src.tools import traffic_flows as tf
+from src.utils.exceptions import ResourceNotFoundError, ValidationError
 
 
 @pytest.fixture
-def mock_settings():
-    """Create mock settings for testing."""
+def mock_settings() -> MagicMock:
+    """Mock Settings object configured for local API access."""
+    from src.config import APIType
+
     settings = MagicMock(spec=Settings)
+    settings.api_type = APIType.LOCAL
     settings.api_key = "test-api-key"
-    settings.api_type = "local"
-    settings.local_host = "192.168.2.1"
+    settings.local_host = "192.0.2.1"
     settings.local_port = 443
     settings.local_verify_ssl = False
+    settings.log_level = "INFO"
+    settings.get_v2_api_path = MagicMock(
+        side_effect=lambda site_id: f"/proxy/network/v2/api/site/{site_id}"
+    )
+    return settings
+
+
+@pytest.fixture
+def cloud_settings() -> MagicMock:
+    """Mock Settings object configured for cloud-EA API access."""
+    from src.config import APIType
+
+    settings = MagicMock(spec=Settings)
+    settings.api_type = APIType.CLOUD_EA
+    settings.api_key = "test-api-key"
     settings.log_level = "INFO"
     return settings
 
 
 @pytest.fixture
-def sample_traffic_flows():
-    """Sample traffic flow data from API."""
+def sample_raw_flows() -> list[dict[str, Any]]:
+    """Realistic v2 ``traffic-flows`` response shape (3 flows)."""
     return [
         {
-            "flow_id": "flow-001",
-            "site_id": "default",
-            "source_ip": "192.168.2.100",
-            "source_port": 54321,
-            "destination_ip": "8.8.8.8",
-            "destination_port": 443,
-            "protocol": "tcp",
-            "application_id": "app-001",
-            "application_name": "HTTPS",
-            "bytes_sent": 1024000,
-            "bytes_received": 5120000,
-            "packets_sent": 1000,
-            "packets_received": 5000,
-            "start_time": "2026-01-05T00:00:00Z",
-            "end_time": None,
-            "duration": 300,
-            "client_mac": "aa:bb:cc:dd:ee:ff",
-            "device_id": "device-001",
+            "id": "flow-1",
+            "action": "allowed",
+            "count": 1,
+            "direction": "outgoing",
+            "protocol": "UDP",
+            "service": "OTHER",
+            "risk": "low",
+            "source": {
+                "id": "aa:bb:cc:dd:ee:01",
+                "ip": "10.0.20.10",
+                "port": 14414,
+                "mac": "aa:bb:cc:dd:ee:01",
+                "client_name": "Camera 01",
+                "client_oui": "Smart Innovation LLC",
+                "network_id": "net-iot",
+                "network_name": "Cameras - Data",
+                "subnet": "10.0.20.0/24",
+                "zone_id": "zone-dmz",
+                "zone_name": "Dmz",
+            },
+            "destination": {
+                "id": "198.51.100.5",
+                "ip": "198.51.100.5",
+                "port": 32100,
+                "region": "US",
+                "zone_id": "zone-external",
+                "zone_name": "External",
+                "domains": [],
+            },
+            "traffic_data": {
+                "bytes_tx": 208,
+                "bytes_rx": 336,
+                "bytes_total": 544,
+                "packets_tx": 5,
+                "packets_rx": 5,
+                "packets_total": 10,
+            },
+            "policies": [
+                {"type": "FIREWALL", "internal_type": "CONNTRACK"},
+            ],
+            "duration_milliseconds": 221461,
+            "flow_start_time": 1_775_932_927_744,
+            "flow_end_time": 1_775_933_149_205,
+            "time": 1_775_933_149_205,
+            "in": {"network_id": "net-iot", "network_name": "Cameras - Data"},
+            "out": {"network_id": "net-wan", "network_name": "Comcast"},
         },
         {
-            "flow_id": "flow-002",
-            "site_id": "default",
-            "source_ip": "192.168.2.101",
-            "source_port": 54322,
-            "destination_ip": "1.1.1.1",
-            "destination_port": 53,
-            "protocol": "udp",
-            "application_id": "app-002",
-            "application_name": "DNS",
-            "bytes_sent": 512,
-            "bytes_received": 1024,
-            "packets_sent": 10,
-            "packets_received": 10,
-            "start_time": "2026-01-05T00:01:00Z",
-            "end_time": "2026-01-05T00:01:01Z",
-            "duration": 1,
-            "client_mac": "11:22:33:44:55:66",
-            "device_id": "device-001",
+            "id": "flow-2",
+            "action": "allowed",
+            "count": 1,
+            "direction": "outgoing",
+            "protocol": "TCP",
+            "service": "DNS",
+            "risk": "medium",
+            "source": {
+                "id": "aa:bb:cc:dd:ee:02",
+                "ip": "10.0.10.20",
+                "port": 54321,
+                "mac": "aa:bb:cc:dd:ee:02",
+                "client_name": "Rob's Laptop",
+                "network_id": "net-lan",
+                "network_name": "Internal - Data",
+                "zone_id": "zone-internal",
+                "zone_name": "Internal",
+            },
+            "destination": {
+                "id": "1.1.1.1",
+                "ip": "1.1.1.1",
+                "port": 443,
+                "region": "US",
+                "zone_id": "zone-external",
+                "zone_name": "External",
+                "domains": ["cloudflare-dns.com"],
+            },
+            "traffic_data": {
+                "bytes_tx": 8000,
+                "bytes_rx": 16000,
+                "bytes_total": 24000,
+                "packets_tx": 30,
+                "packets_rx": 42,
+                "packets_total": 72,
+            },
+            "policies": [{"type": "FIREWALL", "internal_type": "ESTABLISHED"}],
+            "duration_milliseconds": 15200,
+            "flow_start_time": 1_775_933_000_000,
+            "flow_end_time": 1_775_933_015_200,
+            "time": 1_775_933_015_200,
+        },
+        {
+            "id": "flow-3",
+            "action": "blocked",
+            "count": 1,
+            "direction": "outgoing",
+            "protocol": "TCP",
+            "service": "OTHER",
+            "risk": "high",
+            "source": {
+                "id": "aa:bb:cc:dd:ee:03",
+                "ip": "10.0.20.11",
+                "port": 33333,
+                "mac": "aa:bb:cc:dd:ee:03",
+                "client_name": "Sketchy IoT",
+                "network_id": "net-iot",
+                "network_name": "Cameras - Data",
+                "zone_id": "zone-dmz",
+                "zone_name": "Dmz",
+            },
+            "destination": {
+                "id": "203.0.113.99",
+                "ip": "203.0.113.99",
+                "port": 6667,
+                "region": "RU",
+                "zone_id": "zone-external",
+                "zone_name": "External",
+                "domains": [],
+            },
+            "traffic_data": {
+                "bytes_tx": 100,
+                "bytes_rx": 0,
+                "bytes_total": 100,
+                "packets_tx": 2,
+                "packets_rx": 0,
+                "packets_total": 2,
+            },
+            "policies": [{"type": "FIREWALL", "internal_type": "REJECT"}],
+            "duration_milliseconds": 500,
+            "flow_start_time": 1_775_933_200_000,
+            "flow_end_time": 1_775_933_200_500,
+            "time": 1_775_933_200_500,
         },
     ]
 
 
-@pytest.fixture
-def sample_flow_statistics():
-    """Sample flow statistics data."""
-    return {
-        "site_id": "default",
-        "time_range": "24h",
-        "total_flows": 1000,
-        "total_bytes_sent": 10240000,
-        "total_bytes_received": 51200000,
-        "total_bytes": 61440000,
-        "total_packets_sent": 10000,
-        "total_packets_received": 50000,
-        "unique_sources": 50,
-        "unique_destinations": 200,
-        "top_applications": [
-            {"application": "HTTPS", "bytes": 30000000},
-            {"application": "YouTube", "bytes": 20000000},
-        ],
-    }
+def _mock_client(raw_flows: list[dict[str, Any]]) -> AsyncMock:
+    """Build an AsyncMock UniFiClient returning the given raw flows."""
+    client = AsyncMock()
+    client.is_authenticated = True
+    client.authenticate = AsyncMock()
+    client.post = AsyncMock(return_value=raw_flows)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
 
 
-@pytest.fixture
-def sample_flow_risks():
-    """Sample flow risk data."""
-    return [
-        {
-            "flow_id": "flow-001",
-            "risk_score": 75.0,
-            "risk_level": "high",
-            "indicators": ["unusual_port", "high_volume"],
-            "threat_type": "data_exfiltration",
-            "description": "Potential data exfiltration detected",
-        },
-        {
-            "flow_id": "flow-003",
-            "risk_score": 30.0,
-            "risk_level": "low",
-            "indicators": ["new_destination"],
-            "threat_type": None,
-            "description": "New destination observed",
-        },
-    ]
+# --------------------------------------------------------------------------- #
+# Local-only gate                                                             #
+# --------------------------------------------------------------------------- #
 
 
-class TestGetTrafficFlowsBasic:
-    """Tests for get_traffic_flows basic functionality."""
+class TestLocalApiGate:
+    @pytest.mark.asyncio
+    async def test_cloud_mode_raises(self, cloud_settings: MagicMock) -> None:
+        with pytest.raises(NotImplementedError, match="UNIFI_API_TYPE='local'"):
+            await tf.get_traffic_flows("default", cloud_settings)
 
     @pytest.mark.asyncio
-    async def test_get_traffic_flows_success(self, mock_settings, sample_traffic_flows):
-        """Successfully retrieve traffic flows."""
-        from src.tools.traffic_flows import get_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
-
-            result = await get_traffic_flows("default", mock_settings)
-
-            assert len(result) == 2
-            assert result[0]["flow_id"] == "flow-001"
-            assert result[0]["source_ip"] == "192.168.2.100"
-            assert result[0]["protocol"] == "tcp"
+    async def test_get_flow_trends_always_raises(
+        self, mock_settings: MagicMock
+    ) -> None:
+        with pytest.raises(NotImplementedError, match="historical time-series"):
+            await tf.get_flow_trends("default", mock_settings)
 
     @pytest.mark.asyncio
-    async def test_get_traffic_flows_empty_response(self, mock_settings):
-        """Handle sites with no traffic flows."""
-        from src.tools.traffic_flows import get_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": []})
-
-            result = await get_traffic_flows("default", mock_settings)
-
-            assert len(result) == 0
-            assert isinstance(result, list)
+    async def test_stream_traffic_flows_raises(
+        self, mock_settings: MagicMock
+    ) -> None:
+        with pytest.raises(NotImplementedError, match="50 flows with no pagination"):
+            await tf.stream_traffic_flows("default", mock_settings)
 
     @pytest.mark.asyncio
-    async def test_get_traffic_flows_with_source_ip_filter(
-        self, mock_settings, sample_traffic_flows
-    ):
-        """Filter traffic flows by source IP."""
-        from src.tools.traffic_flows import get_traffic_flows
-
-        filtered_flows = [f for f in sample_traffic_flows if f["source_ip"] == "192.168.2.100"]
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": filtered_flows})
-
-            result = await get_traffic_flows("default", mock_settings, source_ip="192.168.2.100")
-
-            assert len(result) == 1
-            assert result[0]["source_ip"] == "192.168.2.100"
-            # Verify source_ip was passed in params
-            call_args = mock_instance.get.call_args
-            assert "source_ip" in call_args[1].get("params", {})
+    async def test_get_connection_states_raises(
+        self, mock_settings: MagicMock
+    ) -> None:
+        with pytest.raises(NotImplementedError, match="completed flows"):
+            await tf.get_connection_states("default", mock_settings)
 
 
-class TestGetTrafficFlowsFilters:
-    """Tests for get_traffic_flows filter parameters."""
+# --------------------------------------------------------------------------- #
+# get_traffic_flows                                                           #
+# --------------------------------------------------------------------------- #
+
+
+class TestGetTrafficFlows:
+    @pytest.mark.asyncio
+    async def test_returns_all_flows_without_filters(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_traffic_flows("default", mock_settings)
+
+        assert len(result) == 3
+        assert result[0]["id"] == "flow-1"
+        assert result[0]["source"]["client_name"] == "Camera 01"
+        assert result[0]["destination"]["ip"] == "198.51.100.5"
 
     @pytest.mark.asyncio
-    async def test_get_traffic_flows_with_dest_ip_filter(self, mock_settings, sample_traffic_flows):
-        """Filter traffic flows by destination IP."""
-        from src.tools.traffic_flows import get_traffic_flows
+    async def test_hits_v2_endpoint_with_empty_body(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        client = _mock_client(sample_raw_flows)
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            await tf.get_traffic_flows("default", mock_settings)
 
-        filtered_flows = [f for f in sample_traffic_flows if f["destination_ip"] == "8.8.8.8"]
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": filtered_flows})
-
-            result = await get_traffic_flows("default", mock_settings, destination_ip="8.8.8.8")
-
-            assert len(result) == 1
-            assert result[0]["destination_ip"] == "8.8.8.8"
-            call_args = mock_instance.get.call_args
-            assert "destination_ip" in call_args[1].get("params", {})
+        client.post.assert_called_once()
+        endpoint = client.post.call_args.args[0]
+        assert endpoint.endswith("/traffic-flows")
+        assert client.post.call_args.kwargs["json_data"] == {}
 
     @pytest.mark.asyncio
-    async def test_get_traffic_flows_with_protocol_filter(
-        self, mock_settings, sample_traffic_flows
-    ):
-        """Filter traffic flows by protocol."""
-        from src.tools.traffic_flows import get_traffic_flows
-
-        filtered_flows = [f for f in sample_traffic_flows if f["protocol"] == "udp"]
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": filtered_flows})
-
-            result = await get_traffic_flows("default", mock_settings, protocol="udp")
-
-            assert len(result) == 1
-            assert result[0]["protocol"] == "udp"
-            call_args = mock_instance.get.call_args
-            assert "protocol" in call_args[1].get("params", {})
+    async def test_filter_by_source_mac(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_traffic_flows(
+                "default", mock_settings, source_mac="aa:bb:cc:dd:ee:02"
+            )
+        assert len(result) == 1
+        assert result[0]["source"]["mac"] == "aa:bb:cc:dd:ee:02"
 
     @pytest.mark.asyncio
-    async def test_get_traffic_flows_with_time_range(self, mock_settings, sample_traffic_flows):
-        """Filter traffic flows by time range."""
-        from src.tools.traffic_flows import get_traffic_flows
+    async def test_filter_by_destination_zone(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_traffic_flows(
+                "default", mock_settings, destination_zone_name="External"
+            )
+        assert len(result) == 3
+        assert all(r["destination"]["zone_name"] == "External" for r in result)
 
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
+    @pytest.mark.asyncio
+    async def test_inter_vlan_filter_by_destination_network(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        """Inter-VLAN flows are labeled ``destination_zone=Gateway`` by
+        UniFi, so the correct way to find them is via
+        ``destination_network_name``. This test pins the behaviour: the
+        zone-name filter must return 0, the network-name filter must find it.
+        """
+        inter_vlan = {
+            "id": "flow-inter-vlan",
+            "action": "allowed",
+            "count": 1,
+            "direction": "outgoing",
+            "protocol": "TCP",
+            "service": "OTHER",
+            "risk": "low",
+            "source": {
+                "id": "aa:bb:cc:dd:ee:02",
+                "ip": "10.0.10.20",
+                "port": 40001,
+                "mac": "aa:bb:cc:dd:ee:02",
+                "client_name": "Rob's Laptop",
+                "network_id": "net-lan",
+                "network_name": "Internal - Data",
+                "zone_id": "zone-internal",
+                "zone_name": "Internal",
+            },
+            # The critical detail: dest zone is "Gateway", not "Servers".
+            "destination": {
+                "id": "10.0.30.5",
+                "ip": "10.0.30.5",
+                "port": 445,
+                "network_id": "net-servers",
+                "network_name": "Server - Data",
+                "zone_id": "zone-gateway",
+                "zone_name": "Gateway",
+                "domains": [],
+            },
+            "traffic_data": {
+                "bytes_tx": 4096, "bytes_rx": 8192, "bytes_total": 12288,
+                "packets_tx": 12, "packets_rx": 18, "packets_total": 30,
+            },
+            "policies": [],
+            "duration_milliseconds": 1500,
+            "flow_start_time": 1_775_933_300_000,
+            "flow_end_time": 1_775_933_301_500,
+            "time": 1_775_933_301_500,
+        }
 
-            result = await get_traffic_flows("default", mock_settings, time_range="7d")
+        flows_with_inter_vlan = [*sample_raw_flows, inter_vlan]
 
-            assert len(result) == 2
-            call_args = mock_instance.get.call_args
-            assert call_args[1].get("params", {}).get("time_range") == "7d"
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(flows_with_inter_vlan)
+            by_zone = await tf.get_traffic_flows(
+                "default", mock_settings, destination_zone_name="Servers"
+            )
+        assert by_zone == [], (
+            "destination_zone_name=Servers must return 0 — inter-VLAN flows "
+            "are labeled as 'Gateway'. This is the bug reproducer."
+        )
+
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(flows_with_inter_vlan)
+            by_network = await tf.get_traffic_flows(
+                "default",
+                mock_settings,
+                destination_network_name="Server - Data",
+            )
+        assert len(by_network) == 1
+        assert by_network[0]["id"] == "flow-inter-vlan"
+        assert by_network[0]["destination"]["network_name"] == "Server - Data"
+        # The "Gateway" label is preserved — we don't rewrite it.
+        assert by_network[0]["destination"]["zone_name"] == "Gateway"
+
+    @pytest.mark.asyncio
+    async def test_filter_by_protocol_and_action(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_traffic_flows(
+                "default", mock_settings, protocol="TCP", action="blocked"
+            )
+        assert len(result) == 1
+        assert result[0]["id"] == "flow-3"
+
+    @pytest.mark.asyncio
+    async def test_filter_by_min_bytes(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_traffic_flows(
+                "default", mock_settings, min_bytes=1000
+            )
+        assert len(result) == 1
+        assert result[0]["id"] == "flow-2"
+
+    @pytest.mark.asyncio
+    async def test_client_name_contains_is_case_insensitive(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_traffic_flows(
+                "default", mock_settings, client_name_contains="laptop"
+            )
+        assert len(result) == 1
+        assert result[0]["source"]["client_name"] == "Rob's Laptop"
+
+    @pytest.mark.asyncio
+    async def test_limit_applied_after_filter(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_traffic_flows("default", mock_settings, limit=2)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_handles_data_wrapped_response(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        wrapped = {"data": sample_raw_flows}
+        client = AsyncMock()
+        client.is_authenticated = True
+        client.post = AsyncMock(return_value=wrapped)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await tf.get_traffic_flows("default", mock_settings)
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_handles_empty_response(
+        self, mock_settings: MagicMock
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client([])
+            result = await tf.get_traffic_flows("default", mock_settings)
+        assert result == []
+
+
+# --------------------------------------------------------------------------- #
+# Statistics / analytics                                                      #
+# --------------------------------------------------------------------------- #
 
 
 class TestGetFlowStatistics:
-    """Tests for get_flow_statistics tool."""
+    @pytest.mark.asyncio
+    async def test_aggregates_correctly(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            stats = await tf.get_flow_statistics("default", mock_settings)
+
+        assert stats["sample_size"] == 3
+        assert stats["total_bytes"] == 544 + 24_000 + 100
+        assert stats["total_bytes_tx"] == 208 + 8000 + 100
+        assert stats["total_packets"] == 10 + 72 + 2
+        assert stats["unique_sources"] == 3
+        assert stats["unique_destinations"] == 3
+        assert stats["protocol_breakdown"] == {"UDP": 1, "TCP": 2}
+        assert stats["action_breakdown"] == {"allowed": 2, "blocked": 1}
+        assert stats["top_destinations"][0]["ip"] == "1.1.1.1"  # biggest by bytes
 
     @pytest.mark.asyncio
-    async def test_get_flow_statistics_success(self, mock_settings, sample_flow_statistics):
-        """Successfully retrieve flow statistics."""
-        from src.tools.traffic_flows import get_flow_statistics
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_flow_statistics})
-
-            result = await get_flow_statistics("default", mock_settings)
-
-            assert result["site_id"] == "default"
-            assert result["total_flows"] == 1000
-            assert result["total_bytes"] == 61440000
-
-    @pytest.mark.asyncio
-    async def test_get_flow_statistics_empty(self, mock_settings):
-        """Handle endpoint not available gracefully."""
-        from src.tools.traffic_flows import get_flow_statistics
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(side_effect=Exception("Endpoint not available"))
-
-            result = await get_flow_statistics("default", mock_settings)
-
-            # Should return empty statistics
-            assert result["site_id"] == "default"
-            assert result["total_flows"] == 0
-            assert result["total_bytes"] == 0
-
-    @pytest.mark.asyncio
-    async def test_get_flow_statistics_time_ranges(self, mock_settings, sample_flow_statistics):
-        """Verify time_range parameter is passed correctly."""
-        from src.tools.traffic_flows import get_flow_statistics
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_flow_statistics})
-
-            await get_flow_statistics("default", mock_settings, time_range="7d")
-
-            call_args = mock_instance.get.call_args
-            assert call_args[1].get("params", {}).get("time_range") == "7d"
-
-
-class TestGetTrafficFlowDetails:
-    """Tests for get_traffic_flow_details tool."""
-
-    @pytest.mark.asyncio
-    async def test_get_traffic_flow_details_success(self, mock_settings, sample_traffic_flows):
-        """Successfully retrieve flow details."""
-        from src.tools.traffic_flows import get_traffic_flow_details
-
-        flow = sample_traffic_flows[0]
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": flow})
-
-            result = await get_traffic_flow_details("default", "flow-001", mock_settings)
-
-            assert result["flow_id"] == "flow-001"
-            assert result["source_ip"] == "192.168.2.100"
-            assert result["application_name"] == "HTTPS"
-
-
-class TestGetTopFlows:
-    """Tests for get_top_flows tool."""
-
-    @pytest.mark.asyncio
-    async def test_get_top_flows_by_bytes(self, mock_settings, sample_traffic_flows):
-        """Get top flows sorted by bytes."""
-        from src.tools.traffic_flows import get_top_flows
-
-        # Sort by total bytes (sent + received)
-        sorted_flows = sorted(
-            sample_traffic_flows,
-            key=lambda x: x.get("bytes_sent", 0) + x.get("bytes_received", 0),
-            reverse=True,
-        )
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sorted_flows})
-
-            result = await get_top_flows("default", mock_settings, limit=10, sort_by="bytes")
-
-            assert len(result) == 2
-            # First flow should have more bytes
-            first_bytes = result[0]["bytes_sent"] + result[0]["bytes_received"]
-            second_bytes = result[1]["bytes_sent"] + result[1]["bytes_received"]
-            assert first_bytes >= second_bytes
-
-    @pytest.mark.asyncio
-    async def test_get_top_flows_by_packets(self, mock_settings, sample_traffic_flows):
-        """Get top flows sorted by packets."""
-        from src.tools.traffic_flows import get_top_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
-
-            result = await get_top_flows("default", mock_settings, limit=5, sort_by="packets")
-
-            assert len(result) == 2
-            call_args = mock_instance.get.call_args
-            assert call_args[1].get("params", {}).get("sort_by") == "packets"
-
-
-class TestGetFlowRisks:
-    """Tests for get_flow_risks tool."""
-
-    @pytest.mark.asyncio
-    async def test_get_flow_risks_success(self, mock_settings, sample_flow_risks):
-        """Successfully retrieve flow risks."""
-        from src.tools.traffic_flows import get_flow_risks
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_flow_risks})
-
-            result = await get_flow_risks("default", mock_settings)
-
-            assert len(result) == 2
-            assert result[0]["risk_level"] == "high"
-            assert result[0]["risk_score"] == 75.0
-
-    @pytest.mark.asyncio
-    async def test_get_flow_risks_with_min_level(self, mock_settings, sample_flow_risks):
-        """Filter flow risks by minimum level."""
-        from src.tools.traffic_flows import get_flow_risks
-
-        high_risks = [r for r in sample_flow_risks if r["risk_level"] == "high"]
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": high_risks})
-
-            result = await get_flow_risks("default", mock_settings, min_risk_level="high")
-
-            assert len(result) == 1
-            assert result[0]["risk_level"] == "high"
-            call_args = mock_instance.get.call_args
-            assert "min_risk_level" in call_args[1].get("params", {})
-
-
-class TestGetFlowTrends:
-    """Tests for get_flow_trends tool."""
-
-    @pytest.mark.asyncio
-    async def test_get_flow_trends_success(self, mock_settings):
-        """Successfully retrieve flow trends."""
-        from src.tools.traffic_flows import get_flow_trends
-
-        trend_data = [
-            {"timestamp": "2026-01-05T00:00:00Z", "flows": 100, "bytes": 1000000},
-            {"timestamp": "2026-01-05T01:00:00Z", "flows": 150, "bytes": 1500000},
-            {"timestamp": "2026-01-05T02:00:00Z", "flows": 120, "bytes": 1200000},
-        ]
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": trend_data})
-
-            result = await get_flow_trends("default", mock_settings)
-
-            assert len(result) == 3
-            assert "timestamp" in result[0]
-
-
-class TestFilterTrafficFlows:
-    """Tests for filter_traffic_flows tool."""
-
-    @pytest.mark.asyncio
-    async def test_filter_traffic_flows_success(self, mock_settings, sample_traffic_flows):
-        """Successfully filter traffic flows."""
-        from src.tools.traffic_flows import filter_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
-
-            result = await filter_traffic_flows(
-                "default", mock_settings, filter_expression="protocol = 'tcp'"
+    async def test_statistics_with_filter_narrows_sample(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            stats = await tf.get_flow_statistics(
+                "default", mock_settings, action="blocked"
             )
-
-            assert isinstance(result, list)
-            call_args = mock_instance.get.call_args
-            assert "filter" in call_args[1].get("params", {})
-
-    @pytest.mark.asyncio
-    async def test_filter_traffic_flows_with_limit(self, mock_settings, sample_traffic_flows):
-        """Filter traffic flows with result limit."""
-        from src.tools.traffic_flows import filter_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows[:1]})
-
-            result = await filter_traffic_flows(
-                "default",
-                mock_settings,
-                filter_expression="bytes > 1000",
-                limit=1,
-            )
-
-            assert len(result) == 1
-            call_args = mock_instance.get.call_args
-            assert call_args[1].get("params", {}).get("limit") == 1
-
-    @pytest.mark.asyncio
-    async def test_filter_traffic_flows_complex_expression(
-        self, mock_settings, sample_traffic_flows
-    ):
-        """Filter traffic flows with complex expression."""
-        from src.tools.traffic_flows import filter_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
-
-            result = await filter_traffic_flows(
-                "default",
-                mock_settings,
-                filter_expression="bytes > 1000 AND protocol = 'tcp'",
-            )
-
-            assert isinstance(result, list)
-            call_args = mock_instance.get.call_args
-            params = call_args[1].get("params", {})
-            assert "bytes > 1000 AND protocol = 'tcp'" in params.get("filter", "")
-
-
-class TestApiErrorHandling:
-    """Tests for error handling in traffic flow tools."""
-
-    @pytest.mark.asyncio
-    async def test_get_traffic_flows_api_error(self, mock_settings):
-        """Handle API errors gracefully."""
-        from src.tools.traffic_flows import get_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(side_effect=Exception("API Error"))
-
-            result = await get_traffic_flows("default", mock_settings)
-
-            assert result == []
-
-    @pytest.mark.asyncio
-    async def test_get_flow_risks_api_error(self, mock_settings):
-        """Handle API errors in get_flow_risks."""
-        from src.tools.traffic_flows import get_flow_risks
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(side_effect=Exception("API Error"))
-
-            result = await get_flow_risks("default", mock_settings)
-
-            assert result == []
-
-    @pytest.mark.asyncio
-    async def test_get_flow_trends_api_error(self, mock_settings):
-        """Handle API errors in get_flow_trends."""
-        from src.tools.traffic_flows import get_flow_trends
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(side_effect=Exception("API Error"))
-
-            result = await get_flow_trends("default", mock_settings)
-
-            assert result == []
-
-    @pytest.mark.asyncio
-    async def test_authentication_called(self, mock_settings, sample_traffic_flows):
-        """Verify authentication is called when not authenticated."""
-        from src.tools.traffic_flows import get_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
-
-            await get_traffic_flows("default", mock_settings)
-
-            mock_instance.authenticate.assert_called_once()
-
-
-class TestApiEndpoints:
-    """Tests for API endpoint construction."""
-
-    @pytest.mark.asyncio
-    async def test_traffic_flows_endpoint(self, mock_settings, sample_traffic_flows):
-        """Verify correct API endpoint for traffic flows."""
-        from src.tools.traffic_flows import get_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
-
-            await get_traffic_flows("test-site", mock_settings)
-
-            call_args = mock_instance.get.call_args
-            endpoint = call_args[0][0]
-            assert "traffic/flows" in endpoint
-            assert "test-site" in endpoint
-
-    @pytest.mark.asyncio
-    async def test_flow_statistics_endpoint(self, mock_settings, sample_flow_statistics):
-        """Verify correct API endpoint for flow statistics."""
-        from src.tools.traffic_flows import get_flow_statistics
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_flow_statistics})
-
-            await get_flow_statistics("test-site", mock_settings)
-
-            call_args = mock_instance.get.call_args
-            endpoint = call_args[0][0]
-            assert "traffic/flows/statistics" in endpoint
-            assert "test-site" in endpoint
-
-    @pytest.mark.asyncio
-    async def test_flow_risks_endpoint(self, mock_settings, sample_flow_risks):
-        """Verify correct API endpoint for flow risks."""
-        from src.tools.traffic_flows import get_flow_risks
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_flow_risks})
-
-            await get_flow_risks("test-site", mock_settings)
-
-            call_args = mock_instance.get.call_args
-            endpoint = call_args[0][0]
-            assert "traffic/flows/risks" in endpoint
-            assert "test-site" in endpoint
-
-
-class TestGetConnectionStates:
-    """Tests for get_connection_states tool."""
-
-    @pytest.mark.asyncio
-    async def test_get_connection_states_success(self, mock_settings, sample_traffic_flows):
-        """Successfully retrieve connection states."""
-        from src.tools.traffic_flows import get_connection_states
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
-
-            result = await get_connection_states("default", mock_settings)
-
-            assert isinstance(result, list)
-            assert len(result) == 2
-            assert "flow_id" in result[0]
-            assert "state" in result[0]
-
-    @pytest.mark.asyncio
-    async def test_get_connection_states_active_flow(self, mock_settings):
-        """Detect active connection state."""
-        from src.tools.traffic_flows import get_connection_states
-
-        active_flow = {
-            "flow_id": "flow-active",
-            "site_id": "default",
-            "source_ip": "192.168.2.100",
-            "destination_ip": "8.8.8.8",
-            "protocol": "tcp",
-            "bytes_sent": 1000,
-            "bytes_received": 2000,
-            "packets_sent": 10,
-            "packets_received": 20,
-            "start_time": "2026-01-05T00:12:00Z",
-            "end_time": None,
-            "duration": None,
-        }
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": [active_flow]})
-
-            result = await get_connection_states("default", mock_settings, time_range="1h")
-
-            assert len(result) == 1
-
-    @pytest.mark.asyncio
-    async def test_get_connection_states_closed_flow(self, mock_settings):
-        """Detect closed connection state."""
-        from src.tools.traffic_flows import get_connection_states
-
-        closed_flow = {
-            "flow_id": "flow-closed",
-            "site_id": "default",
-            "source_ip": "192.168.2.100",
-            "destination_ip": "8.8.8.8",
-            "protocol": "tcp",
-            "bytes_sent": 1000,
-            "bytes_received": 2000,
-            "packets_sent": 10,
-            "packets_received": 20,
-            "start_time": "2026-01-05T00:00:00Z",
-            "end_time": "2026-01-05T00:01:00Z",
-            "duration": 60,
-        }
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": [closed_flow]})
-
-            result = await get_connection_states("default", mock_settings)
-
-            assert len(result) == 1
-            assert result[0]["state"] == "closed"
-
-
-class TestGetClientFlowAggregation:
-    """Tests for get_client_flow_aggregation tool."""
-
-    @pytest.mark.asyncio
-    async def test_get_client_flow_aggregation_success(self, mock_settings, sample_traffic_flows):
-        """Successfully retrieve client flow aggregation."""
-        from src.tools.traffic_flows import get_client_flow_aggregation
-
-        client_mac = "aa:bb:cc:dd:ee:ff"
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
-
-            result = await get_client_flow_aggregation("default", client_mac, mock_settings)
-
-            assert "client_mac" in result
-            assert "total_bytes" in result
-            assert "total_flows" in result
-
-    @pytest.mark.asyncio
-    async def test_get_client_flow_aggregation_with_time_range(
-        self, mock_settings, sample_traffic_flows
-    ):
-        """Retrieve client aggregation with time range."""
-        from src.tools.traffic_flows import get_client_flow_aggregation
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
-
-            result = await get_client_flow_aggregation(
-                "default", "aa:bb:cc:dd:ee:ff", mock_settings, time_range="7d"
-            )
-
-            assert isinstance(result, dict)
-            assert "top_applications" in result
-
-
-class TestBlockFlowSourceIP:
-    """Tests for block_flow_source_ip tool."""
-
-    @pytest.mark.asyncio
-    async def test_block_flow_source_ip_dry_run(self, mock_settings, sample_traffic_flows):
-        """Dry run block flow source IP."""
-        from src.tools.traffic_flows import block_flow_source_ip
-
-        flow = sample_traffic_flows[0]
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": flow})
-
-            result = await block_flow_source_ip(
-                "default",
-                "flow-001",
-                mock_settings,
-                confirm=True,
-                dry_run=True,
-            )
-
-            assert result["block_type"] == "source_ip"
-            assert result["blocked_target"] == "192.168.2.100"
-            assert result["rule_id"] is None
-
-    @pytest.mark.asyncio
-    async def test_block_flow_source_ip_no_confirm_error(self, mock_settings):
-        """Block source IP requires confirmation."""
-        from src.tools.traffic_flows import block_flow_source_ip
-        from src.utils.exceptions import ValidationError
-
-        with pytest.raises(ValidationError, match="requires confirmation"):
-            await block_flow_source_ip("default", "flow-001", mock_settings, confirm=False)
-
-
-class TestBlockFlowDestinationIP:
-    """Tests for block_flow_destination_ip tool."""
-
-    @pytest.mark.asyncio
-    async def test_block_flow_destination_ip_dry_run(self, mock_settings, sample_traffic_flows):
-        """Dry run block flow destination IP."""
-        from src.tools.traffic_flows import block_flow_destination_ip
-
-        flow = sample_traffic_flows[0]
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": flow})
-
-            result = await block_flow_destination_ip(
-                "default",
-                "flow-001",
-                mock_settings,
-                confirm=True,
-                dry_run=True,
-            )
-
-            assert result["block_type"] == "destination_ip"
-            assert result["blocked_target"] == "8.8.8.8"
-
-    @pytest.mark.asyncio
-    async def test_block_flow_destination_ip_no_confirm_error(self, mock_settings):
-        """Block destination IP requires confirmation."""
-        from src.tools.traffic_flows import block_flow_destination_ip
-        from src.utils.exceptions import ValidationError
-
-        with pytest.raises(ValidationError, match="requires confirmation"):
-            await block_flow_destination_ip("default", "flow-001", mock_settings, confirm=False)
-
-
-class TestBlockFlowApplication:
-    """Tests for block_flow_application tool."""
-
-    @pytest.mark.asyncio
-    async def test_block_flow_application_dry_run(self, mock_settings, sample_traffic_flows):
-        """Dry run block flow application."""
-        from src.tools.traffic_flows import block_flow_application
-
-        flow = sample_traffic_flows[0]
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": flow})
-
-            result = await block_flow_application(
-                "default",
-                "flow-001",
-                mock_settings,
-                confirm=True,
-                dry_run=True,
-            )
-
-            assert result["block_type"] == "application"
-            assert result["blocked_target"] == "app-001"
-
-    @pytest.mark.asyncio
-    async def test_block_flow_application_no_confirm_error(self, mock_settings):
-        """Block application requires confirmation."""
-        from src.tools.traffic_flows import block_flow_application
-        from src.utils.exceptions import ValidationError
-
-        with pytest.raises(ValidationError, match="requires confirmation"):
-            await block_flow_application("default", "flow-001", mock_settings, confirm=False)
-
-
-class TestExportTrafficFlows:
-    """Tests for export_traffic_flows tool."""
-
-    @pytest.mark.asyncio
-    async def test_export_traffic_flows_json(self, mock_settings, sample_traffic_flows):
-        """Export traffic flows as JSON."""
-        from src.tools.traffic_flows import export_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
-
-            result = await export_traffic_flows("default", mock_settings, export_format="json")
-
-            assert isinstance(result, str)
-            import json
-
-            parsed = json.loads(result)
-            assert len(parsed) == 2
-
-    @pytest.mark.asyncio
-    async def test_export_traffic_flows_csv(self, mock_settings, sample_traffic_flows):
-        """Export traffic flows as CSV."""
-        from src.tools.traffic_flows import export_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
-
-            result = await export_traffic_flows("default", mock_settings, export_format="csv")
-
-            assert isinstance(result, str)
-            assert "flow_id" in result
-
-    @pytest.mark.asyncio
-    async def test_export_traffic_flows_with_limit(self, mock_settings, sample_traffic_flows):
-        """Export traffic flows with max records limit."""
-        from src.tools.traffic_flows import export_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
-
-            result = await export_traffic_flows(
-                "default", mock_settings, export_format="json", max_records=1
-            )
-
-            import json
-
-            parsed = json.loads(result)
-            assert len(parsed) == 1
-
-    @pytest.mark.asyncio
-    async def test_export_traffic_flows_unsupported_format(self, mock_settings):
-        """Raise error for unsupported export format."""
-        from src.tools.traffic_flows import export_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": []})
-
-            with pytest.raises(ValueError, match="Unsupported export format"):
-                await export_traffic_flows("default", mock_settings, export_format="xml")
+        assert stats["sample_size"] == 1
+        assert stats["total_bytes"] == 100
 
 
 class TestGetFlowAnalytics:
-    """Tests for get_flow_analytics tool."""
-
     @pytest.mark.asyncio
-    async def test_get_flow_analytics_success(self, mock_settings, sample_traffic_flows):
-        """Successfully retrieve flow analytics."""
-        from src.tools.traffic_flows import get_flow_analytics
+    async def test_analytics_includes_risk_breakdown(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_flow_analytics("default", mock_settings)
+        assert result["risk_breakdown"] == {"low": 1, "medium": 1, "high": 1}
+        assert result["sample_size"] == 3
 
-        stats = {
-            "site_id": "default",
-            "time_range": "24h",
-            "total_flows": 2,
-            "total_bytes_sent": 1024512,
-            "total_bytes_received": 5121024,
-            "total_bytes": 6145536,
-            "total_packets_sent": 1010,
-            "total_packets_received": 5010,
-            "unique_sources": 2,
-            "unique_destinations": 2,
-        }
 
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
+# --------------------------------------------------------------------------- #
+# Single-flow details                                                         #
+# --------------------------------------------------------------------------- #
 
-            def get_side_effect(endpoint, **kwargs):
-                if "statistics" in endpoint:
-                    return {"data": stats}
-                return {"data": sample_traffic_flows}
 
-            mock_instance.get = AsyncMock(side_effect=get_side_effect)
-
-            result = await get_flow_analytics("default", mock_settings)
-
-            assert "site_id" in result
-            assert "statistics" in result
-            assert "protocol_distribution" in result
-            assert "application_distribution" in result
-
+class TestGetTrafficFlowDetails:
     @pytest.mark.asyncio
-    async def test_get_flow_analytics_with_time_range(self, mock_settings, sample_traffic_flows):
-        """Retrieve analytics with custom time range."""
-        from src.tools.traffic_flows import get_flow_analytics
-
-        stats = {
-            "site_id": "default",
-            "time_range": "7d",
-            "total_flows": 2,
-            "total_bytes_sent": 0,
-            "total_bytes_received": 0,
-            "total_bytes": 0,
-            "total_packets_sent": 0,
-            "total_packets_received": 0,
-            "unique_sources": 0,
-            "unique_destinations": 0,
-        }
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-
-            def get_side_effect(endpoint, **kwargs):
-                if "statistics" in endpoint:
-                    return {"data": stats}
-                return {"data": sample_traffic_flows}
-
-            mock_instance.get = AsyncMock(side_effect=get_side_effect)
-
-            result = await get_flow_analytics("default", mock_settings, time_range="7d")
-
-            assert result["time_range"] == "7d"
-
-
-class TestGetTopFlowsFallback:
-    """Tests for get_top_flows fallback behavior."""
-
-    @pytest.mark.asyncio
-    async def test_get_top_flows_fallback_to_manual_sort(self, mock_settings, sample_traffic_flows):
-        """Test fallback when top endpoint unavailable."""
-        from src.tools.traffic_flows import get_top_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-
-            call_count = 0
-
-            async def get_side_effect(endpoint, **kwargs):
-                nonlocal call_count
-                call_count += 1
-                if call_count == 1:
-                    raise Exception("Top endpoint not available")
-                return {"data": sample_traffic_flows}
-
-            mock_instance.get = AsyncMock(side_effect=get_side_effect)
-
-            result = await get_top_flows("default", mock_settings, limit=1)
-
-            assert len(result) == 1
-
-
-class TestFilterTrafficFlowsFallback:
-    """Tests for filter_traffic_flows fallback behavior."""
-
-    @pytest.mark.asyncio
-    async def test_filter_traffic_flows_fallback(self, mock_settings, sample_traffic_flows):
-        """Test fallback when filter endpoint not available."""
-        from src.tools.traffic_flows import filter_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-
-            call_count = 0
-
-            async def get_side_effect(endpoint, **kwargs):
-                nonlocal call_count
-                call_count += 1
-                if call_count == 1:
-                    raise Exception("Filter endpoint not available")
-                return {"data": sample_traffic_flows}
-
-            mock_instance.get = AsyncMock(side_effect=get_side_effect)
-
-            result = await filter_traffic_flows(
-                "default", mock_settings, filter_expression="protocol = 'tcp'", limit=1
+    async def test_found_in_sample(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_traffic_flow_details(
+                "default", "flow-2", mock_settings
             )
-
-            assert len(result) == 1
-
-
-class TestBlockFlowSourceIPExecution:
-    """Tests for block_flow_source_ip actual execution."""
+        assert result["id"] == "flow-2"
+        assert result["source"]["client_name"] == "Rob's Laptop"
 
     @pytest.mark.asyncio
-    async def test_block_flow_source_ip_execution(self, mock_settings, sample_traffic_flows):
-        """Execute block flow source IP with firewall rule creation."""
-        from src.tools.traffic_flows import block_flow_source_ip
-
-        flow = sample_traffic_flows[0]
-
-        with (
-            patch("src.tools.traffic_flows.UniFiClient") as mock_client,
-            patch(
-                "src.tools.firewall.create_firewall_rule", new_callable=AsyncMock
-            ) as mock_firewall,
-            patch("src.tools.traffic_flows.audit_action", new_callable=AsyncMock),
-        ):
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": flow})
-
-            mock_firewall.return_value = {"_id": "rule-123", "name": "Block_192.168.2.100"}
-
-            result = await block_flow_source_ip(
-                "default",
-                "flow-001",
-                mock_settings,
-                confirm=True,
-                dry_run=False,
-            )
-
-            assert result["block_type"] == "source_ip"
-            assert result["blocked_target"] == "192.168.2.100"
-            assert result["rule_id"] == "rule-123"
-            mock_firewall.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_block_flow_source_ip_temporary(self, mock_settings, sample_traffic_flows):
-        """Block source IP with temporary duration."""
-        from src.tools.traffic_flows import block_flow_source_ip
-
-        flow = sample_traffic_flows[0]
-
-        with (
-            patch("src.tools.traffic_flows.UniFiClient") as mock_client,
-            patch(
-                "src.tools.firewall.create_firewall_rule", new_callable=AsyncMock
-            ) as mock_firewall,
-            patch("src.tools.traffic_flows.audit_action", new_callable=AsyncMock),
-        ):
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": flow})
-
-            mock_firewall.return_value = {"_id": "rule-124", "name": "Block_temp"}
-
-            result = await block_flow_source_ip(
-                "default",
-                "flow-001",
-                mock_settings,
-                duration="temporary",
-                expires_in_hours=24,
-                confirm=True,
-                dry_run=False,
-            )
-
-            assert result["duration"] == "temporary"
-            assert result["expires_at"] is not None
-
-
-class TestBlockFlowDestinationIPExecution:
-    """Tests for block_flow_destination_ip actual execution."""
-
-    @pytest.mark.asyncio
-    async def test_block_flow_destination_ip_execution(self, mock_settings, sample_traffic_flows):
-        """Execute block flow destination IP with firewall rule creation."""
-        from src.tools.traffic_flows import block_flow_destination_ip
-
-        flow = sample_traffic_flows[0]
-
-        with (
-            patch("src.tools.traffic_flows.UniFiClient") as mock_client,
-            patch(
-                "src.tools.firewall.create_firewall_rule", new_callable=AsyncMock
-            ) as mock_firewall,
-            patch("src.tools.traffic_flows.audit_action", new_callable=AsyncMock),
-        ):
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": flow})
-
-            mock_firewall.return_value = {"_id": "rule-125", "name": "Block_8.8.8.8"}
-
-            result = await block_flow_destination_ip(
-                "default",
-                "flow-001",
-                mock_settings,
-                confirm=True,
-                dry_run=False,
-            )
-
-            assert result["block_type"] == "destination_ip"
-            assert result["blocked_target"] == "8.8.8.8"
-            assert result["rule_id"] == "rule-125"
-
-
-class TestBlockFlowApplicationExecution:
-    """Tests for block_flow_application actual execution."""
-
-    @pytest.mark.asyncio
-    async def test_block_flow_application_without_zbf(self, mock_settings, sample_traffic_flows):
-        """Block application using traditional firewall (no ZBF)."""
-        from src.tools.traffic_flows import block_flow_application
-
-        flow = sample_traffic_flows[0]
-
-        with (
-            patch("src.tools.traffic_flows.UniFiClient") as mock_client,
-            patch(
-                "src.tools.firewall.create_firewall_rule", new_callable=AsyncMock
-            ) as mock_firewall,
-            patch("src.tools.traffic_flows.audit_action", new_callable=AsyncMock),
-        ):
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": flow})
-
-            mock_firewall.return_value = {"_id": "rule-126", "name": "Block_App_HTTPS"}
-
-            result = await block_flow_application(
-                "default",
-                "flow-001",
-                mock_settings,
-                use_zbf=False,
-                confirm=True,
-                dry_run=False,
-            )
-
-            assert result["block_type"] == "application"
-            assert result["blocked_target"] == "app-001"
-            assert result["rule_id"] == "rule-126"
-
-
-class TestBlockFlowErrors:
-    """Tests for block flow error handling."""
-
-    @pytest.mark.asyncio
-    async def test_block_flow_source_ip_no_source_ip(self, mock_settings):
-        """Handle flow with no source IP - Pydantic validation catches missing required field."""
-        from pydantic import ValidationError
-
-        from src.tools.traffic_flows import block_flow_source_ip
-
-        flow_without_source = {
-            "flow_id": "flow-bad",
-            "site_id": "default",
-            "destination_ip": "8.8.8.8",
-            "protocol": "tcp",
-            "bytes_sent": 0,
-            "bytes_received": 0,
-            "packets_sent": 0,
-            "packets_received": 0,
-            "start_time": "2026-01-05T00:00:00Z",
-        }
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": flow_without_source})
-
-            # Pydantic validation fails because source_ip is required in TrafficFlow model
-            with pytest.raises(ValidationError, match="source_ip"):
-                await block_flow_source_ip(
-                    "default", "flow-bad", mock_settings, confirm=True, dry_run=False
-                )
-
-    @pytest.mark.asyncio
-    async def test_block_flow_application_no_app_id(self, mock_settings):
-        """Handle flow with no application ID."""
-        from src.tools.traffic_flows import block_flow_application
-
-        flow_without_app = {
-            "flow_id": "flow-noapp",
-            "site_id": "default",
-            "source_ip": "192.168.2.100",
-            "destination_ip": "8.8.8.8",
-            "protocol": "tcp",
-            "bytes_sent": 0,
-            "bytes_received": 0,
-            "packets_sent": 0,
-            "packets_received": 0,
-            "start_time": "2026-01-05T00:00:00Z",
-            "application_id": None,
-        }
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": flow_without_app})
-
-            with pytest.raises(ValueError, match="No application ID found"):
-                await block_flow_application(
-                    "default", "flow-noapp", mock_settings, confirm=True, dry_run=False
+    async def test_not_in_sample_raises(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            with pytest.raises(ResourceNotFoundError):
+                await tf.get_traffic_flow_details(
+                    "default", "missing-id", mock_settings
                 )
 
 
-class TestExportEmptyFlows:
-    """Tests for export_traffic_flows with empty data."""
+# --------------------------------------------------------------------------- #
+# Top flows / risks / filter expression                                       #
+# --------------------------------------------------------------------------- #
+
+
+class TestGetTopFlows:
+    @pytest.mark.asyncio
+    async def test_sort_by_bytes_default(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_top_flows("default", mock_settings, limit=2)
+        assert [r["id"] for r in result] == ["flow-2", "flow-1"]
 
     @pytest.mark.asyncio
-    async def test_export_csv_empty_flows(self, mock_settings):
-        """Export empty flows as CSV returns empty string."""
-        from src.tools.traffic_flows import export_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": []})
-
-            result = await export_traffic_flows("default", mock_settings, export_format="csv")
-
-            assert result == ""
+    async def test_sort_by_packets(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_top_flows(
+                "default", mock_settings, limit=1, sort_by="packets"
+            )
+        assert result[0]["id"] == "flow-2"  # 72 packets
 
     @pytest.mark.asyncio
-    async def test_export_with_include_fields(self, mock_settings, sample_traffic_flows):
-        """Export with specific fields only."""
-        from src.tools.traffic_flows import export_traffic_flows
+    async def test_sort_by_duration(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_top_flows(
+                "default", mock_settings, limit=1, sort_by="duration"
+            )
+        assert result[0]["id"] == "flow-1"  # 221461 ms
 
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": sample_traffic_flows})
 
-            result = await export_traffic_flows(
+class TestGetFlowRisks:
+    @pytest.mark.asyncio
+    async def test_threshold_medium(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_flow_risks(
+                "default", mock_settings, min_risk_level="medium"
+            )
+        assert [r["id"] for r in result] == ["flow-2", "flow-3"]
+
+    @pytest.mark.asyncio
+    async def test_threshold_high_only(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_flow_risks(
+                "default", mock_settings, min_risk_level="high"
+            )
+        assert len(result) == 1
+        assert result[0]["id"] == "flow-3"
+
+
+class TestFilterTrafficFlows:
+    @pytest.mark.asyncio
+    async def test_filter_expression_parsing(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.filter_traffic_flows(
                 "default",
                 mock_settings,
-                export_format="json",
-                include_fields=["flow_id", "source_ip"],
+                "protocol=TCP,action=blocked,min_bytes=50",
+            )
+        assert len(result) == 1
+        assert result[0]["id"] == "flow-3"
+
+
+# --------------------------------------------------------------------------- #
+# Client aggregation                                                          #
+# --------------------------------------------------------------------------- #
+
+
+class TestGetClientFlowAggregation:
+    @pytest.mark.asyncio
+    async def test_aggregates_for_client(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_client_flow_aggregation(
+                "default", "aa:bb:cc:dd:ee:02", mock_settings
+            )
+        assert result["sample_size"] == 1
+        assert result["client_name"] == "Rob's Laptop"
+        assert result["total_bytes"] == 24_000
+        assert result["protocol_breakdown"] == {"TCP": 1}
+
+    @pytest.mark.asyncio
+    async def test_unknown_client_returns_empty_aggregation(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.get_client_flow_aggregation(
+                "default", "00:00:00:00:00:00", mock_settings
+            )
+        assert result["sample_size"] == 0
+        assert result["total_bytes"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# find_flows_for_rule_reference                                               #
+# --------------------------------------------------------------------------- #
+
+
+class TestFindFlowsForRuleReference:
+    @pytest.mark.asyncio
+    async def test_match_zone_pair(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        """Simulated workflow: 'show me what a Dmz→External rule would match'."""
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            matches = await tf.find_flows_for_rule_reference(
+                "default",
+                mock_settings,
+                source_zone_name="Dmz",
+                destination_zone_name="External",
+            )
+        assert len(matches) == 2
+        ids = {m["flow_id"] for m in matches}
+        assert ids == {"flow-1", "flow-3"}
+        # Match records expose the rule-reference shape, not the full flow.
+        assert "source_label" in matches[0]
+        assert "destination_label" in matches[0]
+        assert "source_zone_name" in matches[0]
+
+    @pytest.mark.asyncio
+    async def test_match_protocol_and_port(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            matches = await tf.find_flows_for_rule_reference(
+                "default",
+                mock_settings,
+                protocol="TCP",
+                destination_port=443,
+            )
+        assert len(matches) == 1
+        assert matches[0]["flow_id"] == "flow-2"
+        assert matches[0]["destination_port"] == 443
+
+    @pytest.mark.asyncio
+    async def test_no_matches_returns_empty(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            matches = await tf.find_flows_for_rule_reference(
+                "default",
+                mock_settings,
+                source_zone_name="Hotspot",
+            )
+        assert matches == []
+
+    @pytest.mark.asyncio
+    async def test_respects_limit(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            matches = await tf.find_flows_for_rule_reference(
+                "default",
+                mock_settings,
+                destination_zone_name="External",
+                limit=1,
+            )
+        assert len(matches) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Export                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+class TestExportTrafficFlows:
+    @pytest.mark.asyncio
+    async def test_json_export(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        import json
+
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.export_traffic_flows(
+                "default", mock_settings, export_format="json"
+            )
+        parsed = json.loads(result)
+        assert len(parsed) == 3
+        assert parsed[0]["id"] == "flow-1"
+
+    @pytest.mark.asyncio
+    async def test_csv_export_has_header_and_rows(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.export_traffic_flows(
+                "default", mock_settings, export_format="csv"
+            )
+        lines = result.strip().split("\n")
+        assert lines[0].startswith("flow_id,action,protocol")
+        assert len(lines) == 4  # header + 3 rows
+
+    @pytest.mark.asyncio
+    async def test_export_invalid_format_raises(
+        self, mock_settings: MagicMock
+    ) -> None:
+        with pytest.raises(ValueError, match="export_format"):
+            await tf.export_traffic_flows(
+                "default", mock_settings, export_format="xml"
             )
 
-            import json
-
-            parsed = json.loads(result)
-            assert "flow_id" in parsed[0]
-            assert "source_ip" in parsed[0]
-            assert "destination_ip" not in parsed[0]
-
-
-class TestStreamTrafficFlows:
-    """Tests for stream_traffic_flows async generator."""
-
     @pytest.mark.asyncio
-    async def test_stream_traffic_flows_single_iteration(self, mock_settings, sample_traffic_flows):
-        """Stream traffic flows yields updates correctly."""
-        from src.tools.traffic_flows import stream_traffic_flows
+    async def test_export_respects_max_records(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        import json
 
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-
-            call_count = 0
-
-            async def get_side_effect(endpoint, **kwargs):
-                nonlocal call_count
-                call_count += 1
-                if call_count == 1:
-                    return {"data": sample_traffic_flows}
-                raise StopAsyncIteration()
-
-            mock_instance.get = AsyncMock(side_effect=get_side_effect)
-
-            with patch(
-                "src.tools.traffic_flows.asyncio.sleep", new_callable=AsyncMock
-            ) as mock_sleep:
-                mock_sleep.side_effect = StopAsyncIteration()
-
-                updates = []
-                try:
-                    async for update in stream_traffic_flows("default", mock_settings):
-                        updates.append(update)
-                        if len(updates) >= 2:
-                            break
-                except StopAsyncIteration:
-                    pass
-
-                assert len(updates) == 2
-                assert updates[0]["update_type"] == "new"
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.export_traffic_flows(
+                "default", mock_settings, export_format="json", max_records=2
+            )
+        parsed = json.loads(result)
+        assert len(parsed) == 2
 
 
-class TestBlockFlowApplicationWithZBF:
-    """Tests for block_flow_application with ZBF enabled."""
+# --------------------------------------------------------------------------- #
+# Block-flow actions (dry-run only; no firewall writes in unit tests)         #
+# --------------------------------------------------------------------------- #
 
+
+class TestBlockFlowActions:
     @pytest.mark.asyncio
-    async def test_block_flow_application_zbf_fallback(self, mock_settings, sample_traffic_flows):
-        """Block application falls back to firewall when ZBF fails."""
-        from src.tools.traffic_flows import block_flow_application
-
-        flow = sample_traffic_flows[0]
-
-        with (
-            patch("src.tools.traffic_flows.UniFiClient") as mock_client,
-            patch(
-                "src.tools.firewall.create_firewall_rule", new_callable=AsyncMock
-            ) as mock_firewall,
-            patch("src.tools.traffic_flows.audit_action", new_callable=AsyncMock),
-        ):
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": flow})
-
-            mock_firewall.return_value = {"_id": "rule-zbf-fallback", "name": "Block_App"}
-
-            result = await block_flow_application(
+    async def test_block_source_ip_dry_run(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.block_flow_source_ip(
                 "default",
-                "flow-001",
+                "flow-1",
                 mock_settings,
-                use_zbf=True,
-                zone_id=None,
                 confirm=True,
-                dry_run=False,
+                dry_run=True,
+            )
+        assert result["block_type"] == "source_ip"
+        assert result["blocked_target"] == "10.0.20.10"
+        assert result["rule_id"] is None  # dry-run, no rule created
+
+    @pytest.mark.asyncio
+    async def test_block_destination_ip_dry_run(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.block_flow_destination_ip(
+                "default",
+                "flow-3",
+                mock_settings,
+                confirm=True,
+                dry_run=True,
+            )
+        assert result["block_type"] == "destination_ip"
+        assert result["blocked_target"] == "203.0.113.99"
+
+    @pytest.mark.asyncio
+    async def test_block_application_dry_run_falls_back_to_destination_ip(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        # flow-1 has service=OTHER so block_flow_application falls back to dst ip
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.block_flow_application(
+                "default",
+                "flow-1",
+                mock_settings,
+                confirm=True,
+                dry_run=True,
+            )
+        assert result["block_type"] == "application"
+        assert result["blocked_target"] == "198.51.100.5"
+
+    @pytest.mark.asyncio
+    async def test_block_without_confirm_raises(
+        self, mock_settings: MagicMock
+    ) -> None:
+        with pytest.raises(ValidationError):
+            await tf.block_flow_source_ip(
+                "default", "flow-1", mock_settings, confirm=False
             )
 
-            assert result["block_type"] == "application"
-            assert result["rule_id"] == "rule-zbf-fallback"
-            mock_firewall.assert_called_once()
-
-
-class TestGetFlowRisksEdgeCases:
-    """Tests for get_flow_risks edge cases."""
-
     @pytest.mark.asyncio
-    async def test_get_flow_risks_with_min_level(self, mock_settings):
-        """Get flow risks with minimum risk level filter."""
-        from src.tools.traffic_flows import get_flow_risks
-
-        risks = [
-            {"flow_id": "flow-1", "risk_level": "high", "risk_score": 90},
-            {"flow_id": "flow-2", "risk_level": "medium", "risk_score": 50},
-        ]
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": risks})
-
-            result = await get_flow_risks("default", mock_settings, min_risk_level="high")
-
-            assert isinstance(result, list)
-
-
-class TestBlockFlowDestinationIPEdgeCases:
-    """Tests for block_flow_destination_ip edge cases."""
-
-    @pytest.mark.asyncio
-    async def test_block_flow_destination_ip_temporary(self, mock_settings, sample_traffic_flows):
-        """Block destination IP with temporary duration."""
-        from src.tools.traffic_flows import block_flow_destination_ip
-
-        flow = sample_traffic_flows[0]
-
-        with (
-            patch("src.tools.traffic_flows.UniFiClient") as mock_client,
-            patch(
-                "src.tools.firewall.create_firewall_rule", new_callable=AsyncMock
-            ) as mock_firewall,
-            patch("src.tools.traffic_flows.audit_action", new_callable=AsyncMock),
-        ):
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": flow})
-
-            mock_firewall.return_value = {"_id": "rule-temp-dest", "name": "Block_8.8.8.8"}
-
-            result = await block_flow_destination_ip(
+    async def test_block_temporary_sets_expiry(
+        self, mock_settings: MagicMock, sample_raw_flows: list[dict[str, Any]]
+    ) -> None:
+        with patch("src.tools.traffic_flows.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client(sample_raw_flows)
+            result = await tf.block_flow_destination_ip(
                 "default",
-                "flow-001",
+                "flow-3",
                 mock_settings,
                 duration="temporary",
-                expires_in_hours=12,
+                expires_in_hours=6,
                 confirm=True,
-                dry_run=False,
+                dry_run=True,
             )
-
-            assert result["duration"] == "temporary"
-            assert result["expires_at"] is not None
-
-
-class TestGetTrafficFlowsEdgeCases:
-    """Tests for get_traffic_flows edge cases."""
-
-    @pytest.mark.asyncio
-    async def test_get_traffic_flows_empty_response(self, mock_settings):
-        """Handle empty response from API."""
-        from src.tools.traffic_flows import get_traffic_flows
-
-        with patch("src.tools.traffic_flows.UniFiClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_client.return_value.__aenter__.return_value = mock_instance
-            mock_instance.is_authenticated = False
-            mock_instance.authenticate = AsyncMock()
-            mock_instance.get = AsyncMock(return_value={"data": []})
-
-            result = await get_traffic_flows("default", mock_settings)
-
-            assert result == []
+        assert result["duration"] == "temporary"
+        assert result["expires_at"] is not None


### PR DESCRIPTION
The existing traffic_flows tools are completely broken — they hit `/integration/v1/sites/{id}/traffic/flows` and 7 sibling paths, **none of which exist on any Ubiquiti API surface**. I audited the scraped Integration API docs (76 endpoints from developer.ui.com) and confirmed: there is no traffic flow endpoint documented, not on cloud-EA, not on local. Every call has been silently 404-ing, hidden by `except Exception: return []`.

This rewrite targets the endpoint that actually exposes flow data: `POST /proxy/network/v2/api/site/{site}/traffic-flows`. It's the same internal endpoint the UniFi Network web UI uses, reachable through the local gateway proxy, authenticated via the same API key — the pattern `firewall_policies.py` established. Verified live against a UDM Pro on UniFi Network 10.2.x.

## Why this isn't a cloud-vs-local confusion

I specifically checked this before rewriting. The Integration API (`api.ui.com/integration/v1/...` cloud, `/proxy/network/integration/v1/...` local) is the same API surface served two ways, and its documented endpoint list contains **no** traffic flow routes. The only "traffic"-prefixed endpoints are `traffic-matching-list` (rule-config primitives). The v2 endpoint is local-only by design — there's no `api.ui.com/v2/api/site/...` equivalent — so cloud-mode users literally cannot reach flow data. The new module raises a clear `NotImplementedError` in cloud mode rather than silently returning empty lists.

## Key v2 endpoint constraints (verified live)

- **Hard cap at 50 flows per call.** `limit`/`offset`/`page_size`/`duration`/`start` parameters are accepted but ignored.
- **Server-side filter keys are non-functional.** I tested `actions`, `protocols`, `risks`, `source_zone_ids`, `destination_zone_ids`, and more — they pass syntax validation but don't narrow results. All filtering must happen client-side.
- **Rolling snapshot.** Repeated calls return different IDs as new flows displace older ones.

The module is structured around these constraints: a single `_fetch_raw_flows` helper hits the endpoint with empty body, and `_flow_matches` applies all filters in Python.

## What this PR does

- **Gates the whole module with `_ensure_local_api()`** — same pattern `firewall_policies.py` uses. Cloud-mode users get a clear error pointing at `UNIFI_API_TYPE=local`.
- **Rewrites the `TrafficFlow` pydantic model** to match the real v2 response shape: nested `source`/`destination` (`TrafficFlowEndpoint`), `traffic_data` byte counters, `policies` match references, `risk`/`service` fields, and `in`/`out` network metadata aliased to `in_network`/`out_network` (the raw keys collide with Python's `in`).
- **Consolidates the 7 fetch helpers** behind a single fetch+filter pipeline. Filters: `source_mac`, `source_ip`, `source_zone_name`, `source_network_name`, `destination_ip`, `destination_port`, `destination_zone_name`, `protocol`, `action`, `direction`, `risk`, `min_bytes`, `client_name_contains`.
- **New tool: `find_flows_for_rule_reference`** — the primary use case. Given the match criteria for a draft firewall policy or ACL rule, return current flows that rule would have matched so the LLM can reason about real traffic before committing. Output shape is trimmed (`source_label`, `destination_label`, `source_zone_name`, `destination_zone_name`, `protocol`, `destination_port`, `bytes_total`, `action`) specifically for rule evaluation.
- **Raises `NotImplementedError`** (not silent empty list) for `get_flow_trends`, `stream_traffic_flows`, and `get_connection_states`. The v2 endpoint fundamentally cannot support these — no historical query, no pagination past 50, no connection state reporting — so failing loud is better than lying silent.
- **Keeps `block_flow_source_ip`/`block_flow_destination_ip`/`block_flow_application` working** by pulling from the new nested `source.ip`/`destination.ip` paths. `block_flow_application` now falls back to the destination IP when the v2 `service` field is `OTHER` (the endpoint doesn't expose DPI application IDs).

## Type of Change

- [x] Bug fix (the old implementation silently returned empty lists from non-existent endpoints on every call)
- [x] Breaking change (the module now raises `NotImplementedError` in cloud mode where it used to silently return `[]`; the `TrafficFlow` model schema changed to match the real v2 response, and `get_flow_trends`/`stream_traffic_flows`/`get_connection_states` now raise instead of returning stubs)

## Testing

**Unit tests:** 1119 passing (1 pre-existing unrelated failure in `test_security.py::test_diskcache_not_installed`).

The existing 57-test `test_traffic_flows_tools.py` was replaced with 40 focused tests against a realistic v2 fixture redacted from a live UDM. The old tests passed only because their mocks matched the broken implementation — they asserted against the imagined integration API shape and exercised code paths that never actually ran against any real controller. The new suite covers:

- Local-API gate (4 tests — cloud-mode rejection + 3 NotImplementedError paths)
- `get_traffic_flows` core + every filter (10 tests including `data`-wrapped and empty responses)
- `get_flow_statistics` with and without filter narrowing (2)
- `get_flow_analytics` risk breakdown (1)
- `get_traffic_flow_details` found / missing-from-sample (2)
- `get_top_flows` sort-by bytes / packets / duration (3)
- `get_flow_risks` severity threshold (2)
- `filter_traffic_flows` expression parser (1)
- `get_client_flow_aggregation` known / unknown client (2)
- `find_flows_for_rule_reference` zone pair / protocol+port / no matches / limit (4)
- `export_traffic_flows` JSON / CSV / invalid format / max_records (4)
- Block-flow actions: source IP / destination IP / application fallback / no confirm / temporary expiry (5)

**Live controller validation** (UDM Pro, UniFi Network 10.2.x):

- `get_traffic_flows` returned real flow records with populated source client names, OUIs, zone mappings, destinations, and byte counters
- `find_flows_for_rule_reference` with `source_zone_name="Dmz"` + `destination_zone_name="External"` correctly surfaced the IoT VLAN flows that would have been affected by a proposed block rule
- Server-side filter parameters confirmed as non-functional (the reason filtering moved client-side)

## Checklist

- [x] Self-reviewed
- [x] Tests added / updated for new functionality
- [x] No new warnings
- [x] Unit tests pass locally
- [x] `sanitize_log_message()` preserved on all touched log sites
- [x] Module follows the same `_ensure_local_api()` + `get_v2_api_path()` + POST pattern as `firewall_policies.py`