### PR TITLE
feat(firewall_groups): port/address group CRUD + port matching on policies

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -14,11 +14,15 @@ from .tools import application as application_tools
 from .tools import backups as backups_tools
 from .tools import client_management as client_mgmt_tools
 from .tools import clients as clients_tools
+from .tools import content_filtering as content_filtering_tools
 from .tools import device_control as device_control_tools
 from .tools import devices as devices_tools
+from .tools import dhcp_reservations as dhcp_tools
+from .tools import dns_management as dns_tools
 from .tools import dpi as dpi_tools
 from .tools import dpi_tools as dpi_new_tools
 from .tools import firewall as firewall_tools
+from .tools import firewall_groups as firewall_groups_tools
 from .tools import firewall_policies as firewall_policies_tools
 from .tools import firewall_zones as firewall_zones_tools
 from .tools import network_config as network_config_tools
@@ -108,11 +112,15 @@ _TOOL_MODULES = [
     backups_tools,
     client_mgmt_tools,
     clients_tools,
+    content_filtering_tools,
     device_control_tools,
+    dhcp_tools,
+    dns_tools,
     devices_tools,
     dpi_tools,
     dpi_new_tools,
     firewall_tools,
+    firewall_groups_tools,
     firewall_policies_tools,
     firewall_zones_tools,
     network_config_tools,

--- a/src/main.py
+++ b/src/main.py
@@ -19,6 +19,7 @@ from .tools import devices as devices_tools
 from .tools import dpi as dpi_tools
 from .tools import dpi_tools as dpi_new_tools
 from .tools import firewall as firewall_tools
+from .tools import firewall_policies as firewall_policies_tools
 from .tools import firewall_zones as firewall_zones_tools
 from .tools import network_config as network_config_tools
 from .tools import networks as networks_tools
@@ -112,6 +113,7 @@ _TOOL_MODULES = [
     dpi_tools,
     dpi_new_tools,
     firewall_tools,
+    firewall_policies_tools,
     firewall_zones_tools,
     network_config_tools,
     networks_tools,

--- a/src/models/firewall_group.py
+++ b/src/models/firewall_group.py
@@ -1,0 +1,69 @@
+"""Firewall group models.
+
+Firewall groups on UniFi are the reusable objects that firewall policies
+and legacy firewall rules reference for ports, IPv4 addresses, and IPv6
+addresses. They live at the legacy V1 internal API endpoint
+``/proxy/network/api/s/{site}/rest/firewallgroup`` — the v2 API does not
+expose them, so these tools are local-gateway only.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+GroupType = Literal["port-group", "address-group", "ipv6-address-group"]
+
+
+class FirewallGroup(BaseModel):
+    """Firewall group object (port-group / address-group / ipv6-address-group).
+
+    ``group_members`` holds a list of string values whose meaning depends on
+    ``group_type``:
+
+    * ``port-group`` — port numbers or ranges, e.g. ``["8080", "9000-9010"]``
+    * ``address-group`` — IPv4 addresses or CIDR blocks
+    * ``ipv6-address-group`` — IPv6 addresses or CIDR blocks
+    """
+
+    id: str = Field(..., alias="_id", description="Group identifier")
+    name: str = Field(..., description="Group display name")
+    group_type: str = Field(..., description="port-group / address-group / ipv6-address-group")
+    group_members: list[str] = Field(
+        default_factory=list,
+        description="Ports (or addresses, depending on group_type)",
+    )
+    site_id: str | None = Field(
+        None,
+        description="Internal site id (not returned on every endpoint)",
+    )
+    external_id: str | None = Field(
+        None,
+        description="External UUID (not always present)",
+    )
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+
+class FirewallGroupCreate(BaseModel):
+    """Request body for creating a new firewall group."""
+
+    name: str = Field(..., description="Group display name")
+    group_type: GroupType = Field(..., description="Group category")
+    group_members: list[str] = Field(
+        default_factory=list,
+        description="List of ports or addresses",
+    )
+
+    model_config = ConfigDict(extra="allow")
+
+
+class FirewallGroupUpdate(BaseModel):
+    """Request body for updating an existing firewall group (partial update)."""
+
+    name: str | None = Field(None, description="Group display name")
+    group_members: list[str] | None = Field(
+        None, description="New members list (replaces existing)"
+    )
+
+    model_config = ConfigDict(extra="allow")

--- a/src/models/firewall_policy.py
+++ b/src/models/firewall_policy.py
@@ -32,8 +32,18 @@ class MatchTarget(BaseModel):
     zone_id: str = Field(..., description="Firewall zone ID")
     matching_target: MatchingTarget = Field(..., description="Target matching type")
     matching_target_type: str | None = Field(None, description="Target type qualifier")
-    port_matching_type: str | None = Field(None, description="Port matching type (ANY/SPECIFIC)")
-    port: str | None = Field(None, description="Port(s) e.g. '53', '80,443', '1000-2000'")
+    port_matching_type: str | None = Field(
+        None,
+        description="Port matching mode: ANY (no filter), SPECIFIC (use 'port'), OBJECT (use 'port_group_id')",
+    )
+    port: str | None = Field(
+        None,
+        description="Port value for SPECIFIC mode — single port '53' or range '9000-9010'",
+    )
+    port_group_id: str | None = Field(
+        None,
+        description="Firewall port-group id for OBJECT mode (see firewall_groups tools)",
+    )
     match_opposite_ports: bool | None = Field(None, description="Invert port matching")
     ips: list[str] | None = Field(None, description="IP addresses for IP matching")
     match_opposite_ips: bool | None = Field(None, description="Invert IP matching")
@@ -102,6 +112,10 @@ class FirewallPolicyCreate(BaseModel):
     description: str | None = Field(None, description="Policy description")
     index: int | None = Field(None, description="Priority order")
     schedule: dict | None = Field(None, description="Time-based scheduling")
+    create_allow_respond: bool | None = Field(
+        None,
+        description="Allow response traffic. Must be False for BLOCK rules.",
+    )
 
     model_config = ConfigDict(extra="allow")
 

--- a/src/models/firewall_policy.py
+++ b/src/models/firewall_policy.py
@@ -106,6 +106,42 @@ class FirewallPolicyCreate(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
+class FirewallZoneV2Mapping(BaseModel):
+    """Zone listing entry from the v2 ``/firewall/zone`` endpoint.
+
+    Exposes both the internal MongoDB ObjectId (used by the v2
+    ``firewall-policies`` endpoint) and the external UUID (used by the public
+    integration API and most other MCP tools), plus the display name and
+    ``zone_key``. Callers can hand any of these identifiers to
+    ``create_firewall_policy`` / ``update_firewall_policy`` and the zone
+    resolver will map them to the internal id.
+    """
+
+    internal_id: str | None = Field(
+        None,
+        description="MongoDB ObjectId used by the v2 firewall-policies endpoint",
+    )
+    external_id: str | None = Field(
+        None,
+        description="UUID returned by the public integration API",
+    )
+    name: str | None = Field(None, description="Display name")
+    zone_key: str | None = Field(
+        None,
+        description="Internal zone key (e.g. 'internal', 'external', 'dmz')",
+    )
+    default_zone: bool = Field(
+        False,
+        description="Whether this is a UniFi-defined default zone",
+    )
+    network_ids: list[str] = Field(
+        default_factory=list,
+        description="Internal network _ids assigned to this zone",
+    )
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+
 class FirewallPolicyUpdate(BaseModel):
     name: str | None = Field(None, description="Policy name")
     action: str | None = Field(None, description="Policy action")

--- a/src/tools/content_filtering.py
+++ b/src/tools/content_filtering.py
@@ -1,0 +1,321 @@
+"""Content filtering (CyberSecure) management tools (local v2 API).
+
+Manages UniFi's DNS-based content filtering profiles via the v2 endpoint
+``/proxy/network/v2/api/site/{site}/content-filtering``. Each profile
+blocks a set of category names (from a fixed list the API provides) and
+can be scoped to specific VLANs (``network_ids``) or client MACs.
+
+**Limitation:** the v2 endpoint does **not** support POST (returns 405),
+so new profiles cannot be created via this API. The initial profile must
+be created in the UniFi Network UI (Settings → Security → Content
+Filtering → Create). Once it exists, the MCP can fully manage it: toggle
+enabled, change categories, adjust VLAN scope, manage domain allow/block
+lists, etc.
+"""
+
+from typing import Any
+
+from ..api.client import UniFiClient
+from ..config import APIType, Settings
+from ..utils import APIError, ResourceNotFoundError, get_logger, log_audit, sanitize_log_message
+from ..utils.validators import coerce_bool
+
+logger = get_logger(__name__)
+
+
+def _ensure_local_api(settings: Settings) -> None:
+    if settings.api_type != APIType.LOCAL:
+        raise NotImplementedError(
+            "Content filtering tools require UNIFI_API_TYPE='local'. "
+            "The cloud/integration API does not expose content filtering."
+        )
+
+
+async def list_content_filters(
+    site_id: str,
+    settings: Settings,
+) -> list[dict[str, Any]]:
+    """List all content filtering profiles.
+
+    Returns:
+        List of profile dicts with id, name, enabled, categories,
+        network_ids, client_macs, allow_list, block_list, safe_search,
+        schedule.
+    """
+    _ensure_local_api(settings)
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(f"Listing content filters for site {site_id}")
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            response = await client.get(
+                f"{settings.get_v2_api_path(site_id)}/content-filtering"
+            )
+        except APIError:
+            logger.exception(
+                sanitize_log_message(
+                    f"Failed to list content filters for site {site_id}"
+                )
+            )
+            raise
+
+        items = response if isinstance(response, list) else response.get("data", [])
+        return [_normalize(item) for item in items if isinstance(item, dict)]
+
+
+async def list_content_filter_categories(
+    site_id: str,
+    settings: Settings,
+) -> list[str]:
+    """List all available content filtering categories.
+
+    Returns the full set of category names (e.g. ``ADVERTISEMENT``,
+    ``ADULT``, ``GAMBLING``, ``HACKING``, ...) that can be assigned to a
+    content filtering profile's ``categories`` list.
+    """
+    _ensure_local_api(settings)
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(f"Listing content filter categories for site {site_id}")
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            response = await client.get(
+                f"{settings.get_v2_api_path(site_id)}/content-filtering/categories"
+            )
+        except APIError:
+            logger.exception(
+                sanitize_log_message("Failed to list content filter categories")
+            )
+            raise
+
+        if isinstance(response, list):
+            return [c for c in response if isinstance(c, str)]
+        return []
+
+
+async def update_content_filter(
+    filter_id: str,
+    site_id: str,
+    settings: Settings,
+    name: str | None = None,
+    enabled: bool | None = None,
+    categories: list[str] | None = None,
+    network_ids: list[str] | None = None,
+    client_macs: list[str] | None = None,
+    allow_list: list[str] | None = None,
+    block_list: list[str] | None = None,
+    safe_search: list[str] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Update a content filtering profile.
+
+    The v2 endpoint requires the full object on PUT, so this tool does a
+    GET (from the list endpoint) → merge overrides → PUT, same pattern as
+    ``update_firewall_policy``.
+
+    Args:
+        filter_id: Content filter profile ID
+        site_id: Site identifier
+        settings: Application settings (must be local)
+        name: Profile display name
+        enabled: Toggle the profile on/off
+        categories: Replace the blocked category list (e.g.
+            ``["ADVERTISEMENT", "GAMBLING"]``). Use
+            ``list_content_filter_categories`` for the full set.
+        network_ids: Replace the VLAN scope (internal network IDs).
+            Pass ``[]`` to apply to all networks.
+        client_macs: Replace the client-MAC scope. Pass ``[]`` for all
+            clients.
+        allow_list: Replace the domain allow-list (overrides category
+            blocks for these domains)
+        block_list: Replace the domain block-list (blocks these domains
+            regardless of category)
+        safe_search: Replace the safe-search engine list
+        confirm: REQUIRED True
+        dry_run: Preview without applying
+    """
+    _ensure_local_api(settings)
+
+    confirm_bool = coerce_bool(confirm)
+    dry_run_bool = coerce_bool(dry_run)
+    if not dry_run_bool and not confirm_bool:
+        raise ValueError(
+            "This operation requires confirm=True to execute. "
+            "Use dry_run=True to preview changes first."
+        )
+
+    overrides: dict[str, Any] = {}
+    if name is not None:
+        overrides["name"] = name
+    if enabled is not None:
+        overrides["enabled"] = enabled
+    if categories is not None:
+        overrides["categories"] = list(categories)
+    if network_ids is not None:
+        overrides["network_ids"] = list(network_ids)
+    if client_macs is not None:
+        overrides["client_macs"] = list(client_macs)
+    if allow_list is not None:
+        overrides["allow_list"] = list(allow_list)
+    if block_list is not None:
+        overrides["block_list"] = list(block_list)
+    if safe_search is not None:
+        overrides["safe_search"] = list(safe_search)
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(
+                f"Updating content filter {filter_id} for site {site_id}"
+            )
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        # Fetch current state (no single-item GET — list endpoint only).
+        base = f"{settings.get_v2_api_path(site_id)}/content-filtering"
+        try:
+            list_response = await client.get(base)
+        except APIError:
+            logger.exception(
+                sanitize_log_message(
+                    f"Failed to fetch content filters for site {site_id}"
+                )
+            )
+            raise
+
+        items = (
+            list_response
+            if isinstance(list_response, list)
+            else list_response.get("data", [])
+        )
+        current = None
+        for item in items:
+            if isinstance(item, dict) and item.get("_id") == filter_id:
+                current = item
+                break
+
+        if current is None:
+            raise ResourceNotFoundError("content_filter", filter_id)
+
+        merged = {**current, **overrides}
+        for field in ("_id",):
+            merged.pop(field, None)
+
+        if dry_run_bool:
+            logger.info(
+                sanitize_log_message(
+                    f"DRY RUN: Would update content filter {filter_id}"
+                )
+            )
+            return {
+                "status": "dry_run",
+                "filter_id": filter_id,
+                "changes": overrides,
+                "merged_payload": merged,
+            }
+
+        try:
+            response = await client.put(f"{base}/{filter_id}", json_data=merged)
+        except ResourceNotFoundError as err:
+            raise ResourceNotFoundError("content_filter", filter_id) from err
+
+        data = response if isinstance(response, dict) else {}
+
+        log_audit(
+            operation="update_content_filter",
+            parameters={"site_id": site_id, "filter_id": filter_id, **overrides},
+            result="success",
+            site_id=site_id,
+        )
+
+        return _normalize(data)
+
+
+async def delete_content_filter(
+    filter_id: str,
+    site_id: str,
+    settings: Settings,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Delete a content filtering profile.
+
+    Args:
+        filter_id: Content filter profile ID
+        site_id: Site identifier
+        settings: Application settings (must be local)
+        confirm: REQUIRED True
+        dry_run: Preview without applying
+    """
+    _ensure_local_api(settings)
+
+    confirm_bool = coerce_bool(confirm)
+    dry_run_bool = coerce_bool(dry_run)
+    if not dry_run_bool and not confirm_bool:
+        raise ValueError(
+            "This operation deletes a content filter profile. "
+            "Pass confirm=True to proceed."
+        )
+
+    if dry_run_bool:
+        logger.info(
+            sanitize_log_message(
+                f"DRY RUN: Would delete content filter {filter_id}"
+            )
+        )
+        return {"status": "dry_run", "filter_id": filter_id, "action": "would_delete"}
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(
+                f"Deleting content filter {filter_id} from site {site_id}"
+            )
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            await client.delete(
+                f"{settings.get_v2_api_path(site_id)}/content-filtering/{filter_id}"
+            )
+        except APIError:
+            logger.exception(
+                sanitize_log_message(
+                    f"Failed to delete content filter {filter_id}"
+                )
+            )
+            raise
+
+        log_audit(
+            operation="delete_content_filter",
+            parameters={"site_id": site_id, "filter_id": filter_id},
+            result="success",
+            site_id=site_id,
+        )
+
+        return {"status": "success", "filter_id": filter_id, "action": "deleted"}
+
+
+def _normalize(item: dict[str, Any]) -> dict[str, Any]:
+    """Extract the standard fields from a content filter profile."""
+    return {
+        "id": item.get("_id"),
+        "name": item.get("name"),
+        "enabled": item.get("enabled", False),
+        "categories": item.get("categories", []),
+        "network_ids": item.get("network_ids", []),
+        "client_macs": item.get("client_macs", []),
+        "allow_list": item.get("allow_list", []),
+        "block_list": item.get("block_list", []),
+        "safe_search": item.get("safe_search", []),
+        "schedule": item.get("schedule"),
+    }

--- a/src/tools/dhcp_reservations.py
+++ b/src/tools/dhcp_reservations.py
@@ -1,0 +1,448 @@
+"""DHCP reservation management tools (local V1 legacy endpoint).
+
+Creates and manages fixed-IP DHCP reservations via the UniFi controller's
+``/rest/user`` endpoint. Each "user" in the UniFi controller represents a
+known client identified by MAC address; DHCP reservations are just users
+with ``use_fixedip=true`` and a ``fixed_ip`` + ``network_id`` set.
+
+The endpoint is on the legacy V1 internal API
+(``/proxy/network/api/s/{site}/rest/user``), which accepts API-key auth
+on current UDM firmware. Local-gateway only — same gating as
+firewall_groups / firewall_policies.
+"""
+
+from typing import Any
+
+from ..api.client import UniFiClient
+from ..config import APIType, Settings
+from ..utils import (
+    APIError,
+    ResourceNotFoundError,
+    get_logger,
+    log_audit,
+    sanitize_log_message,
+)
+from ..utils.validators import coerce_bool
+
+logger = get_logger(__name__)
+
+
+def _ensure_local_api(settings: Settings) -> None:
+    if settings.api_type != APIType.LOCAL:
+        raise NotImplementedError(
+            "DHCP reservation tools require UNIFI_API_TYPE='local'. "
+            "The cloud/integration API does not expose the /rest/user endpoint."
+        )
+
+
+def _endpoint(site_id: str, user_id: str | None = None) -> str:
+    suffix = f"/{user_id}" if user_id else ""
+    return f"/ea/sites/{site_id}/rest/user{suffix}"
+
+
+def _unwrap(response: Any) -> list[dict[str, Any]]:
+    if isinstance(response, list):
+        return [i for i in response if isinstance(i, dict)]
+    if isinstance(response, dict):
+        inner = response.get("data")
+        if isinstance(inner, list):
+            return [i for i in inner if isinstance(i, dict)]
+        if isinstance(inner, dict):
+            return [inner]
+    return []
+
+
+async def list_dhcp_reservations(
+    site_id: str,
+    settings: Settings,
+    network_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """List all DHCP reservations (clients with fixed IPs).
+
+    Args:
+        site_id: Site identifier
+        settings: Application settings (must be local)
+        network_id: Optional filter by network (VLAN) internal ID
+
+    Returns:
+        List of reservation dicts with mac, fixed_ip, name, network_id.
+    """
+    _ensure_local_api(settings)
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(f"Listing DHCP reservations for site {site_id}")
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            response = await client.get(_endpoint(site_id))
+        except APIError:
+            logger.exception(
+                sanitize_log_message(
+                    f"Failed to list DHCP reservations for site {site_id}"
+                )
+            )
+            raise
+
+        items = _unwrap(response)
+        reservations = [
+            {
+                "id": u.get("_id"),
+                "mac": u.get("mac"),
+                "name": u.get("name") or u.get("hostname"),
+                "fixed_ip": u.get("fixed_ip"),
+                "network_id": u.get("network_id"),
+                "use_fixedip": u.get("use_fixedip", False),
+                "local_dns_record": u.get("local_dns_record"),
+                "local_dns_record_enabled": u.get("local_dns_record_enabled", False),
+            }
+            for u in items
+            if u.get("use_fixedip")
+        ]
+
+        if network_id:
+            reservations = [r for r in reservations if r.get("network_id") == network_id]
+
+        return reservations
+
+
+async def get_dhcp_reservation(
+    mac: str,
+    site_id: str,
+    settings: Settings,
+) -> dict[str, Any]:
+    """Get DHCP reservation for a specific MAC address.
+
+    Returns the reservation dict if the MAC has a fixed IP, otherwise raises
+    ResourceNotFoundError.
+    """
+    _ensure_local_api(settings)
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(f"Getting DHCP reservation for {mac}")
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        response = await client.get(_endpoint(site_id))
+        items = _unwrap(response)
+
+        mac_lower = mac.lower()
+        for u in items:
+            if (u.get("mac") or "").lower() == mac_lower and u.get("use_fixedip"):
+                return {
+                    "id": u.get("_id"),
+                    "mac": u.get("mac"),
+                    "name": u.get("name") or u.get("hostname"),
+                    "fixed_ip": u.get("fixed_ip"),
+                    "network_id": u.get("network_id"),
+                    "use_fixedip": True,
+                    "local_dns_record": u.get("local_dns_record"),
+                    "local_dns_record_enabled": u.get("local_dns_record_enabled", False),
+                }
+
+        raise ResourceNotFoundError("dhcp_reservation", mac)
+
+
+async def create_dhcp_reservation(
+    mac: str,
+    fixed_ip: str,
+    network_id: str,
+    site_id: str,
+    settings: Settings,
+    name: str | None = None,
+    local_dns_record: str | None = None,
+    local_dns_record_enabled: bool = False,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Create a DHCP reservation (fixed IP) for a client MAC.
+
+    If the MAC already exists in the controller's known-clients table, the
+    controller merges the reservation into the existing entry. If it's a
+    new MAC, a new user entry is created.
+
+    Args:
+        mac: Client MAC address (e.g. ``"aa:bb:cc:dd:ee:ff"``)
+        fixed_ip: Fixed IP to assign (must be within the network's DHCP range
+            or static allocation pool)
+        network_id: Internal network (VLAN) ID where the reservation applies.
+            Use ``list_networks`` or ``list_firewall_zones_v2`` to find IDs.
+        site_id: Site identifier
+        settings: Application settings (must be local)
+        name: Friendly name for the client (optional)
+        local_dns_record: Local DNS hostname to register (optional)
+        local_dns_record_enabled: Enable local DNS registration
+        confirm: REQUIRED True for mutating operations
+        dry_run: Preview without applying
+
+    Returns:
+        Created / merged reservation dict.
+    """
+    _ensure_local_api(settings)
+
+    confirm_bool = coerce_bool(confirm)
+    dry_run_bool = coerce_bool(dry_run)
+    if not dry_run_bool and not confirm_bool:
+        raise ValueError(
+            "This operation requires confirm=True to execute. "
+            "Use dry_run=True to preview changes first."
+        )
+
+    payload: dict[str, Any] = {
+        "mac": mac.lower(),
+        "use_fixedip": True,
+        "fixed_ip": fixed_ip,
+        "network_id": network_id,
+    }
+    if name is not None:
+        payload["name"] = name
+    if local_dns_record is not None:
+        payload["local_dns_record"] = local_dns_record
+        payload["local_dns_record_enabled"] = local_dns_record_enabled
+
+    if dry_run_bool:
+        logger.info(
+            sanitize_log_message(
+                f"DRY RUN: Would create DHCP reservation {mac} → {fixed_ip}"
+            )
+        )
+        return {"status": "dry_run", "payload": payload}
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(
+                f"Creating DHCP reservation {mac} → {fixed_ip} on site {site_id}"
+            )
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        response = await client.post(_endpoint(site_id), json_data=payload)
+        items = _unwrap(response)
+        if not items:
+            raise APIError(f"DHCP reservation POST returned no data for {mac}")
+        data = items[0]
+
+        log_audit(
+            operation="create_dhcp_reservation",
+            parameters={"site_id": site_id, "mac": mac, "fixed_ip": fixed_ip},
+            result="success",
+            site_id=site_id,
+        )
+
+        return {
+            "id": data.get("_id"),
+            "mac": data.get("mac"),
+            "name": data.get("name"),
+            "fixed_ip": data.get("fixed_ip"),
+            "network_id": data.get("network_id"),
+            "use_fixedip": data.get("use_fixedip", True),
+        }
+
+
+async def update_dhcp_reservation(
+    mac: str,
+    site_id: str,
+    settings: Settings,
+    fixed_ip: str | None = None,
+    name: str | None = None,
+    network_id: str | None = None,
+    local_dns_record: str | None = None,
+    local_dns_record_enabled: bool | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Update an existing DHCP reservation by MAC.
+
+    Looks up the client by MAC, then PUTs the overrides. The V1 ``rest/user``
+    endpoint accepts partial updates.
+
+    Args:
+        mac: Client MAC address to update
+        site_id: Site identifier
+        settings: Application settings (must be local)
+        fixed_ip: New fixed IP (optional — only if changing)
+        name: New friendly name
+        network_id: Move reservation to a different network
+        local_dns_record: Update local DNS hostname
+        local_dns_record_enabled: Toggle local DNS registration
+        confirm: REQUIRED True
+        dry_run: Preview without applying
+    """
+    _ensure_local_api(settings)
+
+    confirm_bool = coerce_bool(confirm)
+    dry_run_bool = coerce_bool(dry_run)
+    if not dry_run_bool and not confirm_bool:
+        raise ValueError(
+            "This operation requires confirm=True to execute. "
+            "Use dry_run=True to preview changes first."
+        )
+
+    # Find the user entry by MAC.
+    async with UniFiClient(settings) as client:
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        response = await client.get(_endpoint(site_id))
+        items = _unwrap(response)
+        mac_lower = mac.lower()
+        user_entry = None
+        for u in items:
+            if (u.get("mac") or "").lower() == mac_lower:
+                user_entry = u
+                break
+
+        if not user_entry:
+            raise ResourceNotFoundError("dhcp_reservation", mac)
+
+        user_id = user_entry["_id"]
+
+        overrides: dict[str, Any] = {}
+        if fixed_ip is not None:
+            overrides["fixed_ip"] = fixed_ip
+        if name is not None:
+            overrides["name"] = name
+        if network_id is not None:
+            overrides["network_id"] = network_id
+        if local_dns_record is not None:
+            overrides["local_dns_record"] = local_dns_record
+        if local_dns_record_enabled is not None:
+            overrides["local_dns_record_enabled"] = local_dns_record_enabled
+
+        if dry_run_bool:
+            logger.info(
+                sanitize_log_message(
+                    f"DRY RUN: Would update DHCP reservation for {mac}"
+                )
+            )
+            return {
+                "status": "dry_run",
+                "user_id": user_id,
+                "changes": overrides,
+            }
+
+        logger.info(
+            sanitize_log_message(
+                f"Updating DHCP reservation for {mac} (user {user_id})"
+            )
+        )
+
+        put_response = await client.put(
+            _endpoint(site_id, user_id), json_data=overrides
+        )
+        data = _unwrap(put_response)
+        if not data:
+            raise APIError(f"DHCP reservation PUT returned no data for {mac}")
+
+        log_audit(
+            operation="update_dhcp_reservation",
+            parameters={"site_id": site_id, "mac": mac, **overrides},
+            result="success",
+            site_id=site_id,
+        )
+
+        return {
+            "id": data[0].get("_id"),
+            "mac": data[0].get("mac"),
+            "name": data[0].get("name"),
+            "fixed_ip": data[0].get("fixed_ip"),
+            "network_id": data[0].get("network_id"),
+            "use_fixedip": data[0].get("use_fixedip", True),
+        }
+
+
+async def remove_dhcp_reservation(
+    mac: str,
+    site_id: str,
+    settings: Settings,
+    forget_client: bool = False,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Remove a DHCP reservation for a client MAC.
+
+    By default this only clears the fixed-IP assignment (sets
+    ``use_fixedip=false``) while keeping the client's history in the
+    controller. Pass ``forget_client=True`` to remove the client entry
+    entirely via ``cmd/stamgr forget-sta``.
+
+    Args:
+        mac: Client MAC address
+        site_id: Site identifier
+        settings: Application settings (must be local)
+        forget_client: If True, remove the entire client entry (not just the
+            reservation). This erases all history (first-seen, stats, name).
+        confirm: REQUIRED True
+        dry_run: Preview without applying
+    """
+    _ensure_local_api(settings)
+
+    confirm_bool = coerce_bool(confirm)
+    dry_run_bool = coerce_bool(dry_run)
+    if not dry_run_bool and not confirm_bool:
+        raise ValueError(
+            "This operation requires confirm=True to execute. "
+            "Use dry_run=True to preview changes first."
+        )
+
+    if dry_run_bool:
+        action = "forget_client" if forget_client else "clear_fixed_ip"
+        logger.info(
+            sanitize_log_message(
+                f"DRY RUN: Would {action} for {mac}"
+            )
+        )
+        return {"status": "dry_run", "mac": mac, "action": action}
+
+    async with UniFiClient(settings) as client:
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        if forget_client:
+            logger.info(
+                sanitize_log_message(f"Forgetting client {mac} from site {site_id}")
+            )
+            await client.post(
+                f"/ea/sites/{site_id}/cmd/stamgr",
+                json_data={"cmd": "forget-sta", "macs": [mac.lower()]},
+            )
+            action = "forgotten"
+        else:
+            # Find the user entry to get the _id for PUT.
+            response = await client.get(_endpoint(site_id))
+            items = _unwrap(response)
+            mac_lower = mac.lower()
+            user_entry = None
+            for u in items:
+                if (u.get("mac") or "").lower() == mac_lower:
+                    user_entry = u
+                    break
+
+            if not user_entry:
+                raise ResourceNotFoundError("dhcp_reservation", mac)
+
+            user_id = user_entry["_id"]
+            logger.info(
+                sanitize_log_message(
+                    f"Clearing DHCP reservation for {mac} (user {user_id})"
+                )
+            )
+            await client.put(
+                _endpoint(site_id, user_id),
+                json_data={"use_fixedip": False},
+            )
+            action = "reservation_cleared"
+
+        log_audit(
+            operation="remove_dhcp_reservation",
+            parameters={"site_id": site_id, "mac": mac, "forget_client": forget_client},
+            result="success",
+            site_id=site_id,
+        )
+
+        return {"status": "success", "mac": mac, "action": action}

--- a/src/tools/dns_management.py
+++ b/src/tools/dns_management.py
@@ -1,0 +1,369 @@
+"""DNS management tools (WAN DNS, DNS filtering).
+
+Manages WAN upstream DNS servers via ``/rest/networkconf/{wan_id}`` and
+per-network DNS filtering (CyberSecure DNS-level) via the ``[ips]``
+settings endpoint. Both are on the legacy V1 internal API, local-only.
+
+**DoT (DNS-over-TLS)** configuration is NOT exposed via REST API on
+current UDM firmware (10.2.x). The ``rest/setting/connectivity`` endpoint
+has no DoT-related fields. DoT must be configured in the UI for now.
+"""
+
+from typing import Any
+
+from ..api.client import UniFiClient
+from ..config import APIType, Settings
+from ..utils import APIError, get_logger, log_audit, sanitize_log_message
+from ..utils.validators import coerce_bool
+
+logger = get_logger(__name__)
+
+
+def _ensure_local_api(settings: Settings) -> None:
+    if settings.api_type != APIType.LOCAL:
+        raise NotImplementedError(
+            "DNS management tools require UNIFI_API_TYPE='local'."
+        )
+
+
+def _unwrap(response: Any) -> list[dict[str, Any]]:
+    if isinstance(response, list):
+        return [i for i in response if isinstance(i, dict)]
+    if isinstance(response, dict):
+        inner = response.get("data")
+        if isinstance(inner, list):
+            return [i for i in inner if isinstance(i, dict)]
+        if isinstance(inner, dict):
+            return [inner]
+    return []
+
+
+# --------------------------------------------------------------------------- #
+# WAN DNS                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+async def list_wan_dns(
+    site_id: str,
+    settings: Settings,
+) -> list[dict[str, Any]]:
+    """List WAN connections with their DNS settings.
+
+    Returns each WAN interface's name, ID, current DNS servers, and
+    dns_preference mode (``auto`` or ``manual``).
+    """
+    _ensure_local_api(settings)
+
+    async with UniFiClient(settings) as client:
+        logger.info(sanitize_log_message(f"Listing WAN DNS for site {site_id}"))
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            response = await client.get(f"/ea/sites/{site_id}/rest/networkconf")
+        except APIError:
+            logger.exception(
+                sanitize_log_message(f"Failed to list networks for site {site_id}")
+            )
+            raise
+
+        items = _unwrap(response)
+        wans = [n for n in items if n.get("purpose") == "wan"]
+
+        return [
+            {
+                "id": w.get("_id"),
+                "name": w.get("name"),
+                "wan_dns1": w.get("wan_dns1"),
+                "wan_dns2": w.get("wan_dns2"),
+                "wan_dns_preference": w.get("wan_dns_preference", "auto"),
+                "wan_type": w.get("wan_type"),
+                "wan_networkgroup": w.get("wan_networkgroup"),
+            }
+            for w in wans
+        ]
+
+
+async def update_wan_dns(
+    wan_network_id: str,
+    site_id: str,
+    settings: Settings,
+    dns1: str | None = None,
+    dns2: str | None = None,
+    dns_preference: str | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Update DNS settings on a WAN interface.
+
+    Args:
+        wan_network_id: The WAN network's ``_id`` (from ``list_wan_dns``)
+        site_id: Site identifier
+        settings: Application settings (must be local)
+        dns1: Primary DNS server IP (e.g. ``"172.64.36.1"``)
+        dns2: Secondary DNS server IP
+        dns_preference: ``"manual"`` to use dns1/dns2, ``"auto"`` for
+            DHCP-provided DNS
+        confirm: REQUIRED True
+        dry_run: Preview without applying
+    """
+    _ensure_local_api(settings)
+
+    confirm_bool = coerce_bool(confirm)
+    dry_run_bool = coerce_bool(dry_run)
+    if not dry_run_bool and not confirm_bool:
+        raise ValueError(
+            "This operation requires confirm=True to execute. "
+            "Use dry_run=True to preview changes first."
+        )
+
+    overrides: dict[str, Any] = {}
+    if dns1 is not None:
+        overrides["wan_dns1"] = dns1
+    if dns2 is not None:
+        overrides["wan_dns2"] = dns2
+    if dns_preference is not None:
+        if dns_preference not in ("auto", "manual"):
+            raise ValueError("dns_preference must be 'auto' or 'manual'")
+        overrides["wan_dns_preference"] = dns_preference
+
+    # Auto-set to manual when specific DNS servers are provided
+    if (dns1 is not None or dns2 is not None) and dns_preference is None:
+        overrides["wan_dns_preference"] = "manual"
+
+    if dry_run_bool:
+        logger.info(
+            sanitize_log_message(
+                f"DRY RUN: Would update WAN DNS on {wan_network_id}"
+            )
+        )
+        return {"status": "dry_run", "wan_network_id": wan_network_id, "changes": overrides}
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(
+                f"Updating WAN DNS on {wan_network_id} for site {site_id}"
+            )
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        endpoint = f"/ea/sites/{site_id}/rest/networkconf/{wan_network_id}"
+
+        try:
+            response = await client.put(endpoint, json_data=overrides)
+        except APIError:
+            logger.exception(
+                sanitize_log_message(
+                    f"Failed to update WAN DNS on {wan_network_id}"
+                )
+            )
+            raise
+
+        items = _unwrap(response)
+        data = items[0] if items else {}
+
+        log_audit(
+            operation="update_wan_dns",
+            parameters={"site_id": site_id, "wan_network_id": wan_network_id, **overrides},
+            result="success",
+            site_id=site_id,
+        )
+
+        return {
+            "id": data.get("_id"),
+            "name": data.get("name"),
+            "wan_dns1": data.get("wan_dns1"),
+            "wan_dns2": data.get("wan_dns2"),
+            "wan_dns_preference": data.get("wan_dns_preference"),
+        }
+
+
+# --------------------------------------------------------------------------- #
+# DNS Filtering (CyberSecure DNS-level, per-network)                          #
+# --------------------------------------------------------------------------- #
+
+
+async def get_dns_filter_settings(
+    site_id: str,
+    settings: Settings,
+) -> dict[str, Any]:
+    """Get DNS filtering settings (CyberSecure DNS-level).
+
+    Returns the global ``dns_filtering`` toggle and the per-network
+    ``dns_filters`` list from the ``[ips]`` settings.
+    """
+    _ensure_local_api(settings)
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(f"Getting DNS filter settings for site {site_id}")
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            response = await client.get(f"/ea/sites/{site_id}/get/setting/ips")
+        except APIError:
+            logger.exception(
+                sanitize_log_message("Failed to get DNS filter settings")
+            )
+            raise
+
+        items = _unwrap(response)
+        if not items:
+            return {"dns_filtering": False, "dns_filters": []}
+
+        ips_settings = items[0]
+        return {
+            "id": ips_settings.get("_id"),
+            "dns_filtering": ips_settings.get("dns_filtering", False),
+            "dns_filters": ips_settings.get("dns_filters", []),
+        }
+
+
+async def update_dns_filter(
+    site_id: str,
+    settings: Settings,
+    network_id: str | None = None,
+    dns_filtering: bool | None = None,
+    filter_level: str | None = None,
+    blocked_sites: list[str] | None = None,
+    allowed_sites: list[str] | None = None,
+    blocked_tld: list[str] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Update DNS filtering settings.
+
+    Can toggle the global ``dns_filtering`` switch and/or update a specific
+    network's DNS filter configuration.
+
+    Args:
+        site_id: Site identifier
+        settings: Application settings (must be local)
+        network_id: Target a specific network's DNS filter entry. Required
+            when updating per-network settings (filter_level, blocked_sites,
+            etc.).
+        dns_filtering: Toggle the global DNS filtering feature on/off
+        filter_level: DNS filter level for the specified network. Common
+            values: ``"none"``, ``"family"``, ``"work"``, ``"custom"``
+        blocked_sites: Replace the blocked-sites list for this network
+        allowed_sites: Replace the allowed-sites list
+        blocked_tld: Replace the blocked TLD list
+        confirm: REQUIRED True
+        dry_run: Preview without applying
+    """
+    _ensure_local_api(settings)
+
+    confirm_bool = coerce_bool(confirm)
+    dry_run_bool = coerce_bool(dry_run)
+    if not dry_run_bool and not confirm_bool:
+        raise ValueError(
+            "This operation requires confirm=True to execute. "
+            "Use dry_run=True to preview changes first."
+        )
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(f"Updating DNS filter settings for site {site_id}")
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        # Fetch current IPS settings
+        try:
+            response = await client.get(f"/ea/sites/{site_id}/get/setting/ips")
+        except APIError:
+            logger.exception(
+                sanitize_log_message("Failed to get current DNS filter settings")
+            )
+            raise
+
+        items = _unwrap(response)
+        if not items:
+            raise APIError("IPS settings not found")
+        current = items[0]
+        settings_id = current.get("_id")
+
+        # Build the update
+        update_payload: dict[str, Any] = {}
+
+        if dns_filtering is not None:
+            update_payload["dns_filtering"] = dns_filtering
+
+        if network_id is not None and (
+            filter_level is not None
+            or blocked_sites is not None
+            or allowed_sites is not None
+            or blocked_tld is not None
+        ):
+            # Update a specific network's entry in dns_filters
+            dns_filters = list(current.get("dns_filters", []))
+            target_entry = None
+            for entry in dns_filters:
+                if isinstance(entry, dict) and entry.get("network_id") == network_id:
+                    target_entry = entry
+                    break
+
+            if target_entry is None:
+                # Create a new entry for this network
+                target_entry = {
+                    "network_id": network_id,
+                    "filter": "none",
+                    "blocked_tld": [],
+                    "blocked_sites": [],
+                    "allowed_sites": [],
+                    "name": "",
+                    "description": "",
+                    "version": "v4",
+                }
+                dns_filters.append(target_entry)
+
+            if filter_level is not None:
+                target_entry["filter"] = filter_level
+            if blocked_sites is not None:
+                target_entry["blocked_sites"] = list(blocked_sites)
+            if allowed_sites is not None:
+                target_entry["allowed_sites"] = list(allowed_sites)
+            if blocked_tld is not None:
+                target_entry["blocked_tld"] = list(blocked_tld)
+
+            update_payload["dns_filters"] = dns_filters
+
+        if dry_run_bool:
+            logger.info(
+                sanitize_log_message("DRY RUN: Would update DNS filter settings")
+            )
+            return {
+                "status": "dry_run",
+                "settings_id": settings_id,
+                "changes": update_payload,
+            }
+
+        try:
+            put_response = await client.put(
+                f"/ea/sites/{site_id}/set/setting/ips/{settings_id}",
+                json_data=update_payload,
+            )
+        except APIError:
+            logger.exception(
+                sanitize_log_message("Failed to update DNS filter settings")
+            )
+            raise
+
+        put_items = _unwrap(put_response)
+        result = put_items[0] if put_items else {}
+
+        log_audit(
+            operation="update_dns_filter",
+            parameters={"site_id": site_id, **update_payload},
+            result="success",
+            site_id=site_id,
+        )
+
+        return {
+            "id": result.get("_id"),
+            "dns_filtering": result.get("dns_filtering"),
+            "dns_filters": result.get("dns_filters", []),
+        }

--- a/src/tools/firewall_groups.py
+++ b/src/tools/firewall_groups.py
@@ -1,0 +1,435 @@
+"""Firewall group management tools (local V1 legacy endpoint).
+
+Firewall groups are the reusable match objects that zone-based firewall
+policies and legacy firewall rules reference for ports and IP addresses.
+They live at the classic V1 internal endpoint
+``/proxy/network/api/s/{site}/rest/firewallgroup``, which the UniFi v2
+API does not replicate — so this module is **local-gateway only**. The
+API key on current UDM firmware authenticates against this legacy surface
+just like it does for the v2 firewall-policies endpoint, so no session
+login is required.
+
+Three group types exist:
+
+* ``port-group`` — ``group_members`` is a list of port strings. Individual
+  ports (``"53"``) and ranges (``"9000-9010"``) are both accepted.
+* ``address-group`` — ``group_members`` is a list of IPv4 addresses or
+  CIDR blocks.
+* ``ipv6-address-group`` — ``group_members`` is a list of IPv6 addresses
+  or CIDR blocks.
+"""
+
+from typing import Any
+
+from ..api.client import UniFiClient
+from ..config import APIType, Settings
+from ..models.firewall_group import FirewallGroup, FirewallGroupCreate
+from ..utils import (
+    APIError,
+    ResourceNotFoundError,
+    get_logger,
+    log_audit,
+    sanitize_log_message,
+)
+from ..utils.validators import coerce_bool
+
+logger = get_logger(__name__)
+
+_VALID_GROUP_TYPES = ("port-group", "address-group", "ipv6-address-group")
+
+
+def _ensure_local_api(settings: Settings) -> None:
+    """Firewall group endpoints live on the local V1 internal API only."""
+    if settings.api_type != APIType.LOCAL:
+        raise NotImplementedError(
+            "Firewall group tools require UNIFI_API_TYPE='local'. The UniFi "
+            "cloud/integration API does not expose firewall groups; they are "
+            "only reachable via the local gateway's legacy "
+            "/rest/firewallgroup endpoint."
+        )
+
+
+def _endpoint(site_id: str, group_id: str | None = None) -> str:
+    """Build an /ea/sites/... path that the client's auto-translator will
+    rewrite to /proxy/network/api/s/{site}/rest/firewallgroup/... in local
+    mode.
+    """
+    suffix = f"/{group_id}" if group_id else ""
+    return f"/ea/sites/{site_id}/rest/firewallgroup{suffix}"
+
+
+def _unwrap(response: Any) -> list[dict[str, Any]]:
+    """Extract a list of items from a `{meta, data: [...]}` response."""
+    if isinstance(response, list):
+        return [item for item in response if isinstance(item, dict)]
+    if isinstance(response, dict):
+        inner = response.get("data")
+        if isinstance(inner, list):
+            return [item for item in inner if isinstance(item, dict)]
+        if isinstance(inner, dict):
+            return [inner]
+    return []
+
+
+def _first_or_raise(response: Any, group_id: str) -> dict[str, Any]:
+    items = _unwrap(response)
+    if not items:
+        raise ResourceNotFoundError("firewall_group", group_id)
+    return items[0]
+
+
+# --------------------------------------------------------------------------- #
+# Read                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+async def list_firewall_groups(
+    site_id: str,
+    settings: Settings,
+    group_type: str | None = None,
+) -> list[dict[str, Any]]:
+    """List firewall groups on a site.
+
+    Args:
+        site_id: Site identifier
+        settings: Application settings (must be local)
+        group_type: Optional filter — ``port-group`` / ``address-group`` /
+            ``ipv6-address-group``. Pass ``None`` to list every group.
+
+    Returns:
+        List of firewall group dicts.
+    """
+    _ensure_local_api(settings)
+
+    if group_type is not None and group_type not in _VALID_GROUP_TYPES:
+        raise ValueError(
+            f"Invalid group_type '{group_type}'. Must be one of: {list(_VALID_GROUP_TYPES)}"
+        )
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(f"Listing firewall groups for site {site_id}")
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            response = await client.get(_endpoint(site_id))
+        except APIError:
+            logger.exception(
+                sanitize_log_message(
+                    f"Failed to list firewall groups for site {site_id}"
+                )
+            )
+            raise
+
+        items = _unwrap(response)
+        if group_type is not None:
+            items = [g for g in items if g.get("group_type") == group_type]
+        return [FirewallGroup(**g).model_dump(by_alias=False) for g in items]
+
+
+async def get_firewall_group(
+    group_id: str,
+    site_id: str,
+    settings: Settings,
+) -> dict[str, Any]:
+    """Get a single firewall group by id."""
+    _ensure_local_api(settings)
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(
+                f"Getting firewall group {group_id} for site {site_id}"
+            )
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            response = await client.get(_endpoint(site_id, group_id))
+        except ResourceNotFoundError as err:
+            raise ResourceNotFoundError("firewall_group", group_id) from err
+        except APIError:
+            logger.exception(
+                sanitize_log_message(
+                    f"Failed to get firewall group {group_id}"
+                )
+            )
+            raise
+
+        data = _first_or_raise(response, group_id)
+        return FirewallGroup(**data).model_dump(by_alias=False)
+
+
+# --------------------------------------------------------------------------- #
+# Create                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+async def create_firewall_group(
+    name: str,
+    group_type: str,
+    group_members: list[str],
+    site_id: str,
+    settings: Settings,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Create a new firewall group.
+
+    Args:
+        name: Display name
+        group_type: ``port-group`` / ``address-group`` / ``ipv6-address-group``
+        group_members: Members list — ports (``"53"``, ``"9000-9010"``) for
+            port-groups; IPv4 addresses / CIDR blocks for address-groups;
+            IPv6 for ipv6-address-groups.
+        site_id: Site identifier
+        settings: Application settings (must be local)
+        confirm: REQUIRED True for mutating operations
+        dry_run: Preview without applying
+    """
+    _ensure_local_api(settings)
+
+    if group_type not in _VALID_GROUP_TYPES:
+        raise ValueError(
+            f"Invalid group_type '{group_type}'. Must be one of: {list(_VALID_GROUP_TYPES)}"
+        )
+    if not isinstance(group_members, list):
+        raise ValueError("group_members must be a list of strings")
+
+    confirm_bool = coerce_bool(confirm)
+    dry_run_bool = coerce_bool(dry_run)
+    if not dry_run_bool and not confirm_bool:
+        raise ValueError(
+            "This operation requires confirm=True to execute. "
+            "Use dry_run=True to preview changes first."
+        )
+
+    create_model = FirewallGroupCreate(
+        name=name,
+        group_type=group_type,  # type: ignore[arg-type]
+        group_members=list(group_members),
+    )
+    payload = create_model.model_dump()
+
+    if dry_run_bool:
+        logger.info(
+            sanitize_log_message(f"DRY RUN: Would create firewall group '{name}'")
+        )
+        return {"status": "dry_run", "payload": payload}
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(
+                f"Creating {group_type} '{name}' for site {site_id}"
+            )
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        response = await client.post(_endpoint(site_id), json_data=payload)
+        data = _first_or_raise(response, group_id="<created>")
+
+        log_audit(
+            operation="create_firewall_group",
+            parameters={"site_id": site_id, "name": name, "group_type": group_type},
+            result="success",
+            site_id=site_id,
+        )
+        return FirewallGroup(**data).model_dump(by_alias=False)
+
+
+async def create_port_group(
+    name: str,
+    ports: list[str],
+    site_id: str,
+    settings: Settings,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Convenience wrapper to create a port-group.
+
+    ``ports`` accepts individual port strings (``"53"``) and ranges
+    (``"9000-9010"``).
+    """
+    return await create_firewall_group(
+        name=name,
+        group_type="port-group",
+        group_members=ports,
+        site_id=site_id,
+        settings=settings,
+        confirm=confirm,
+        dry_run=dry_run,
+    )
+
+
+async def create_address_group(
+    name: str,
+    addresses: list[str],
+    site_id: str,
+    settings: Settings,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Convenience wrapper to create an IPv4 address-group."""
+    return await create_firewall_group(
+        name=name,
+        group_type="address-group",
+        group_members=addresses,
+        site_id=site_id,
+        settings=settings,
+        confirm=confirm,
+        dry_run=dry_run,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Update                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+async def update_firewall_group(
+    group_id: str,
+    site_id: str,
+    settings: Settings,
+    name: str | None = None,
+    group_members: list[str] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Update a firewall group by merging overrides with the existing object.
+
+    The legacy V1 ``rest/firewallgroup`` PUT endpoint accepts partial bodies,
+    but to match the behaviour of ``update_firewall_policy`` (and to avoid
+    future API strictness regressions) this tool does a GET-merge-PUT so
+    callers can reason about the final object that will be persisted.
+
+    ``group_members`` replaces the existing members entirely when supplied.
+    """
+    _ensure_local_api(settings)
+
+    confirm_bool = coerce_bool(confirm)
+    dry_run_bool = coerce_bool(dry_run)
+    if not dry_run_bool and not confirm_bool:
+        raise ValueError(
+            "This operation requires confirm=True to execute. "
+            "Use dry_run=True to preview changes first."
+        )
+
+    overrides: dict[str, Any] = {}
+    if name is not None:
+        overrides["name"] = name
+    if group_members is not None:
+        if not isinstance(group_members, list):
+            raise ValueError("group_members must be a list of strings")
+        overrides["group_members"] = list(group_members)
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(
+                f"Updating firewall group {group_id} for site {site_id}"
+            )
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            current_response = await client.get(_endpoint(site_id, group_id))
+        except ResourceNotFoundError as err:
+            raise ResourceNotFoundError("firewall_group", group_id) from err
+
+        current = _first_or_raise(current_response, group_id)
+        merged = {**current, **overrides}
+        # Strip server-controlled fields before PUT.
+        for field in ("_id", "site_id", "external_id"):
+            merged.pop(field, None)
+
+        if dry_run_bool:
+            logger.info(
+                sanitize_log_message(
+                    f"DRY RUN: Would update firewall group {group_id}"
+                )
+            )
+            return {
+                "status": "dry_run",
+                "group_id": group_id,
+                "changes": overrides,
+                "merged_payload": merged,
+            }
+
+        try:
+            response = await client.put(
+                _endpoint(site_id, group_id), json_data=merged
+            )
+        except ResourceNotFoundError as err:
+            raise ResourceNotFoundError("firewall_group", group_id) from err
+
+        data = _first_or_raise(response, group_id)
+        log_audit(
+            operation="update_firewall_group",
+            parameters={"site_id": site_id, "group_id": group_id, **overrides},
+            result="success",
+            site_id=site_id,
+        )
+        return FirewallGroup(**data).model_dump(by_alias=False)
+
+
+# --------------------------------------------------------------------------- #
+# Delete                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+async def delete_firewall_group(
+    group_id: str,
+    site_id: str,
+    settings: Settings,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Delete a firewall group.
+
+    Warning: this tool does not verify that the group is unreferenced. If a
+    firewall policy or legacy rule references it, the UniFi controller will
+    reject the delete with an error.
+    """
+    _ensure_local_api(settings)
+
+    confirm_bool = coerce_bool(confirm)
+    dry_run_bool = coerce_bool(dry_run)
+    if not dry_run_bool and not confirm_bool:
+        raise ValueError(
+            "This operation deletes a firewall group. Pass confirm=True to proceed."
+        )
+
+    if dry_run_bool:
+        logger.info(
+            sanitize_log_message(f"DRY RUN: Would delete firewall group {group_id}")
+        )
+        return {
+            "status": "dry_run",
+            "group_id": group_id,
+            "action": "would_delete",
+        }
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(
+                f"Deleting firewall group {group_id} from site {site_id}"
+            )
+        )
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            await client.delete(_endpoint(site_id, group_id))
+        except ResourceNotFoundError as err:
+            raise ResourceNotFoundError("firewall_group", group_id) from err
+
+        log_audit(
+            operation="delete_firewall_group",
+            parameters={"site_id": site_id, "group_id": group_id},
+            result="success",
+            site_id=site_id,
+        )
+        return {"status": "success", "group_id": group_id, "action": "deleted"}

--- a/src/tools/firewall_policies.py
+++ b/src/tools/firewall_policies.py
@@ -21,6 +21,196 @@ logger = get_logger(__name__)
 _zone_cache: dict[str, dict[str, str]] = {}
 
 _VALID_IP_VERSIONS = ("IPV4", "IPV6", "BOTH")
+_VALID_PORT_MATCHING_TYPES = ("ANY", "SPECIFIC", "OBJECT")
+
+
+def _build_match_target(
+    *,
+    zone_id: str | None,
+    matching_target: str,
+    port: str | None,
+    port_group_id: str | None,
+    port_matching_type: str | None,
+    match_opposite_ports: bool | None,
+    ips: list[str] | None = None,
+    network_ids: list[str] | None = None,
+    client_macs: list[str] | None = None,
+    match_opposite_ips: bool | None = None,
+) -> dict[str, Any]:
+    """Build a source/destination match-target dict for a firewall policy.
+
+    The v2 ``firewall-policies`` endpoint stores source and destination
+    criteria as nested objects with two discriminators:
+
+    **Port matching** (``port_matching_type``):
+
+    * ``ANY`` — no port filter (default)
+    * ``SPECIFIC`` — a literal port / range in ``port``
+    * ``OBJECT`` — a reference to a firewall port-group via ``port_group_id``
+
+    **Target matching** (``matching_target`` + ``matching_target_type``):
+
+    * ``ANY`` — match everything in the zone
+    * ``IP`` — match specific IPs/CIDRs via ``ips`` list (requires
+      ``matching_target_type=SPECIFIC``, auto-set when ``ips`` is provided)
+    * ``NETWORK`` — match specific VLANs via ``network_ids``
+    * ``CLIENT`` — match specific MACs via ``client_macs``
+    * ``REGION`` — match by ISO country codes (not wired yet)
+
+    Both discriminators are auto-selected based on which fields the caller
+    provides, so callers don't have to think about the mode fields.
+    """
+    if port and port_group_id:
+        raise ValueError(
+            "Cannot specify both 'port' and 'port_group_id' on the same "
+            "match target — use one or the other."
+        )
+
+    if port_matching_type is None:
+        if port_group_id:
+            resolved_mt = "OBJECT"
+        elif port:
+            resolved_mt = "SPECIFIC"
+        else:
+            resolved_mt = "ANY"
+    else:
+        resolved_mt = port_matching_type.upper()
+        if resolved_mt not in _VALID_PORT_MATCHING_TYPES:
+            raise ValueError(
+                f"Invalid port_matching_type '{port_matching_type}'. "
+                f"Must be one of: {list(_VALID_PORT_MATCHING_TYPES)}"
+            )
+
+    # Validate consistency: an explicit SPECIFIC requires `port` and
+    # OBJECT requires `port_group_id`. Without these the API would receive
+    # an incomplete payload and reject it, so fail fast here.
+    if resolved_mt == "SPECIFIC" and not port:
+        raise ValueError(
+            "port_matching_type='SPECIFIC' requires a 'port' value "
+            "(e.g. '53' or '9000-9010')."
+        )
+    if resolved_mt == "OBJECT" and not port_group_id:
+        raise ValueError(
+            "port_matching_type='OBJECT' requires a 'port_group_id' "
+            "referencing an existing firewall port-group."
+        )
+
+    # Auto-detect matching_target from the provided lists when the caller
+    # passes the default "ANY" but also supplies ips/network_ids/client_macs.
+    resolved_matching_target = matching_target.upper()
+    if resolved_matching_target == "ANY":
+        if ips:
+            resolved_matching_target = "IP"
+        elif network_ids:
+            resolved_matching_target = "NETWORK"
+        elif client_macs:
+            resolved_matching_target = "CLIENT"
+
+    target: dict[str, Any] = {
+        "matching_target": resolved_matching_target,
+        "port_matching_type": resolved_mt,
+    }
+
+    # When matching_target is not ANY, the API requires matching_target_type.
+    if resolved_matching_target != "ANY":
+        target["matching_target_type"] = "SPECIFIC"
+
+    if zone_id:
+        target["zone_id"] = zone_id
+    if resolved_mt == "SPECIFIC":
+        target["port"] = port
+    if resolved_mt == "OBJECT":
+        target["port_group_id"] = port_group_id
+    if match_opposite_ports is not None:
+        target["match_opposite_ports"] = match_opposite_ports
+    if ips is not None:
+        target["ips"] = list(ips)
+    if network_ids is not None:
+        target["network_ids"] = list(network_ids)
+    if client_macs is not None:
+        target["client_macs"] = list(client_macs)
+    if match_opposite_ips is not None:
+        target["match_opposite_ips"] = match_opposite_ips
+    return target
+
+
+def _collect_port_overrides(
+    *,
+    port: str | None,
+    port_group_id: str | None,
+    port_matching_type: str | None,
+    match_opposite_ports: bool | None,
+) -> dict[str, Any] | None:
+    """Build the partial port-related override dict applied during update.
+
+    Returns ``None`` when the caller did not request any port-related
+    change. The result is a small dict with the keys the v2 API expects on
+    the ``source`` / ``destination`` sub-objects: ``port_matching_type``,
+    optionally ``port`` or ``port_group_id``, and optionally
+    ``match_opposite_ports``. It also clears the field that no longer
+    applies (e.g. clearing ``port`` when switching to OBJECT mode) so the
+    merged payload remains internally consistent.
+    """
+    if (
+        port is None
+        and port_group_id is None
+        and port_matching_type is None
+        and match_opposite_ports is None
+    ):
+        return None
+
+    if port and port_group_id:
+        raise ValueError(
+            "Cannot specify both 'port' and 'port_group_id' on the same "
+            "match target — use one or the other."
+        )
+
+    if port_matching_type is None:
+        if port_group_id:
+            resolved_mt: str | None = "OBJECT"
+        elif port:
+            resolved_mt = "SPECIFIC"
+        else:
+            resolved_mt = None
+    else:
+        resolved_mt = port_matching_type.upper()
+        if resolved_mt not in _VALID_PORT_MATCHING_TYPES:
+            raise ValueError(
+                f"Invalid port_matching_type '{port_matching_type}'. "
+                f"Must be one of: {list(_VALID_PORT_MATCHING_TYPES)}"
+            )
+
+    overrides: dict[str, Any] = {}
+    if resolved_mt is not None:
+        overrides["port_matching_type"] = resolved_mt
+    if port is not None:
+        overrides["port"] = port
+    if port_group_id is not None:
+        overrides["port_group_id"] = port_group_id
+    if match_opposite_ports is not None:
+        overrides["match_opposite_ports"] = match_opposite_ports
+    return overrides
+
+
+def _merge_port_overrides(
+    existing: dict[str, Any], overrides: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge port overrides into an existing source/destination sub-dict.
+
+    Clears the now-unused field when switching modes — e.g. switching from
+    SPECIFIC to OBJECT removes the stale ``port``; switching to ANY removes
+    both ``port`` and ``port_group_id``.
+    """
+    merged = {**existing, **overrides}
+    new_mode = merged.get("port_matching_type")
+    if new_mode == "ANY":
+        merged.pop("port", None)
+        merged.pop("port_group_id", None)
+    elif new_mode == "SPECIFIC":
+        merged.pop("port_group_id", None)
+    elif new_mode == "OBJECT":
+        merged.pop("port", None)
+    return merged
 
 
 def _extract_zone_list(response: Any) -> list[dict[str, Any]]:
@@ -273,10 +463,27 @@ async def create_firewall_policy(
     destination_zone_id: str | None = None,
     source_matching_target: str = "ANY",
     destination_matching_target: str = "ANY",
+    source_port: str | None = None,
+    destination_port: str | None = None,
+    source_port_group_id: str | None = None,
+    destination_port_group_id: str | None = None,
+    source_port_matching_type: str | None = None,
+    destination_port_matching_type: str | None = None,
+    source_match_opposite_ports: bool | None = None,
+    destination_match_opposite_ports: bool | None = None,
+    source_ips: list[str] | None = None,
+    destination_ips: list[str] | None = None,
+    source_network_ids: list[str] | None = None,
+    destination_network_ids: list[str] | None = None,
+    source_client_macs: list[str] | None = None,
+    destination_client_macs: list[str] | None = None,
+    source_match_opposite_ips: bool | None = None,
+    destination_match_opposite_ips: bool | None = None,
     protocol: str = "all",
     enabled: bool = True,
     description: str | None = None,
     ip_version: str = "BOTH",
+    create_allow_respond: bool | None = None,
     confirm: bool | str = False,
     dry_run: bool | str = False,
 ) -> dict[str, Any]:
@@ -297,6 +504,36 @@ async def create_firewall_policy(
             source)
         source_matching_target: ANY, IP, NETWORK, REGION, or CLIENT
         destination_matching_target: ANY, IP, NETWORK, or REGION
+        source_port: Source port — single port "53" or range "9000-9010".
+            Implies ``source_port_matching_type=SPECIFIC``.
+        destination_port: Destination port — same format as source_port.
+            Implies ``destination_port_matching_type=SPECIFIC``.
+        source_port_group_id: Reference a firewall port-group on the source
+            side. Implies ``source_port_matching_type=OBJECT``. Use the
+            ``firewall_groups`` tools to create / list port groups.
+        destination_port_group_id: Same as source_port_group_id but on the
+            destination side.
+        source_port_matching_type: Override auto-detection of port matching
+            mode (ANY/SPECIFIC/OBJECT). Usually you don't need this — pass
+            ``source_port`` or ``source_port_group_id`` and the mode is set
+            automatically.
+        destination_port_matching_type: Same as source_port_matching_type
+            but on the destination side.
+        source_match_opposite_ports: Invert the source port match (NOT)
+        destination_match_opposite_ports: Invert the destination port match
+        source_ips: List of source IPs or CIDRs (e.g. ``["10.0.100.0/24"]``).
+            Auto-sets ``source_matching_target=IP`` +
+            ``matching_target_type=SPECIFIC``.
+        destination_ips: List of destination IPs or CIDRs. Auto-sets
+            ``destination_matching_target=IP``.
+        source_network_ids: List of source network (VLAN) internal IDs.
+            Auto-sets ``source_matching_target=NETWORK``.
+        destination_network_ids: List of destination network IDs.
+        source_client_macs: List of source client MAC addresses.
+            Auto-sets ``source_matching_target=CLIENT``.
+        destination_client_macs: List of destination client MACs.
+        source_match_opposite_ips: Invert the source IP match (NOT)
+        destination_match_opposite_ips: Invert the destination IP match
         protocol: all, tcp, udp, tcp_udp, or icmpv6
         enabled: Whether policy is active
         description: Optional description
@@ -353,26 +590,58 @@ async def create_firewall_policy(
             if not client.is_authenticated:
                 await client.authenticate()
 
-            # Resolve zone identifiers to internal _ids expected by the v2 API.
-            source_config: dict[str, Any] = {
-                "matching_target": source_matching_target.upper()
-            }
-            if source_zone_id:
-                source_config["zone_id"] = await _resolve_zone_id(
-                    client, settings, site_id, source_zone_id
-                )
-
-            destination_config: dict[str, Any] = {
-                "matching_target": destination_matching_target.upper()
-            }
-            if destination_zone_id:
-                destination_config["zone_id"] = await _resolve_zone_id(
+            # Resolve zone identifiers to the internal _ids the v2 API
+            # requires (accepting zone name / external UUID / internal _id).
+            resolved_source_zone = (
+                await _resolve_zone_id(client, settings, site_id, source_zone_id)
+                if source_zone_id
+                else None
+            )
+            resolved_destination_zone = (
+                await _resolve_zone_id(
                     client, settings, site_id, destination_zone_id
                 )
+                if destination_zone_id
+                else None
+            )
+
+            source_config = _build_match_target(
+                zone_id=resolved_source_zone,
+                matching_target=source_matching_target,
+                port=source_port,
+                port_group_id=source_port_group_id,
+                port_matching_type=source_port_matching_type,
+                match_opposite_ports=source_match_opposite_ports,
+                ips=source_ips,
+                network_ids=source_network_ids,
+                client_macs=source_client_macs,
+                match_opposite_ips=source_match_opposite_ips,
+            )
+            destination_config = _build_match_target(
+                zone_id=resolved_destination_zone,
+                matching_target=destination_matching_target,
+                port=destination_port,
+                port_group_id=destination_port_group_id,
+                port_matching_type=destination_port_matching_type,
+                match_opposite_ports=destination_match_opposite_ports,
+                ips=destination_ips,
+                network_ids=destination_network_ids,
+                client_macs=destination_client_macs,
+                match_opposite_ips=destination_match_opposite_ips,
+            )
 
             # The v2 firewall-policies endpoint requires `schedule` and
             # `ip_version`; the API 400s (with an obfuscated Spring error)
             # if either is omitted. Default to an always-on rule.
+            #
+            # create_allow_respond must be False for BLOCK rules — the API
+            # rejects BLOCK + respond-traffic enabled. Auto-set when the
+            # caller doesn't specify.
+            if create_allow_respond is None:
+                resolved_allow_respond = action_upper != "BLOCK"
+            else:
+                resolved_allow_respond = create_allow_respond
+
             policy_data = FirewallPolicyCreate(
                 name=name,
                 action=action_upper,
@@ -383,6 +652,7 @@ async def create_firewall_policy(
                 destination=destination_config,
                 description=description,
                 schedule={"mode": "ALWAYS"},
+                create_allow_respond=resolved_allow_respond,
             )
 
             if dry_run_bool:
@@ -446,6 +716,25 @@ async def update_firewall_policy(
     ip_version: str | None = None,
     protocol: str | None = None,
     description: str | None = None,
+    source_zone_id: str | None = None,
+    destination_zone_id: str | None = None,
+    source_port: str | None = None,
+    destination_port: str | None = None,
+    source_port_group_id: str | None = None,
+    destination_port_group_id: str | None = None,
+    source_port_matching_type: str | None = None,
+    destination_port_matching_type: str | None = None,
+    source_match_opposite_ports: bool | None = None,
+    destination_match_opposite_ports: bool | None = None,
+    source_ips: list[str] | None = None,
+    destination_ips: list[str] | None = None,
+    source_network_ids: list[str] | None = None,
+    destination_network_ids: list[str] | None = None,
+    source_client_macs: list[str] | None = None,
+    destination_client_macs: list[str] | None = None,
+    source_match_opposite_ips: bool | None = None,
+    destination_match_opposite_ips: bool | None = None,
+    create_allow_respond: bool | None = None,
     confirm: bool | str = False,
     dry_run: bool | str = False,
 ) -> dict[str, Any]:
@@ -473,6 +762,19 @@ async def update_firewall_policy(
         ip_version: IPV4 / IPV6 / BOTH
         protocol: Transport protocol (all, tcp, udp, tcp_udp, icmpv6)
         description: Free-form description
+        source_port: Source port — single port "53" or range "9000-9010".
+            Auto-sets ``source_port_matching_type=SPECIFIC``.
+        destination_port: Destination port — same format as source_port.
+        source_port_group_id: Reference a firewall port-group on the source
+            side. Auto-sets ``source_port_matching_type=OBJECT``.
+        destination_port_group_id: Reference a firewall port-group on the
+            destination side.
+        source_port_matching_type: Override auto-detection of port matching
+            mode (ANY/SPECIFIC/OBJECT). To clear an existing port filter,
+            pass ``"ANY"`` explicitly.
+        destination_port_matching_type: Same as source_port_matching_type.
+        source_match_opposite_ports: Invert the source port match (NOT)
+        destination_match_opposite_ports: Invert the destination port match
         confirm: REQUIRED True for mutating operations
         dry_run: Preview changes without applying
 
@@ -510,7 +812,7 @@ async def update_firewall_policy(
                 f"Invalid ip_version '{ip_version}'. Must be one of: {list(_VALID_IP_VERSIONS)}"
             )
 
-    # Collect overrides so we can both preview them (dry_run) and merge them.
+    # Collect top-level overrides so we can both preview them and merge them.
     overrides: dict[str, Any] = {}
     if name is not None:
         overrides["name"] = name
@@ -526,6 +828,61 @@ async def update_firewall_policy(
         overrides["protocol"] = protocol
     if description is not None:
         overrides["description"] = description
+    if create_allow_respond is not None:
+        overrides["create_allow_respond"] = create_allow_respond
+
+    # Validate / collect port overrides; these merge into the source and
+    # destination sub-dicts inside the policy, not as top-level fields.
+    source_port_overrides: dict[str, Any] | None = _collect_port_overrides(
+        port=source_port,
+        port_group_id=source_port_group_id,
+        port_matching_type=source_port_matching_type,
+        match_opposite_ports=source_match_opposite_ports,
+    )
+    destination_port_overrides: dict[str, Any] | None = _collect_port_overrides(
+        port=destination_port,
+        port_group_id=destination_port_group_id,
+        port_matching_type=destination_port_matching_type,
+        match_opposite_ports=destination_match_opposite_ports,
+    )
+
+    # Collect zone + IP/network/client matching overrides for the source/dest
+    # sub-dicts. Zone changes go into the same sub-dict as other target
+    # matching fields.
+    source_target_overrides: dict[str, Any] = {}
+    # Note: source_zone_id resolution is deferred to inside the UniFiClient
+    # context manager where _resolve_zone_id can make API calls.
+    if source_ips is not None:
+        source_target_overrides["matching_target"] = "IP"
+        source_target_overrides["matching_target_type"] = "SPECIFIC"
+        source_target_overrides["ips"] = list(source_ips)
+    if source_network_ids is not None:
+        source_target_overrides["matching_target"] = "NETWORK"
+        source_target_overrides["matching_target_type"] = "SPECIFIC"
+        source_target_overrides["network_ids"] = list(source_network_ids)
+    if source_client_macs is not None:
+        source_target_overrides["matching_target"] = "CLIENT"
+        source_target_overrides["matching_target_type"] = "SPECIFIC"
+        source_target_overrides["client_macs"] = list(source_client_macs)
+    if source_match_opposite_ips is not None:
+        source_target_overrides["match_opposite_ips"] = source_match_opposite_ips
+
+    destination_target_overrides: dict[str, Any] = {}
+    # Note: destination_zone_id resolution also deferred to the client context.
+    if destination_ips is not None:
+        destination_target_overrides["matching_target"] = "IP"
+        destination_target_overrides["matching_target_type"] = "SPECIFIC"
+        destination_target_overrides["ips"] = list(destination_ips)
+    if destination_network_ids is not None:
+        destination_target_overrides["matching_target"] = "NETWORK"
+        destination_target_overrides["matching_target_type"] = "SPECIFIC"
+        destination_target_overrides["network_ids"] = list(destination_network_ids)
+    if destination_client_macs is not None:
+        destination_target_overrides["matching_target"] = "CLIENT"
+        destination_target_overrides["matching_target_type"] = "SPECIFIC"
+        destination_target_overrides["client_macs"] = list(destination_client_macs)
+    if destination_match_opposite_ips is not None:
+        destination_target_overrides["match_opposite_ips"] = destination_match_opposite_ips
 
     async with UniFiClient(settings) as client:
         logger.info(
@@ -536,6 +893,17 @@ async def update_firewall_policy(
 
         if not client.is_authenticated:
             await client.authenticate()
+
+        # Resolve zone identifiers to internal _ids (accepts name, UUID, or
+        # ObjectId — same flexibility as create_firewall_policy).
+        if source_zone_id is not None:
+            source_target_overrides["zone_id"] = await _resolve_zone_id(
+                client, settings, site_id, source_zone_id
+            )
+        if destination_zone_id is not None:
+            destination_target_overrides["zone_id"] = await _resolve_zone_id(
+                client, settings, site_id, destination_zone_id
+            )
 
         endpoint = f"{settings.get_v2_api_path(site_id)}/firewall-policies/{policy_id}"
 
@@ -559,6 +927,20 @@ async def update_firewall_policy(
             )
 
         merged = {**current, **overrides}
+        # Apply port and target-matching overrides to the existing source /
+        # destination sub-dicts so other fields survive.
+        if source_port_overrides or source_target_overrides:
+            src = dict(merged.get("source", {}))
+            if source_port_overrides:
+                src = _merge_port_overrides(src, source_port_overrides)
+            src.update(source_target_overrides)
+            merged["source"] = src
+        if destination_port_overrides or destination_target_overrides:
+            dst = dict(merged.get("destination", {}))
+            if destination_port_overrides:
+                dst = _merge_port_overrides(dst, destination_port_overrides)
+            dst.update(destination_target_overrides)
+            merged["destination"] = dst
         # Strip fields the API controls; sending them back causes validation errors.
         for field in ("_id", "predefined"):
             merged.pop(field, None)

--- a/src/tools/firewall_policies.py
+++ b/src/tools/firewall_policies.py
@@ -4,11 +4,42 @@ from typing import Any
 
 from ..api.client import UniFiClient
 from ..config import APIType, Settings
-from ..models.firewall_policy import FirewallPolicy, FirewallPolicyCreate
-from ..utils import ResourceNotFoundError, get_logger, log_audit, sanitize_log_message
+from ..models.firewall_policy import (
+    FirewallPolicy,
+    FirewallPolicyCreate,
+    FirewallZoneV2Mapping,
+)
+from ..utils import APIError, ResourceNotFoundError, get_logger, log_audit, sanitize_log_message
 from ..utils.validators import coerce_bool
 
 logger = get_logger(__name__)
+
+# The v2 `firewall-policies` API uses internal MongoDB ObjectIds for zone_id,
+# while the integration API (and most other MCP tools) return the public
+# UUIDs as `external_id`. This cache maps both the external UUID, zone name,
+# and zone_key to the internal ObjectId, populated on demand.
+_zone_cache: dict[str, dict[str, str]] = {}
+
+_VALID_IP_VERSIONS = ("IPV4", "IPV6", "BOTH")
+
+
+def _extract_zone_list(response: Any) -> list[dict[str, Any]]:
+    """Normalize a zone-listing response into a plain list of dicts.
+
+    Handles the three shapes ``UniFiClient`` can return:
+    - raw list (when the API response is ``{"data": [...]}``)
+    - dict with ``data`` field (may be ``None`` or another list)
+    - bare dict payload (unusual but defensively handled)
+    """
+    if isinstance(response, list):
+        return [z for z in response if isinstance(z, dict)]
+    if isinstance(response, dict):
+        inner = response.get("data")
+        if inner is None:
+            return []
+        if isinstance(inner, list):
+            return [z for z in inner if isinstance(z, dict)]
+    return []
 
 
 def _ensure_local_api(settings: Settings) -> None:
@@ -18,6 +49,117 @@ def _ensure_local_api(settings: Settings) -> None:
             "Firewall policies (v2 API) are only available when UNIFI_API_TYPE='local'. "
             "Please configure a local UniFi gateway connection to use these tools."
         )
+
+
+async def _load_zone_index(
+    client: UniFiClient, settings: Settings, site_id: str
+) -> dict[str, str]:
+    """Fetch the v2 zone list and build a name/UUID → internal-_id index."""
+    endpoint = f"{settings.get_v2_api_path(site_id)}/firewall/zone"
+    response = await client.get(endpoint)
+    zones = _extract_zone_list(response)
+
+    index: dict[str, str] = {}
+    for zone in zones:
+        internal_id = zone.get("_id")
+        if not internal_id:
+            continue
+        # Index the internal _id as itself so callers that already know the
+        # ObjectId continue to work.
+        index[internal_id] = internal_id
+        if external_id := zone.get("external_id"):
+            index[external_id] = internal_id
+        if name := zone.get("name"):
+            index[name.lower()] = internal_id
+        if zone_key := zone.get("zone_key"):
+            index[zone_key.lower()] = internal_id
+    _zone_cache[site_id] = index
+    return index
+
+
+async def _resolve_zone_id(
+    client: UniFiClient, settings: Settings, site_id: str, identifier: str
+) -> str:
+    """Resolve a zone name, external UUID, or internal ObjectId to the v2 API's
+    internal zone _id. Raises ValueError if no match."""
+    if not identifier:
+        raise ValueError("Zone identifier is required")
+    index = _zone_cache.get(site_id) or await _load_zone_index(client, settings, site_id)
+    if identifier in index:
+        return index[identifier]
+    lowered = identifier.lower()
+    if lowered in index:
+        return index[lowered]
+    # Refresh once in case the zone was created after the cache was populated.
+    index = await _load_zone_index(client, settings, site_id)
+    if identifier in index:
+        return index[identifier]
+    if lowered in index:
+        return index[lowered]
+    known_internal_ids = sorted({v for v in index.values()})
+    raise ValueError(
+        f"Could not resolve firewall zone '{identifier}'. Pass a zone name "
+        f"(e.g. 'Internal'), external UUID, or internal _id. "
+        f"Known internal zone ids: {known_internal_ids}"
+    )
+
+
+async def list_firewall_zones_v2(
+    site_id: str,
+    settings: Settings,
+) -> list[dict[str, Any]]:
+    """List firewall zones from the v2 API with internal + external IDs.
+
+    The v2 ``firewall-policies`` endpoint uses internal MongoDB ObjectIds for
+    zone_id, not the public integration API UUIDs. This tool returns the
+    mapping so callers can hand either identifier (or the zone name) to
+    ``create_firewall_policy`` / ``update_firewall_policy``.
+
+    Args:
+        site_id: Site identifier
+        settings: Application settings
+
+    Returns:
+        List of :class:`FirewallZoneV2Mapping` dicts.
+
+    Raises:
+        NotImplementedError: When using cloud API
+        APIError: When the API request fails
+    """
+    _ensure_local_api(settings)
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(f"Listing v2 firewall zones for site {site_id}")
+        )
+
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        endpoint = f"{settings.get_v2_api_path(site_id)}/firewall/zone"
+        try:
+            response = await client.get(endpoint)
+        except APIError:
+            logger.exception(
+                sanitize_log_message(
+                    f"Failed to list v2 firewall zones for site {site_id}"
+                )
+            )
+            raise
+
+        zones = _extract_zone_list(response)
+
+        return [
+            FirewallZoneV2Mapping(
+                internal_id=z.get("_id"),
+                external_id=z.get("external_id"),
+                name=z.get("name"),
+                zone_key=z.get("zone_key"),
+                default_zone=z.get("default_zone") or False,
+                network_ids=z.get("network_ids") or [],
+            ).model_dump()
+            for z in zones
+        ]
 
 
 async def list_firewall_policies(
@@ -134,6 +276,7 @@ async def create_firewall_policy(
     protocol: str = "all",
     enabled: bool = True,
     description: str | None = None,
+    ip_version: str = "BOTH",
     confirm: bool | str = False,
     dry_run: bool | str = False,
 ) -> dict[str, Any]:
@@ -147,13 +290,17 @@ async def create_firewall_policy(
         action: ALLOW or BLOCK
         site_id: Site identifier
         settings: Application settings
-        source_zone_id: Source zone ID
-        destination_zone_id: Destination zone ID
+        source_zone_id: Source zone — accepts a zone name (e.g. "Internal"),
+            public integration-API UUID, or internal ObjectId. All forms are
+            resolved to the v2 API's internal zone _id automatically.
+        destination_zone_id: Destination zone (same identifier flexibility as
+            source)
         source_matching_target: ANY, IP, NETWORK, REGION, or CLIENT
         destination_matching_target: ANY, IP, NETWORK, or REGION
         protocol: all, tcp, udp, tcp_udp, or icmpv6
         enabled: Whether policy is active
         description: Optional description
+        ip_version: IPV4, IPV6, or BOTH (required by API; defaults to BOTH)
         confirm: REQUIRED True for mutating operations
         dry_run: Preview changes without applying
 
@@ -161,7 +308,8 @@ async def create_firewall_policy(
         Created firewall policy object or dry-run preview
 
     Raises:
-        ValueError: If confirm not True or invalid action
+        ValueError: If confirm not True, invalid action, or zone cannot be
+            resolved.
         NotImplementedError: When using cloud API
     """
     _ensure_local_api(settings)
@@ -171,51 +319,32 @@ async def create_firewall_policy(
     if action_upper not in valid_actions:
         raise ValueError(f"Invalid action '{action}'. Must be one of: {valid_actions}")
 
-    source_config: dict[str, Any] = {"matching_target": source_matching_target.upper()}
-    if source_zone_id:
-        source_config["zone_id"] = source_zone_id
+    ip_version_upper = ip_version.upper()
+    if ip_version_upper not in _VALID_IP_VERSIONS:
+        raise ValueError(
+            f"Invalid ip_version '{ip_version}'. Must be one of: {list(_VALID_IP_VERSIONS)}"
+        )
 
-    destination_config: dict[str, Any] = {"matching_target": destination_matching_target.upper()}
-    if destination_zone_id:
-        destination_config["zone_id"] = destination_zone_id
+    # Coerce string inputs ("true"/"false") to real booleans — MCP clients
+    # may serialise these flags as strings and plain truthiness would treat
+    # "False" as True, bypassing the confirmation gate entirely.
+    confirm_bool = coerce_bool(confirm)
+    dry_run_bool = coerce_bool(dry_run)
 
-    policy_data = FirewallPolicyCreate(
-        name=name,
-        action=action_upper,
-        enabled=enabled,
-        protocol=protocol,
-        source=source_config,
-        destination=destination_config,
-        description=description,
-    )
+    if not dry_run_bool and not confirm_bool:
+        raise ValueError(
+            "This operation requires confirm=True to execute. "
+            "Use dry_run=True to preview changes first."
+        )
 
     parameters = {
         "site_id": site_id,
         "name": name,
         "action": action_upper,
         "enabled": enabled,
+        "source_zone_id": source_zone_id,
+        "destination_zone_id": destination_zone_id,
     }
-
-    if dry_run:
-        logger.info(sanitize_log_message(f"DRY RUN: Would create firewall policy '{name}' in site '{site_id}'"))
-        log_audit(
-            operation="create_firewall_policy",
-            parameters=parameters,
-            result="dry_run",
-            site_id=site_id,
-            dry_run=True,
-        )
-        return {
-            "status": "dry_run",
-            "message": f"Would create firewall policy '{name}'",
-            "policy": policy_data.model_dump(exclude_none=True),
-        }
-
-    if not confirm:
-        raise ValueError(
-            "This operation requires confirm=True to execute. "
-            "Use dry_run=True to preview changes first."
-        )
 
     try:
         async with UniFiClient(settings) as client:
@@ -223,6 +352,57 @@ async def create_firewall_policy(
 
             if not client.is_authenticated:
                 await client.authenticate()
+
+            # Resolve zone identifiers to internal _ids expected by the v2 API.
+            source_config: dict[str, Any] = {
+                "matching_target": source_matching_target.upper()
+            }
+            if source_zone_id:
+                source_config["zone_id"] = await _resolve_zone_id(
+                    client, settings, site_id, source_zone_id
+                )
+
+            destination_config: dict[str, Any] = {
+                "matching_target": destination_matching_target.upper()
+            }
+            if destination_zone_id:
+                destination_config["zone_id"] = await _resolve_zone_id(
+                    client, settings, site_id, destination_zone_id
+                )
+
+            # The v2 firewall-policies endpoint requires `schedule` and
+            # `ip_version`; the API 400s (with an obfuscated Spring error)
+            # if either is omitted. Default to an always-on rule.
+            policy_data = FirewallPolicyCreate(
+                name=name,
+                action=action_upper,
+                enabled=enabled,
+                protocol=protocol,
+                ip_version=ip_version_upper,
+                source=source_config,
+                destination=destination_config,
+                description=description,
+                schedule={"mode": "ALWAYS"},
+            )
+
+            if dry_run_bool:
+                logger.info(
+                    sanitize_log_message(
+                        f"DRY RUN: Would create firewall policy '{name}' in site '{site_id}'"
+                    )
+                )
+                log_audit(
+                    operation="create_firewall_policy",
+                    parameters=parameters,
+                    result="dry_run",
+                    site_id=site_id,
+                    dry_run=True,
+                )
+                return {
+                    "status": "dry_run",
+                    "message": f"Would create firewall policy '{name}'",
+                    "policy": policy_data.model_dump(exclude_none=True),
+                }
 
             endpoint = f"{settings.get_v2_api_path(site_id)}/firewall-policies"
             response = await client.post(
@@ -262,20 +442,37 @@ async def update_firewall_policy(
     name: str | None = None,
     action: str | None = None,
     enabled: bool | None = None,
+    logging: bool | None = None,
+    ip_version: str | None = None,
+    protocol: str | None = None,
+    description: str | None = None,
     confirm: bool | str = False,
     dry_run: bool | str = False,
 ) -> dict[str, Any]:
     """Update an existing firewall policy.
 
-    Only provided fields are updated (partial update).
+    The v2 ``firewall-policies`` PUT endpoint requires the **full** policy
+    object — a partial payload like ``{"logging": true}`` is rejected with
+    ``Validation failed ... field 'action': rejected value [null]``. To
+    support partial updates from the caller's perspective, this tool
+    fetches the existing policy, merges in the provided field overrides,
+    strips ``_id`` / ``predefined`` (which the API controls), and PUTs the
+    merged object back.
 
     Args:
         policy_id: ID of policy to update
         site_id: Site identifier
         settings: Application settings
-        name: New policy name (optional)
-        action: New action ALLOW/BLOCK (optional)
-        enabled: Enable/disable (optional)
+        name: New policy name
+        action: New action ALLOW/BLOCK
+        enabled: Enable/disable the policy
+        logging: Toggle firewall rule logging. Forces CPU inspection of the
+            matched flows, which makes them visible in the v2 traffic-flows
+            endpoint (default-allowed inter-VLAN traffic is normally
+            hardware-offloaded and never reaches the flow table).
+        ip_version: IPV4 / IPV6 / BOTH
+        protocol: Transport protocol (all, tcp, udp, tcp_udp, icmpv6)
+        description: Free-form description
         confirm: REQUIRED True for mutating operations
         dry_run: Preview changes without applying
 
@@ -284,59 +481,114 @@ async def update_firewall_policy(
 
     Raises:
         NotImplementedError: When using cloud API (v2 endpoints require local access)
-        ValueError: If confirmation not provided
+        ValueError: If confirmation not provided or an invalid value is supplied
         ResourceNotFoundError: If policy not found
     """
     _ensure_local_api(settings)
 
-    if not coerce_bool(dry_run) and not coerce_bool(confirm):
+    confirm_bool = coerce_bool(confirm)
+    dry_run_bool = coerce_bool(dry_run)
+
+    if not dry_run_bool and not confirm_bool:
         raise ValueError(
             "This operation requires confirm=True to execute. "
             "Use dry_run=True to preview changes first."
         )
 
-    # Build update payload with only provided fields
-    update_data: dict[str, Any] = {}
-    if name is not None:
-        update_data["name"] = name
+    # Validate overrides up-front so we fail fast before hitting the API.
+    action_upper: str | None = None
     if action is not None:
         action_upper = action.upper()
-        if action_upper not in ["ALLOW", "BLOCK"]:
+        if action_upper not in ("ALLOW", "BLOCK"):
             raise ValueError(f"Invalid action '{action}'. Must be ALLOW or BLOCK.")
-        update_data["action"] = action_upper
-    if enabled is not None:
-        update_data["enabled"] = enabled
 
-    if dry_run:
-        logger.info(sanitize_log_message(f"DRY RUN: Would update firewall policy {policy_id}"))
-        return {
-            "status": "dry_run",
-            "policy_id": policy_id,
-            "changes": update_data,
-        }
+    ip_version_upper: str | None = None
+    if ip_version is not None:
+        ip_version_upper = ip_version.upper()
+        if ip_version_upper not in _VALID_IP_VERSIONS:
+            raise ValueError(
+                f"Invalid ip_version '{ip_version}'. Must be one of: {list(_VALID_IP_VERSIONS)}"
+            )
+
+    # Collect overrides so we can both preview them (dry_run) and merge them.
+    overrides: dict[str, Any] = {}
+    if name is not None:
+        overrides["name"] = name
+    if action_upper is not None:
+        overrides["action"] = action_upper
+    if enabled is not None:
+        overrides["enabled"] = enabled
+    if logging is not None:
+        overrides["logging"] = logging
+    if ip_version_upper is not None:
+        overrides["ip_version"] = ip_version_upper
+    if protocol is not None:
+        overrides["protocol"] = protocol
+    if description is not None:
+        overrides["description"] = description
 
     async with UniFiClient(settings) as client:
-        logger.info(sanitize_log_message(f"Updating firewall policy {policy_id} for site {site_id}"))
+        logger.info(
+            sanitize_log_message(
+                f"Updating firewall policy {policy_id} for site {site_id}"
+            )
+        )
 
         if not client.is_authenticated:
             await client.authenticate()
 
         endpoint = f"{settings.get_v2_api_path(site_id)}/firewall-policies/{policy_id}"
 
+        # Fetch the existing policy so we can merge + PUT the full object.
         try:
-            response = await client.put(endpoint, json_data=update_data)
+            current_response = await client.get(endpoint)
         except ResourceNotFoundError as err:
             raise ResourceNotFoundError("firewall_policy", policy_id) from err
 
-        if isinstance(response, dict) and "data" in response:
-            data = response["data"]
-        else:
-            data = response
+        current = (
+            current_response.get("data", current_response)
+            if isinstance(current_response, dict)
+            else current_response
+        )
+        if not current or not isinstance(current, dict):
+            raise ResourceNotFoundError("firewall_policy", policy_id)
+
+        if current.get("predefined"):
+            raise ValueError(
+                f"Cannot update predefined system rule '{current.get('name', policy_id)}'."
+            )
+
+        merged = {**current, **overrides}
+        # Strip fields the API controls; sending them back causes validation errors.
+        for field in ("_id", "predefined"):
+            merged.pop(field, None)
+
+        if dry_run_bool:
+            logger.info(
+                sanitize_log_message(
+                    f"DRY RUN: Would update firewall policy {policy_id}"
+                )
+            )
+            return {
+                "status": "dry_run",
+                "policy_id": policy_id,
+                "changes": overrides,
+                "merged_payload": merged,
+            }
+
+        try:
+            response = await client.put(endpoint, json_data=merged)
+        except ResourceNotFoundError as err:
+            raise ResourceNotFoundError("firewall_policy", policy_id) from err
+
+        data = (
+            response.get("data", response) if isinstance(response, dict) else response
+        )
 
         logger.info(sanitize_log_message(f"Updated firewall policy {policy_id}"))
         log_audit(
             operation="update_firewall_policy",
-            parameters={"policy_id": policy_id, "site_id": site_id, **update_data},
+            parameters={"policy_id": policy_id, "site_id": site_id, **overrides},
             result="success",
             site_id=site_id,
         )

--- a/src/tools/firewall_zones.py
+++ b/src/tools/firewall_zones.py
@@ -1,5 +1,6 @@
 """Firewall zone management tools."""
 
+import re
 from typing import Any
 
 from ..api.client import UniFiClient
@@ -14,6 +15,54 @@ from ..utils import (
 )
 
 logger = get_logger(__name__)
+
+_UUID_RE = re.compile(
+    r"^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+)
+
+
+async def _resolve_network_uuid(
+    client: UniFiClient, settings: Settings, site_id: str, identifier: str
+) -> str:
+    """Resolve a network identifier to the integration-API UUID format.
+
+    The integration API ``/firewall/zones`` PUT requires network IDs in UUID
+    format (``xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx``). But callers may pass
+    a MongoDB ObjectId from the v2/legacy API. This helper:
+
+    1. Returns ``identifier`` as-is if it's already a valid UUID.
+    2. Otherwise searches the legacy ``/rest/networkconf`` endpoint for a
+       matching ``_id`` and returns its ``external_id`` (the UUID).
+    """
+    if _UUID_RE.match(identifier.lower()):
+        return identifier
+
+    # ObjectId — resolve via legacy networkconf
+    try:
+        response = await client.get(f"/ea/sites/{site_id}/rest/networkconf")
+        items = response if isinstance(response, list) else response.get("data", [])
+        for n in items:
+            if isinstance(n, dict) and n.get("_id") == identifier:
+                ext = n.get("external_id")
+                if ext:
+                    logger.debug(
+                        sanitize_log_message(
+                            f"Resolved network ObjectId {identifier} → UUID {ext}"
+                        )
+                    )
+                    return ext
+    except Exception:
+        logger.debug(
+            sanitize_log_message(
+                f"Failed to resolve network ObjectId {identifier} via legacy API"
+            )
+        )
+
+    raise ValueError(
+        f"Could not resolve network '{identifier}' to an integration-API UUID. "
+        "Pass the UUID from the integration /networks endpoint, or a MongoDB "
+        "ObjectId that has an external_id mapping in /rest/networkconf."
+    )
 
 
 def _ensure_local_api(settings: Settings) -> None:
@@ -240,35 +289,47 @@ async def assign_network_to_zone(
 
         resolved_site_id = await client.resolve_site_id(site_id)
 
+        # The integration API PUT requires UUIDs in networkIds. Resolve
+        # ObjectIds to UUIDs if needed (the user may pass either format).
+        resolved_network_id = await _resolve_network_uuid(
+            client, settings, resolved_site_id, network_id
+        )
+
         # Get network name
         network_name = None
         try:
             network_response = await client.get(
-                settings.get_integration_path(f"sites/{resolved_site_id}/networks/{network_id}")
+                settings.get_integration_path(f"sites/{resolved_site_id}/networks/{resolved_network_id}")
             )
-            network_data = network_response.get("data", {})
+            network_data = network_response.get("data", network_response) if isinstance(network_response, dict) else {}
             network_name = network_data.get("name")
         except Exception:
-            logger.warning(sanitize_log_message(f"Could not fetch network name for {network_id}"))
+            logger.warning(sanitize_log_message(f"Could not fetch network name for {resolved_network_id}"))
 
         # Update zone to include this network
         zone_response = await client.get(
             settings.get_integration_path(f"sites/{resolved_site_id}/firewall/zones/{zone_id}")
         )
-        zone_data = zone_response.get("data", {})
+        # The integration API returns the zone object directly (no "data"
+        # wrapper), so fall back to zone_response itself when "data" is absent.
+        zone_data = zone_response.get("data", zone_response) if isinstance(zone_response, dict) else zone_response
         current_networks = zone_data.get("networkIds", [])
+        zone_name = zone_data.get("name")
 
-        if network_id in current_networks:
-            logger.info(sanitize_log_message(f"Network {network_id} already assigned to zone {zone_id}"))
+        if resolved_network_id in current_networks:
+            logger.info(sanitize_log_message(f"Network {resolved_network_id} already assigned to zone {zone_id}"))
             return ZoneNetworkAssignment(  # type: ignore[no-any-return]
                 zone_id=zone_id,
-                network_id=network_id,
+                network_id=resolved_network_id,
                 network_name=network_name,
             ).model_dump()
 
-        updated_networks = list(current_networks) + [network_id]
+        updated_networks = list(current_networks) + [resolved_network_id]
 
-        payload = {"networkIds": updated_networks}
+        # The integration API PUT requires both networkIds AND name.
+        payload: dict[str, Any] = {"networkIds": updated_networks}
+        if zone_name is not None:
+            payload["name"] = zone_name
 
         if dry_run:
             logger.info(sanitize_log_message(f"[DRY RUN] Would assign network {network_id} to zone {zone_id}"))
@@ -284,14 +345,14 @@ async def assign_network_to_zone(
             settings,
             action_type="assign_network_to_zone",
             resource_type="zone_network_assignment",
-            resource_id=network_id,
+            resource_id=resolved_network_id,
             site_id=site_id,
-            details={"zone_id": zone_id, "network_id": network_id},
+            details={"zone_id": zone_id, "network_id": resolved_network_id},
         )
 
         return ZoneNetworkAssignment(  # type: ignore[no-any-return]
             zone_id=zone_id,
-            network_id=network_id,
+            network_id=resolved_network_id,
             network_name=network_name,
         ).model_dump()
 
@@ -320,7 +381,7 @@ async def get_zone_networks(site_id: str, zone_id: str, settings: Settings) -> l
         response = await client.get(
             settings.get_integration_path(f"sites/{resolved_site_id}/firewall/zones/{zone_id}")
         )
-        zone_data = response.get("data", {})
+        zone_data = response.get("data", response) if isinstance(response, dict) else response
         network_ids = zone_data.get("networkIds", [])
 
         # Fetch network details for each network ID
@@ -444,8 +505,9 @@ async def unassign_network_from_zone(
         zone_response = await client.get(
             settings.get_integration_path(f"sites/{resolved_site_id}/firewall/zones/{zone_id}")
         )
-        zone_data = zone_response.get("data", {})
+        zone_data = zone_response.get("data", zone_response) if isinstance(zone_response, dict) else zone_response
         current_networks = zone_data.get("networkIds", [])
+        zone_name = zone_data.get("name")
 
         if network_id not in current_networks:
             raise ValueError(f"Network {network_id} is not assigned to zone {zone_id}")
@@ -453,7 +515,9 @@ async def unassign_network_from_zone(
         # Remove network from list
         updated_networks = [nid for nid in current_networks if nid != network_id]
 
-        payload = {"networkIds": updated_networks}
+        payload: dict[str, Any] = {"networkIds": updated_networks}
+        if zone_name is not None:
+            payload["name"] = zone_name
 
         if dry_run:
             logger.info(sanitize_log_message(f"[DRY RUN] Would remove network {network_id} from zone {zone_id}"))

--- a/tests/unit/tools/test_dhcp_reservations_tools.py
+++ b/tests/unit/tools/test_dhcp_reservations_tools.py
@@ -1,0 +1,326 @@
+"""Unit tests for DHCP reservation tools."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.config import APIType
+from src.tools import dhcp_reservations as dhcp
+from src.utils.exceptions import ResourceNotFoundError
+
+
+@pytest.fixture
+def local_settings() -> MagicMock:
+    settings = MagicMock()
+    settings.api_type = APIType.LOCAL
+    settings.api_key = "test-key"
+    settings.log_level = "INFO"
+    return settings
+
+
+@pytest.fixture
+def cloud_settings() -> MagicMock:
+    settings = MagicMock()
+    settings.api_type = APIType.CLOUD_EA
+    settings.api_key = "test-key"
+    settings.log_level = "INFO"
+    return settings
+
+
+@pytest.fixture
+def sample_users() -> list[dict[str, Any]]:
+    return [
+        {
+            "_id": "user-1",
+            "mac": "aa:bb:cc:dd:ee:01",
+            "name": "Camera 1",
+            "hostname": "cam-1",
+            "use_fixedip": True,
+            "fixed_ip": "192.168.30.10",
+            "network_id": "net-cameras",
+            "local_dns_record": "cam1.local",
+            "local_dns_record_enabled": True,
+        },
+        {
+            "_id": "user-2",
+            "mac": "aa:bb:cc:dd:ee:02",
+            "name": "Laptop",
+            "hostname": "laptop",
+            "use_fixedip": False,
+        },
+        {
+            "_id": "user-3",
+            "mac": "aa:bb:cc:dd:ee:03",
+            "name": "Server",
+            "use_fixedip": True,
+            "fixed_ip": "192.168.40.10",
+            "network_id": "net-servers",
+            "local_dns_record": "",
+            "local_dns_record_enabled": False,
+        },
+    ]
+
+
+def _mock_client(get_response: Any = None) -> AsyncMock:
+    client = AsyncMock()
+    client.is_authenticated = True
+    client.authenticate = AsyncMock()
+    client.get = AsyncMock(return_value=get_response)
+    client.post = AsyncMock()
+    client.put = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+class TestLocalApiGate:
+    @pytest.mark.asyncio
+    async def test_cloud_mode_raises(self, cloud_settings: MagicMock) -> None:
+        with pytest.raises(NotImplementedError, match="UNIFI_API_TYPE='local'"):
+            await dhcp.list_dhcp_reservations("default", cloud_settings)
+
+
+class TestListDhcpReservations:
+    @pytest.mark.asyncio
+    async def test_lists_only_fixed_ip_users(
+        self, local_settings: MagicMock, sample_users: list[dict[str, Any]]
+    ) -> None:
+        client = _mock_client({"data": sample_users})
+        with patch("src.tools.dhcp_reservations.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await dhcp.list_dhcp_reservations("default", local_settings)
+
+        assert len(result) == 2
+        macs = {r["mac"] for r in result}
+        assert macs == {"aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:03"}
+
+    @pytest.mark.asyncio
+    async def test_filter_by_network_id(
+        self, local_settings: MagicMock, sample_users: list[dict[str, Any]]
+    ) -> None:
+        client = _mock_client({"data": sample_users})
+        with patch("src.tools.dhcp_reservations.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await dhcp.list_dhcp_reservations(
+                "default", local_settings, network_id="net-cameras"
+            )
+
+        assert len(result) == 1
+        assert result[0]["mac"] == "aa:bb:cc:dd:ee:01"
+
+
+class TestGetDhcpReservation:
+    @pytest.mark.asyncio
+    async def test_found(
+        self, local_settings: MagicMock, sample_users: list[dict[str, Any]]
+    ) -> None:
+        client = _mock_client({"data": sample_users})
+        with patch("src.tools.dhcp_reservations.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await dhcp.get_dhcp_reservation(
+                "aa:bb:cc:dd:ee:01", "default", local_settings
+            )
+
+        assert result["fixed_ip"] == "192.168.30.10"
+        assert result["name"] == "Camera 1"
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises(
+        self, local_settings: MagicMock, sample_users: list[dict[str, Any]]
+    ) -> None:
+        client = _mock_client({"data": sample_users})
+        with patch("src.tools.dhcp_reservations.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            with pytest.raises(ResourceNotFoundError):
+                await dhcp.get_dhcp_reservation(
+                    "ff:ff:ff:ff:ff:ff", "default", local_settings
+                )
+
+    @pytest.mark.asyncio
+    async def test_non_fixed_ip_user_not_found(
+        self, local_settings: MagicMock, sample_users: list[dict[str, Any]]
+    ) -> None:
+        """user-2 exists but has use_fixedip=False — should not match."""
+        client = _mock_client({"data": sample_users})
+        with patch("src.tools.dhcp_reservations.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            with pytest.raises(ResourceNotFoundError):
+                await dhcp.get_dhcp_reservation(
+                    "aa:bb:cc:dd:ee:02", "default", local_settings
+                )
+
+
+class TestCreateDhcpReservation:
+    @pytest.mark.asyncio
+    async def test_create_success(self, local_settings: MagicMock) -> None:
+        created = {
+            "_id": "new-1",
+            "mac": "11:22:33:44:55:66",
+            "name": "New Device",
+            "use_fixedip": True,
+            "fixed_ip": "192.168.10.200",
+            "network_id": "net-lan",
+        }
+        client = _mock_client()
+        client.post.return_value = {"data": [created]}
+
+        with patch("src.tools.dhcp_reservations.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await dhcp.create_dhcp_reservation(
+                mac="11:22:33:44:55:66",
+                fixed_ip="192.168.10.200",
+                network_id="net-lan",
+                site_id="default",
+                settings=local_settings,
+                name="New Device",
+                confirm=True,
+            )
+
+        assert result["fixed_ip"] == "192.168.10.200"
+        assert result["mac"] == "11:22:33:44:55:66"
+        post_body = client.post.call_args.kwargs["json_data"]
+        assert post_body["use_fixedip"] is True
+        assert post_body["fixed_ip"] == "192.168.10.200"
+        assert post_body["network_id"] == "net-lan"
+
+    @pytest.mark.asyncio
+    async def test_create_dry_run(self, local_settings: MagicMock) -> None:
+        with patch("src.tools.dhcp_reservations.UniFiClient") as MockClient:
+            MockClient.return_value = _mock_client()
+            result = await dhcp.create_dhcp_reservation(
+                mac="11:22:33:44:55:66",
+                fixed_ip="192.168.10.200",
+                network_id="net-lan",
+                site_id="default",
+                settings=local_settings,
+                confirm=True,
+                dry_run=True,
+            )
+
+        assert result["status"] == "dry_run"
+        assert result["payload"]["fixed_ip"] == "192.168.10.200"
+
+    @pytest.mark.asyncio
+    async def test_create_without_confirm_raises(
+        self, local_settings: MagicMock
+    ) -> None:
+        with pytest.raises(ValueError, match="confirm=True"):
+            await dhcp.create_dhcp_reservation(
+                mac="11:22:33:44:55:66",
+                fixed_ip="192.168.10.200",
+                network_id="net-lan",
+                site_id="default",
+                settings=local_settings,
+                confirm=False,
+            )
+
+
+class TestUpdateDhcpReservation:
+    @pytest.mark.asyncio
+    async def test_update_ip(
+        self, local_settings: MagicMock, sample_users: list[dict[str, Any]]
+    ) -> None:
+        updated = {**sample_users[0], "fixed_ip": "192.168.30.99"}
+        client = _mock_client({"data": sample_users})
+        client.put.return_value = {"data": [updated]}
+
+        with patch("src.tools.dhcp_reservations.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await dhcp.update_dhcp_reservation(
+                mac="aa:bb:cc:dd:ee:01",
+                site_id="default",
+                settings=local_settings,
+                fixed_ip="192.168.30.99",
+                confirm=True,
+            )
+
+        assert result["fixed_ip"] == "192.168.30.99"
+        put_body = client.put.call_args.kwargs["json_data"]
+        assert put_body == {"fixed_ip": "192.168.30.99"}
+
+    @pytest.mark.asyncio
+    async def test_update_unknown_mac_raises(
+        self, local_settings: MagicMock, sample_users: list[dict[str, Any]]
+    ) -> None:
+        client = _mock_client({"data": sample_users})
+        with patch("src.tools.dhcp_reservations.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            with pytest.raises(ResourceNotFoundError):
+                await dhcp.update_dhcp_reservation(
+                    mac="ff:ff:ff:ff:ff:ff",
+                    site_id="default",
+                    settings=local_settings,
+                    fixed_ip="192.168.10.1",
+                    confirm=True,
+                )
+
+
+class TestRemoveDhcpReservation:
+    @pytest.mark.asyncio
+    async def test_clear_reservation_keeps_client(
+        self, local_settings: MagicMock, sample_users: list[dict[str, Any]]
+    ) -> None:
+        client = _mock_client({"data": sample_users})
+        client.put.return_value = {"data": [{**sample_users[0], "use_fixedip": False}]}
+
+        with patch("src.tools.dhcp_reservations.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await dhcp.remove_dhcp_reservation(
+                mac="aa:bb:cc:dd:ee:01",
+                site_id="default",
+                settings=local_settings,
+                confirm=True,
+            )
+
+        assert result["action"] == "reservation_cleared"
+        put_body = client.put.call_args.kwargs["json_data"]
+        assert put_body == {"use_fixedip": False}
+
+    @pytest.mark.asyncio
+    async def test_forget_client_entirely(
+        self, local_settings: MagicMock
+    ) -> None:
+        client = _mock_client()
+        client.post.return_value = {"data": []}
+
+        with patch("src.tools.dhcp_reservations.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await dhcp.remove_dhcp_reservation(
+                mac="aa:bb:cc:dd:ee:01",
+                site_id="default",
+                settings=local_settings,
+                forget_client=True,
+                confirm=True,
+            )
+
+        assert result["action"] == "forgotten"
+        post_body = client.post.call_args.kwargs["json_data"]
+        assert post_body == {"cmd": "forget-sta", "macs": ["aa:bb:cc:dd:ee:01"]}
+
+    @pytest.mark.asyncio
+    async def test_dry_run(self, local_settings: MagicMock) -> None:
+        result = await dhcp.remove_dhcp_reservation(
+            mac="aa:bb:cc:dd:ee:01",
+            site_id="default",
+            settings=local_settings,
+            confirm=True,
+            dry_run=True,
+        )
+        assert result["status"] == "dry_run"
+        assert result["action"] == "clear_fixed_ip"
+
+    @pytest.mark.asyncio
+    async def test_dry_run_forget(self, local_settings: MagicMock) -> None:
+        result = await dhcp.remove_dhcp_reservation(
+            mac="aa:bb:cc:dd:ee:01",
+            site_id="default",
+            settings=local_settings,
+            forget_client=True,
+            confirm=True,
+            dry_run=True,
+        )
+        assert result["status"] == "dry_run"
+        assert result["action"] == "forget_client"

--- a/tests/unit/tools/test_firewall_groups_tools.py
+++ b/tests/unit/tools/test_firewall_groups_tools.py
@@ -1,0 +1,419 @@
+"""Unit tests for firewall_groups tools.
+
+These exercise the legacy V1 internal endpoint
+``/proxy/network/api/s/{site}/rest/firewallgroup`` (auto-translated by the
+client from the ``/ea/sites/{site}/rest/firewallgroup`` shape used here).
+The endpoint accepts an ``X-API-Key`` header on current UDM firmware, so
+no session login is required, but it is local-gateway only — every tool
+in the module is gated with ``_ensure_local_api``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.config import APIType, Settings
+from src.tools import firewall_groups as fg
+from src.utils.exceptions import ResourceNotFoundError
+
+
+@pytest.fixture
+def local_settings() -> MagicMock:
+    settings = MagicMock(spec=Settings)
+    settings.api_type = APIType.LOCAL
+    settings.api_key = "test-api-key"
+    settings.local_host = "192.0.2.1"
+    settings.log_level = "INFO"
+    return settings
+
+
+@pytest.fixture
+def cloud_settings() -> MagicMock:
+    settings = MagicMock(spec=Settings)
+    settings.api_type = APIType.CLOUD_EA
+    settings.api_key = "test-api-key"
+    settings.log_level = "INFO"
+    return settings
+
+
+@pytest.fixture
+def sample_groups() -> list[dict[str, Any]]:
+    """Three firewall groups across the three group types."""
+    return [
+        {
+            "_id": "group-port-1",
+            "name": "HomeKit-HAP",
+            "group_type": "port-group",
+            "group_members": ["8080", "9000-9010"],
+            "site_id": "site-1",
+            "external_id": "external-1",
+        },
+        {
+            "_id": "group-addr-1",
+            "name": "Trusted Subnets",
+            "group_type": "address-group",
+            "group_members": ["10.0.0.0/8", "192.168.50.0/24"],
+            "site_id": "site-1",
+            "external_id": "external-2",
+        },
+        {
+            "_id": "group-port-2",
+            "name": "RTSP-Streams",
+            "group_type": "port-group",
+            "group_members": ["554", "8554"],
+            "site_id": "site-1",
+            "external_id": "external-3",
+        },
+    ]
+
+
+def _mock_client(get_response: Any = None) -> AsyncMock:
+    client = AsyncMock()
+    client.is_authenticated = True
+    client.authenticate = AsyncMock()
+    client.get = AsyncMock(return_value=get_response)
+    client.post = AsyncMock()
+    client.put = AsyncMock()
+    client.delete = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+# --------------------------------------------------------------------------- #
+# Local-API gate                                                              #
+# --------------------------------------------------------------------------- #
+
+
+class TestLocalApiGate:
+    @pytest.mark.asyncio
+    async def test_list_rejects_cloud(self, cloud_settings: MagicMock) -> None:
+        with pytest.raises(NotImplementedError, match="UNIFI_API_TYPE='local'"):
+            await fg.list_firewall_groups("default", cloud_settings)
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_cloud(self, cloud_settings: MagicMock) -> None:
+        with pytest.raises(NotImplementedError, match="UNIFI_API_TYPE='local'"):
+            await fg.create_firewall_group(
+                name="x",
+                group_type="port-group",
+                group_members=["80"],
+                site_id="default",
+                settings=cloud_settings,
+                confirm=True,
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Read                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+class TestListFirewallGroups:
+    @pytest.mark.asyncio
+    async def test_lists_all_groups(
+        self, local_settings: MagicMock, sample_groups: list[dict[str, Any]]
+    ) -> None:
+        client = _mock_client(get_response={"meta": {"rc": "ok"}, "data": sample_groups})
+        with patch("src.tools.firewall_groups.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await fg.list_firewall_groups("default", local_settings)
+
+        assert len(result) == 3
+        assert {g["name"] for g in result} == {
+            "HomeKit-HAP",
+            "Trusted Subnets",
+            "RTSP-Streams",
+        }
+        endpoint = client.get.call_args.args[0]
+        assert endpoint.endswith("/rest/firewallgroup")
+
+    @pytest.mark.asyncio
+    async def test_filter_by_group_type(
+        self, local_settings: MagicMock, sample_groups: list[dict[str, Any]]
+    ) -> None:
+        client = _mock_client(get_response={"data": sample_groups})
+        with patch("src.tools.firewall_groups.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await fg.list_firewall_groups(
+                "default", local_settings, group_type="port-group"
+            )
+        assert len(result) == 2
+        assert all(g["group_type"] == "port-group" for g in result)
+
+    @pytest.mark.asyncio
+    async def test_invalid_group_type_raises(
+        self, local_settings: MagicMock
+    ) -> None:
+        with pytest.raises(ValueError, match="Invalid group_type"):
+            await fg.list_firewall_groups(
+                "default", local_settings, group_type="bogus-group"
+            )
+
+    @pytest.mark.asyncio
+    async def test_handles_raw_list_response(
+        self, local_settings: MagicMock, sample_groups: list[dict[str, Any]]
+    ) -> None:
+        client = _mock_client(get_response=sample_groups)
+        with patch("src.tools.firewall_groups.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await fg.list_firewall_groups("default", local_settings)
+        assert len(result) == 3
+
+
+class TestGetFirewallGroup:
+    @pytest.mark.asyncio
+    async def test_returns_first_item(
+        self, local_settings: MagicMock, sample_groups: list[dict[str, Any]]
+    ) -> None:
+        client = _mock_client(get_response={"data": [sample_groups[0]]})
+        with patch("src.tools.firewall_groups.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await fg.get_firewall_group(
+                "group-port-1", "default", local_settings
+            )
+        assert result["id"] == "group-port-1"
+        assert result["name"] == "HomeKit-HAP"
+
+    @pytest.mark.asyncio
+    async def test_empty_data_raises(self, local_settings: MagicMock) -> None:
+        client = _mock_client(get_response={"meta": {"rc": "ok"}, "data": []})
+        with patch("src.tools.firewall_groups.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            with pytest.raises(ResourceNotFoundError):
+                await fg.get_firewall_group("missing", "default", local_settings)
+
+
+# --------------------------------------------------------------------------- #
+# Create                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+class TestCreateFirewallGroup:
+    @pytest.mark.asyncio
+    async def test_create_port_group_round_trip(
+        self, local_settings: MagicMock, sample_groups: list[dict[str, Any]]
+    ) -> None:
+        client = _mock_client()
+        client.post.return_value = {"data": [sample_groups[0]]}
+
+        with patch("src.tools.firewall_groups.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await fg.create_port_group(
+                name="HomeKit-HAP",
+                ports=["8080", "9000-9010"],
+                site_id="default",
+                settings=local_settings,
+                confirm=True,
+            )
+
+        assert result["name"] == "HomeKit-HAP"
+        assert result["group_type"] == "port-group"
+        post_body = client.post.call_args.kwargs["json_data"]
+        assert post_body["group_type"] == "port-group"
+        assert post_body["group_members"] == ["8080", "9000-9010"]
+
+    @pytest.mark.asyncio
+    async def test_create_address_group_round_trip(
+        self, local_settings: MagicMock, sample_groups: list[dict[str, Any]]
+    ) -> None:
+        client = _mock_client()
+        client.post.return_value = {"data": [sample_groups[1]]}
+
+        with patch("src.tools.firewall_groups.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await fg.create_address_group(
+                name="Trusted Subnets",
+                addresses=["10.0.0.0/8", "192.168.50.0/24"],
+                site_id="default",
+                settings=local_settings,
+                confirm=True,
+            )
+
+        assert result["group_type"] == "address-group"
+        post_body = client.post.call_args.kwargs["json_data"]
+        assert post_body["group_type"] == "address-group"
+        assert post_body["group_members"] == ["10.0.0.0/8", "192.168.50.0/24"]
+
+    @pytest.mark.asyncio
+    async def test_create_dry_run_does_not_post(
+        self, local_settings: MagicMock
+    ) -> None:
+        client = _mock_client()
+        with patch("src.tools.firewall_groups.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await fg.create_port_group(
+                name="dry",
+                ports=["80"],
+                site_id="default",
+                settings=local_settings,
+                confirm=True,
+                dry_run=True,
+            )
+        assert result["status"] == "dry_run"
+        client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_without_confirm_raises(
+        self, local_settings: MagicMock
+    ) -> None:
+        with pytest.raises(ValueError, match="confirm=True"):
+            await fg.create_port_group(
+                name="x",
+                ports=["80"],
+                site_id="default",
+                settings=local_settings,
+                confirm=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_string_false_confirm_does_not_bypass(
+        self, local_settings: MagicMock
+    ) -> None:
+        """confirm='False' (truthy string) must NOT bypass the gate."""
+        with pytest.raises(ValueError, match="confirm=True"):
+            await fg.create_port_group(
+                name="x",
+                ports=["80"],
+                site_id="default",
+                settings=local_settings,
+                confirm="False",
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_group_type_raises(
+        self, local_settings: MagicMock
+    ) -> None:
+        with pytest.raises(ValueError, match="Invalid group_type"):
+            await fg.create_firewall_group(
+                name="x",
+                group_type="bogus",
+                group_members=["80"],
+                site_id="default",
+                settings=local_settings,
+                confirm=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_non_list_members_raises(
+        self, local_settings: MagicMock
+    ) -> None:
+        with pytest.raises(ValueError, match="must be a list"):
+            await fg.create_firewall_group(
+                name="x",
+                group_type="port-group",
+                group_members="80",  # type: ignore[arg-type]
+                site_id="default",
+                settings=local_settings,
+                confirm=True,
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Update                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+class TestUpdateFirewallGroup:
+    @pytest.mark.asyncio
+    async def test_update_get_merge_put(
+        self, local_settings: MagicMock, sample_groups: list[dict[str, Any]]
+    ) -> None:
+        existing = sample_groups[0]
+        client = _mock_client(get_response={"data": [existing]})
+        client.put.return_value = {
+            "data": [{**existing, "group_members": ["8080", "9000-9010", "5555"]}]
+        }
+
+        with patch("src.tools.firewall_groups.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await fg.update_firewall_group(
+                group_id="group-port-1",
+                site_id="default",
+                settings=local_settings,
+                group_members=["8080", "9000-9010", "5555"],
+                confirm=True,
+            )
+
+        assert result["group_members"] == ["8080", "9000-9010", "5555"]
+        # PUT body must be the full merged object with server-controlled
+        # fields stripped.
+        put_body = client.put.call_args.kwargs["json_data"]
+        assert put_body["name"] == "HomeKit-HAP"
+        assert put_body["group_type"] == "port-group"
+        assert put_body["group_members"] == ["8080", "9000-9010", "5555"]
+        assert "_id" not in put_body
+        assert "site_id" not in put_body
+        assert "external_id" not in put_body
+
+    @pytest.mark.asyncio
+    async def test_update_dry_run(
+        self, local_settings: MagicMock, sample_groups: list[dict[str, Any]]
+    ) -> None:
+        client = _mock_client(get_response={"data": [sample_groups[0]]})
+        with patch("src.tools.firewall_groups.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await fg.update_firewall_group(
+                group_id="group-port-1",
+                site_id="default",
+                settings=local_settings,
+                name="HAP-renamed",
+                confirm=True,
+                dry_run=True,
+            )
+        assert result["status"] == "dry_run"
+        assert result["changes"]["name"] == "HAP-renamed"
+        client.put.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Delete                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+class TestDeleteFirewallGroup:
+    @pytest.mark.asyncio
+    async def test_delete_success(self, local_settings: MagicMock) -> None:
+        client = _mock_client()
+        with patch("src.tools.firewall_groups.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await fg.delete_firewall_group(
+                group_id="group-port-1",
+                site_id="default",
+                settings=local_settings,
+                confirm=True,
+            )
+        assert result["status"] == "success"
+        assert result["action"] == "deleted"
+        client.delete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_dry_run(self, local_settings: MagicMock) -> None:
+        client = _mock_client()
+        with patch("src.tools.firewall_groups.UniFiClient") as MockClient:
+            MockClient.return_value = client
+            result = await fg.delete_firewall_group(
+                group_id="group-port-1",
+                site_id="default",
+                settings=local_settings,
+                confirm=True,
+                dry_run=True,
+            )
+        assert result["status"] == "dry_run"
+        assert result["action"] == "would_delete"
+        client.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_without_confirm_raises(
+        self, local_settings: MagicMock
+    ) -> None:
+        with pytest.raises(ValueError, match="confirm=True"):
+            await fg.delete_firewall_group(
+                group_id="group-port-1",
+                site_id="default",
+                settings=local_settings,
+                confirm=False,
+            )

--- a/tests/unit/tools/test_firewall_policies.py
+++ b/tests/unit/tools/test_firewall_policies.py
@@ -1521,3 +1521,415 @@ class TestCreateFirewallPolicyConfirmCoercion:
                 ip_version="IPV5",
                 confirm=True,
             )
+
+
+class TestCreateFirewallPolicyPortMatching:
+    """Verify port / port_group_id / port_matching_type plumbing."""
+
+    @pytest.fixture
+    def local_settings(self, monkeypatch: pytest.MonkeyPatch) -> Settings:
+        monkeypatch.setenv("UNIFI_API_KEY", "test-api-key")
+        monkeypatch.setenv("UNIFI_API_TYPE", "local")
+        monkeypatch.setenv("UNIFI_LOCAL_HOST", "192.168.2.1")
+        return Settings()
+
+    @pytest.fixture
+    def created_policy(self) -> dict:
+        return {
+            "_id": "new-policy",
+            "name": "test",
+            "action": "ALLOW",
+            "enabled": True,
+            "predefined": False,
+            "ip_version": "BOTH",
+            "protocol": "all",
+            "schedule": {"mode": "ALWAYS"},
+            "source": {"zone_id": "z1", "matching_target": "ANY"},
+            "destination": {"zone_id": "z2", "matching_target": "ANY"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_specific_destination_port_auto_sets_mode(
+        self, local_settings: Settings, created_policy: dict
+    ) -> None:
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        _zone_cache["default"] = {"z1": "z1", "z2": "z2"}
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.post.return_value = created_policy
+
+            try:
+                await create_firewall_policy(
+                    name="Allow DNS",
+                    action="ALLOW",
+                    site_id="default",
+                    settings=local_settings,
+                    source_zone_id="z1",
+                    destination_zone_id="z2",
+                    destination_port="53",
+                    confirm=True,
+                )
+            finally:
+                _zone_cache.pop("default", None)
+
+            body = mock_client.post.call_args[1]["json_data"]
+            assert body["destination"]["port_matching_type"] == "SPECIFIC"
+            assert body["destination"]["port"] == "53"
+            assert "port_group_id" not in body["destination"]
+            # Source side stays ANY (default)
+            assert body["source"]["port_matching_type"] == "ANY"
+            assert "port" not in body["source"]
+
+    @pytest.mark.asyncio
+    async def test_destination_port_range(
+        self, local_settings: Settings, created_policy: dict
+    ) -> None:
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        _zone_cache["default"] = {"z1": "z1", "z2": "z2"}
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.post.return_value = created_policy
+
+            try:
+                await create_firewall_policy(
+                    name="Allow ranges",
+                    action="ALLOW",
+                    site_id="default",
+                    settings=local_settings,
+                    source_zone_id="z1",
+                    destination_zone_id="z2",
+                    destination_port="9000-9010",
+                    confirm=True,
+                )
+            finally:
+                _zone_cache.pop("default", None)
+
+            body = mock_client.post.call_args[1]["json_data"]
+            assert body["destination"]["port"] == "9000-9010"
+            assert body["destination"]["port_matching_type"] == "SPECIFIC"
+
+    @pytest.mark.asyncio
+    async def test_port_group_id_auto_sets_object_mode(
+        self, local_settings: Settings, created_policy: dict
+    ) -> None:
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        _zone_cache["default"] = {"z1": "z1", "z2": "z2"}
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.post.return_value = created_policy
+
+            try:
+                await create_firewall_policy(
+                    name="Allow port group",
+                    action="ALLOW",
+                    site_id="default",
+                    settings=local_settings,
+                    source_zone_id="z1",
+                    destination_zone_id="z2",
+                    destination_port_group_id="pg-1",
+                    confirm=True,
+                )
+            finally:
+                _zone_cache.pop("default", None)
+
+            body = mock_client.post.call_args[1]["json_data"]
+            assert body["destination"]["port_matching_type"] == "OBJECT"
+            assert body["destination"]["port_group_id"] == "pg-1"
+            assert "port" not in body["destination"]
+
+    @pytest.mark.asyncio
+    async def test_port_and_port_group_id_conflict(
+        self, local_settings: Settings, created_policy: dict
+    ) -> None:
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        _zone_cache["default"] = {"z1": "z1", "z2": "z2"}
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+
+            try:
+                with pytest.raises(ValueError, match="port.*port_group_id"):
+                    await create_firewall_policy(
+                        name="Conflict",
+                        action="ALLOW",
+                        site_id="default",
+                        settings=local_settings,
+                        source_zone_id="z1",
+                        destination_zone_id="z2",
+                        destination_port="53",
+                        destination_port_group_id="pg-1",
+                        confirm=True,
+                    )
+            finally:
+                _zone_cache.pop("default", None)
+
+    @pytest.mark.asyncio
+    async def test_match_opposite_ports_passthrough(
+        self, local_settings: Settings, created_policy: dict
+    ) -> None:
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        _zone_cache["default"] = {"z1": "z1", "z2": "z2"}
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.post.return_value = created_policy
+
+            try:
+                await create_firewall_policy(
+                    name="NOT 53",
+                    action="BLOCK",
+                    site_id="default",
+                    settings=local_settings,
+                    source_zone_id="z1",
+                    destination_zone_id="z2",
+                    destination_port="53",
+                    destination_match_opposite_ports=True,
+                    confirm=True,
+                )
+            finally:
+                _zone_cache.pop("default", None)
+
+            body = mock_client.post.call_args[1]["json_data"]
+            assert body["destination"]["match_opposite_ports"] is True
+
+    @pytest.mark.asyncio
+    async def test_specific_without_port_raises(
+        self, local_settings: Settings
+    ) -> None:
+        """port_matching_type='SPECIFIC' without a port value must error."""
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        _zone_cache["default"] = {"z1": "z1", "z2": "z2"}
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+
+            try:
+                with pytest.raises(ValueError, match="SPECIFIC.*requires.*port"):
+                    await create_firewall_policy(
+                        name="Bad",
+                        action="ALLOW",
+                        site_id="default",
+                        settings=local_settings,
+                        source_zone_id="z1",
+                        destination_zone_id="z2",
+                        destination_port_matching_type="SPECIFIC",
+                        confirm=True,
+                    )
+            finally:
+                _zone_cache.pop("default", None)
+
+    @pytest.mark.asyncio
+    async def test_object_without_port_group_id_raises(
+        self, local_settings: Settings
+    ) -> None:
+        """port_matching_type='OBJECT' without a port_group_id must error."""
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        _zone_cache["default"] = {"z1": "z1", "z2": "z2"}
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+
+            try:
+                with pytest.raises(ValueError, match="OBJECT.*requires.*port_group_id"):
+                    await create_firewall_policy(
+                        name="Bad",
+                        action="ALLOW",
+                        site_id="default",
+                        settings=local_settings,
+                        source_zone_id="z1",
+                        destination_zone_id="z2",
+                        destination_port_matching_type="OBJECT",
+                        confirm=True,
+                    )
+            finally:
+                _zone_cache.pop("default", None)
+
+
+class TestUpdateFirewallPolicyPortMatching:
+    """Verify update_firewall_policy port-merge behaviour."""
+
+    @pytest.fixture
+    def local_settings(self, monkeypatch: pytest.MonkeyPatch) -> Settings:
+        monkeypatch.setenv("UNIFI_API_KEY", "test-api-key")
+        monkeypatch.setenv("UNIFI_API_TYPE", "local")
+        monkeypatch.setenv("UNIFI_LOCAL_HOST", "192.168.2.1")
+        return Settings()
+
+    @pytest.fixture
+    def existing_policy(self) -> dict:
+        return {
+            "_id": "p1",
+            "name": "Allow Identity Sync",
+            "action": "ALLOW",
+            "enabled": True,
+            "predefined": False,
+            "ip_version": "BOTH",
+            "protocol": "all",
+            "logging": False,
+            "schedule": {"mode": "ALWAYS"},
+            "source": {
+                "zone_id": "z-internal",
+                "matching_target": "ANY",
+                "port_matching_type": "ANY",
+            },
+            "destination": {
+                "zone_id": "z-gateway",
+                "matching_target": "ANY",
+                "port_matching_type": "OBJECT",
+                "port_group_id": "pg-old",
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_switch_object_to_specific_clears_port_group_id(
+        self, local_settings: Settings, existing_policy: dict
+    ) -> None:
+        from src.tools.firewall_policies import update_firewall_policy
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = existing_policy
+            mock_client.put.return_value = existing_policy
+
+            await update_firewall_policy(
+                policy_id="p1",
+                site_id="default",
+                settings=local_settings,
+                destination_port="9543",
+                confirm=True,
+            )
+
+            put_body = mock_client.put.call_args[1]["json_data"]
+            assert put_body["destination"]["port_matching_type"] == "SPECIFIC"
+            assert put_body["destination"]["port"] == "9543"
+            # Old port_group_id must be removed since we switched modes
+            assert "port_group_id" not in put_body["destination"]
+            # Existing zone_id and matching_target preserved
+            assert put_body["destination"]["zone_id"] == "z-gateway"
+            assert put_body["destination"]["matching_target"] == "ANY"
+
+    @pytest.mark.asyncio
+    async def test_switch_to_any_clears_both_port_fields(
+        self, local_settings: Settings, existing_policy: dict
+    ) -> None:
+        from src.tools.firewall_policies import update_firewall_policy
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = existing_policy
+            mock_client.put.return_value = existing_policy
+
+            await update_firewall_policy(
+                policy_id="p1",
+                site_id="default",
+                settings=local_settings,
+                destination_port_matching_type="ANY",
+                confirm=True,
+            )
+
+            put_body = mock_client.put.call_args[1]["json_data"]
+            assert put_body["destination"]["port_matching_type"] == "ANY"
+            assert "port" not in put_body["destination"]
+            assert "port_group_id" not in put_body["destination"]
+
+    @pytest.mark.asyncio
+    async def test_change_only_port_group_id(
+        self, local_settings: Settings, existing_policy: dict
+    ) -> None:
+        from src.tools.firewall_policies import update_firewall_policy
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = existing_policy
+            mock_client.put.return_value = existing_policy
+
+            await update_firewall_policy(
+                policy_id="p1",
+                site_id="default",
+                settings=local_settings,
+                destination_port_group_id="pg-new",
+                confirm=True,
+            )
+
+            put_body = mock_client.put.call_args[1]["json_data"]
+            assert put_body["destination"]["port_group_id"] == "pg-new"
+            assert put_body["destination"]["port_matching_type"] == "OBJECT"
+            assert "port" not in put_body["destination"]
+
+    @pytest.mark.asyncio
+    async def test_unrelated_field_does_not_touch_ports(
+        self, local_settings: Settings, existing_policy: dict
+    ) -> None:
+        """A name-only update must leave existing port settings alone."""
+        from src.tools.firewall_policies import update_firewall_policy
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = existing_policy
+            mock_client.put.return_value = existing_policy
+
+            await update_firewall_policy(
+                policy_id="p1",
+                site_id="default",
+                settings=local_settings,
+                name="renamed",
+                confirm=True,
+            )
+
+            put_body = mock_client.put.call_args[1]["json_data"]
+            assert put_body["destination"]["port_matching_type"] == "OBJECT"
+            assert put_body["destination"]["port_group_id"] == "pg-old"
+
+    @pytest.mark.asyncio
+    async def test_port_and_port_group_id_conflict_on_update(
+        self, local_settings: Settings, existing_policy: dict
+    ) -> None:
+        from src.tools.firewall_policies import update_firewall_policy
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = existing_policy
+
+            with pytest.raises(ValueError, match="port.*port_group_id"):
+                await update_firewall_policy(
+                    policy_id="p1",
+                    site_id="default",
+                    settings=local_settings,
+                    destination_port="53",
+                    destination_port_group_id="pg-1",
+                    confirm=True,
+                )

--- a/tests/unit/tools/test_firewall_policies.py
+++ b/tests/unit/tools/test_firewall_policies.py
@@ -435,18 +435,20 @@ class TestUpdateFirewallPolicy:
         return Settings()
 
     @pytest.fixture
-    def sample_updated_policy(self) -> dict:
-        """Sample updated policy response from UniFi controller."""
+    def sample_existing_policy(self) -> dict:
+        """Existing policy as returned by GET before update."""
         return {
             "_id": "682a0e42220317278bb0b2cb",
-            "name": "Updated Policy Name",
+            "name": "Original Name",
             "enabled": True,
             "action": "ALLOW",
             "predefined": False,
             "index": 10000,
             "protocol": "all",
             "ip_version": "BOTH",
+            "logging": False,
             "connection_state_type": "ALL",
+            "schedule": {"mode": "ALWAYS"},
             "source": {
                 "zone_id": "682a0e42220317278bb0b2c5",
                 "matching_target": "ANY",
@@ -457,9 +459,19 @@ class TestUpdateFirewallPolicy:
             },
         }
 
+    @pytest.fixture
+    def sample_updated_policy(self, sample_existing_policy: dict) -> dict:
+        """Sample updated policy response from UniFi controller."""
+        updated = sample_existing_policy.copy()
+        updated["name"] = "Updated Policy Name"
+        return updated
+
     @pytest.mark.asyncio
     async def test_update_firewall_policy_success_with_confirm(
-        self, local_settings: Settings, sample_updated_policy: dict
+        self,
+        local_settings: Settings,
+        sample_existing_policy: dict,
+        sample_updated_policy: dict,
     ) -> None:
         """Test successful update of a firewall policy with confirm=True."""
         from src.tools.firewall_policies import update_firewall_policy
@@ -468,6 +480,8 @@ class TestUpdateFirewallPolicy:
             mock_client = AsyncMock()
             MockClient.return_value.__aenter__.return_value = mock_client
             mock_client.is_authenticated = True
+            # The new GET-merge-PUT flow fetches the existing policy first.
+            mock_client.get.return_value = sample_existing_policy
             mock_client.put.return_value = sample_updated_policy
 
             result = await update_firewall_policy(
@@ -482,7 +496,17 @@ class TestUpdateFirewallPolicy:
             assert isinstance(result, dict)
             assert result["name"] == "Updated Policy Name"
             assert result["action"] == "ALLOW"
+            mock_client.get.assert_called_once()
             mock_client.put.assert_called_once()
+            # The PUT body should be the full merged object, not just the
+            # overrides, because the v2 endpoint requires all required
+            # fields on every update.
+            put_body = mock_client.put.call_args[1]["json_data"]
+            assert put_body["name"] == "Updated Policy Name"
+            assert put_body["source"]["zone_id"] == "682a0e42220317278bb0b2c5"
+            # _id and predefined must be stripped before PUT.
+            assert "_id" not in put_body
+            assert "predefined" not in put_body
 
     @pytest.mark.asyncio
     async def test_update_firewall_policy_rejected_without_confirm(
@@ -503,13 +527,17 @@ class TestUpdateFirewallPolicy:
         assert "confirm=True" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_update_firewall_policy_dry_run_mode(self, local_settings: Settings) -> None:
+    async def test_update_firewall_policy_dry_run_mode(
+        self, local_settings: Settings, sample_existing_policy: dict
+    ) -> None:
         """Test dry_run mode returns preview without making changes."""
         from src.tools.firewall_policies import update_firewall_policy
 
         with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
             mock_client = AsyncMock()
             MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = sample_existing_policy
 
             result = await update_firewall_policy(
                 policy_id="682a0e42220317278bb0b2cb",
@@ -523,6 +551,7 @@ class TestUpdateFirewallPolicy:
             assert result["policy_id"] == "682a0e42220317278bb0b2cb"
             assert "changes" in result
             assert result["changes"]["name"] == "Updated Policy Name"
+            assert "merged_payload" in result
             mock_client.put.assert_not_called()
 
     @pytest.mark.asyncio
@@ -567,19 +596,24 @@ class TestUpdateFirewallPolicy:
         assert "local" in str(exc_info.value).lower()
 
     @pytest.mark.asyncio
-    async def test_update_firewall_policy_partial_update_name_only(
-        self, local_settings: Settings, sample_updated_policy: dict
+    async def test_update_firewall_policy_name_override_merges_with_existing(
+        self,
+        local_settings: Settings,
+        sample_existing_policy: dict,
+        sample_updated_policy: dict,
     ) -> None:
-        """Test partial update with only name field."""
+        """A name override must be merged into the existing object and the
+        full object PUT back (partial PUT is rejected by the v2 endpoint)."""
         from src.tools.firewall_policies import update_firewall_policy
 
         with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
             mock_client = AsyncMock()
             MockClient.return_value.__aenter__.return_value = mock_client
             mock_client.is_authenticated = True
+            mock_client.get.return_value = sample_existing_policy
             mock_client.put.return_value = sample_updated_policy
 
-            result = await update_firewall_policy(
+            await update_firewall_policy(
                 policy_id="682a0e42220317278bb0b2cb",
                 name="Updated Policy Name",
                 site_id="default",
@@ -587,26 +621,35 @@ class TestUpdateFirewallPolicy:
                 settings=local_settings,
             )
 
-            assert result["name"] == "Updated Policy Name"
-            call_args = mock_client.put.call_args
-            request_body = call_args[1]["json_data"]
-            assert "name" in request_body
-            assert "action" not in request_body
+            put_body = mock_client.put.call_args[1]["json_data"]
+            # Override applied
+            assert put_body["name"] == "Updated Policy Name"
+            # Existing fields preserved (merged)
+            assert put_body["action"] == "ALLOW"
+            assert put_body["enabled"] is True
+            assert put_body["schedule"] == {"mode": "ALWAYS"}
+            assert put_body["source"]["zone_id"] == "682a0e42220317278bb0b2c5"
+            # Required-field-strip contract
+            assert "_id" not in put_body
+            assert "predefined" not in put_body
 
     @pytest.mark.asyncio
-    async def test_update_firewall_policy_partial_update_enabled_only(
-        self, local_settings: Settings, sample_updated_policy: dict
+    async def test_update_firewall_policy_enabled_toggle(
+        self,
+        local_settings: Settings,
+        sample_existing_policy: dict,
     ) -> None:
-        """Test partial update with only enabled field."""
+        """Toggling enabled=False flows through without touching other fields."""
         from src.tools.firewall_policies import update_firewall_policy
 
-        disabled_policy = sample_updated_policy.copy()
+        disabled_policy = sample_existing_policy.copy()
         disabled_policy["enabled"] = False
 
         with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
             mock_client = AsyncMock()
             MockClient.return_value.__aenter__.return_value = mock_client
             mock_client.is_authenticated = True
+            mock_client.get.return_value = sample_existing_policy
             mock_client.put.return_value = disabled_policy
 
             result = await update_firewall_policy(
@@ -618,10 +661,85 @@ class TestUpdateFirewallPolicy:
             )
 
             assert result["enabled"] is False
-            call_args = mock_client.put.call_args
-            request_body = call_args[1]["json_data"]
-            assert "enabled" in request_body
-            assert request_body["enabled"] is False
+            put_body = mock_client.put.call_args[1]["json_data"]
+            assert put_body["enabled"] is False
+            # Other existing fields untouched
+            assert put_body["name"] == "Original Name"
+            assert put_body["action"] == "ALLOW"
+
+    @pytest.mark.asyncio
+    async def test_update_firewall_policy_logging_toggle(
+        self,
+        local_settings: Settings,
+        sample_existing_policy: dict,
+    ) -> None:
+        """Enabling ``logging`` forces CPU inspection so the matched flows
+        show up in the v2 traffic-flows endpoint."""
+        from src.tools.firewall_policies import update_firewall_policy
+
+        logging_on = sample_existing_policy.copy()
+        logging_on["logging"] = True
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = sample_existing_policy
+            mock_client.put.return_value = logging_on
+
+            result = await update_firewall_policy(
+                policy_id="682a0e42220317278bb0b2cb",
+                logging=True,
+                site_id="default",
+                confirm=True,
+                settings=local_settings,
+            )
+
+            assert result["logging"] is True
+            put_body = mock_client.put.call_args[1]["json_data"]
+            assert put_body["logging"] is True
+            # Existing required fields still present
+            assert put_body["action"] == "ALLOW"
+            assert put_body["source"]["zone_id"] == "682a0e42220317278bb0b2c5"
+
+    @pytest.mark.asyncio
+    async def test_update_firewall_policy_rejects_predefined(
+        self, local_settings: Settings, sample_existing_policy: dict
+    ) -> None:
+        """Predefined system policies must not be updatable."""
+        from src.tools.firewall_policies import update_firewall_policy
+
+        system_policy = {**sample_existing_policy, "predefined": True}
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = system_policy
+
+            with pytest.raises(ValueError, match="predefined"):
+                await update_firewall_policy(
+                    policy_id="682a0e42220317278bb0b2cb",
+                    name="Hacked",
+                    site_id="default",
+                    confirm=True,
+                    settings=local_settings,
+                )
+
+    @pytest.mark.asyncio
+    async def test_update_firewall_policy_invalid_ip_version_raises(
+        self, local_settings: Settings
+    ) -> None:
+        from src.tools.firewall_policies import update_firewall_policy
+
+        with pytest.raises(ValueError, match="Invalid ip_version"):
+            await update_firewall_policy(
+                policy_id="682a0e42220317278bb0b2cb",
+                ip_version="IPV5",
+                site_id="default",
+                confirm=True,
+                settings=local_settings,
+            )
 
 
 class TestDeleteFirewallPolicy:
@@ -1059,8 +1177,14 @@ class TestCreateFirewallPolicy:
     async def test_create_firewall_policy_with_zones(
         self, local_settings: Settings, sample_created_policy: dict
     ) -> None:
-        """Test creation with specific zone IDs."""
-        from src.tools.firewall_policies import create_firewall_policy
+        """Test creation with specific zone IDs resolved via the v2 zone index."""
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        # Prime the zone cache so tests don't need to mock /firewall/zone.
+        _zone_cache["default"] = {
+            "zone-iot": "zone-iot",
+            "zone-lan": "zone-lan",
+        }
 
         with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
             mock_client = AsyncMock()
@@ -1068,20 +1192,97 @@ class TestCreateFirewallPolicy:
             mock_client.is_authenticated = True
             mock_client.post.return_value = sample_created_policy
 
-            await create_firewall_policy(
-                name="Block IOT to LAN",
-                action="BLOCK",
-                site_id="default",
-                settings=local_settings,
-                source_zone_id="zone-iot",
-                destination_zone_id="zone-lan",
-                confirm=True,
-            )
+            try:
+                await create_firewall_policy(
+                    name="Block IOT to LAN",
+                    action="BLOCK",
+                    site_id="default",
+                    settings=local_settings,
+                    source_zone_id="zone-iot",
+                    destination_zone_id="zone-lan",
+                    confirm=True,
+                )
+            finally:
+                _zone_cache.pop("default", None)
 
             call_args = mock_client.post.call_args
             request_body = call_args[1]["json_data"]
             assert request_body["source"]["zone_id"] == "zone-iot"
             assert request_body["destination"]["zone_id"] == "zone-lan"
+            # Required v2 API fields are always included.
+            assert request_body["schedule"] == {"mode": "ALWAYS"}
+            assert request_body["ip_version"] == "BOTH"
+
+    @pytest.mark.asyncio
+    async def test_create_firewall_policy_resolves_zone_by_name(
+        self, local_settings: Settings, sample_created_policy: dict
+    ) -> None:
+        """Zone names ('Internal') and external UUIDs should resolve to the
+        internal ObjectId via the v2 zone index."""
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        # Simulated zone index: zone name + external UUID → internal _id
+        _zone_cache["default"] = {
+            "internal": "690d6e64e9671173fd71c586",
+            "1daa9f24-eeaf-4bec-a714-e5eb65ea7ba2": "690d6e64e9671173fd71c586",
+            "690d6e64e9671173fd71c586": "690d6e64e9671173fd71c586",
+            "dmz": "690d6e64e9671173fd71c58b",
+            "690d6e64e9671173fd71c58b": "690d6e64e9671173fd71c58b",
+        }
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.post.return_value = sample_created_policy
+
+            try:
+                await create_firewall_policy(
+                    name="Internal to DMZ",
+                    action="ALLOW",
+                    site_id="default",
+                    settings=local_settings,
+                    source_zone_id="Internal",  # by name (case-insensitive)
+                    destination_zone_id="1daa9f24-eeaf-4bec-a714-e5eb65ea7ba2",  # noqa: E501 — external UUID
+                    confirm=True,
+                )
+            finally:
+                _zone_cache.pop("default", None)
+
+            request_body = mock_client.post.call_args[1]["json_data"]
+            assert request_body["source"]["zone_id"] == "690d6e64e9671173fd71c586"
+            assert (
+                request_body["destination"]["zone_id"] == "690d6e64e9671173fd71c586"
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_firewall_policy_unknown_zone_raises(
+        self, local_settings: Settings
+    ) -> None:
+        """Unresolvable zone identifiers raise ValueError with a helpful hint."""
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        _zone_cache["default"] = {"known": "abc123"}
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            # Make refresh return an empty list too, so no new mappings appear.
+            mock_client.get.return_value = {"data": []}
+
+            try:
+                with pytest.raises(ValueError, match="Could not resolve firewall zone"):
+                    await create_firewall_policy(
+                        name="Bad zone",
+                        action="ALLOW",
+                        site_id="default",
+                        settings=local_settings,
+                        source_zone_id="nonexistent",
+                        confirm=True,
+                    )
+            finally:
+                _zone_cache.pop("default", None)
 
     @pytest.mark.asyncio
     async def test_create_firewall_policy_invalid_action(self, local_settings: Settings) -> None:
@@ -1161,3 +1362,162 @@ class TestCreateFirewallPolicy:
             )
 
             mock_client.authenticate.assert_called_once()
+
+
+class TestListFirewallZonesV2:
+    """Tests for the v2 firewall zone listing helper."""
+
+    @pytest.fixture
+    def local_settings(self, monkeypatch: pytest.MonkeyPatch) -> Settings:
+        monkeypatch.setenv("UNIFI_API_KEY", "test-api-key")
+        monkeypatch.setenv("UNIFI_API_TYPE", "local")
+        monkeypatch.setenv("UNIFI_LOCAL_HOST", "192.168.2.1")
+        return Settings()
+
+    @pytest.mark.asyncio
+    async def test_list_firewall_zones_v2_returns_id_mapping(
+        self, local_settings: Settings
+    ) -> None:
+        """Each returned entry exposes both internal and external IDs plus
+        zone name and zone_key so callers can look up zones by any
+        identifier."""
+        from src.tools.firewall_policies import list_firewall_zones_v2
+
+        raw_zones = [
+            {
+                "_id": "690d6e64e9671173fd71c586",
+                "external_id": "1daa9f24-eeaf-4bec-a714-e5eb65ea7ba2",
+                "name": "Internal",
+                "zone_key": "internal",
+                "default_zone": True,
+                "network_ids": ["net-1", "net-2"],
+            },
+            {
+                "_id": "6918c2f7dec8680b5fc97ffb",
+                "external_id": "4d1c7bb4-1714-4b55-933d-f37ee9fccdda",
+                "name": "Semi-Trusted",
+                "zone_key": None,
+                "default_zone": False,
+                "network_ids": [],
+            },
+        ]
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = raw_zones
+
+            result = await list_firewall_zones_v2("default", local_settings)
+
+            assert len(result) == 2
+            assert result[0] == {
+                "internal_id": "690d6e64e9671173fd71c586",
+                "external_id": "1daa9f24-eeaf-4bec-a714-e5eb65ea7ba2",
+                "name": "Internal",
+                "zone_key": "internal",
+                "default_zone": True,
+                "network_ids": ["net-1", "net-2"],
+            }
+            assert result[1]["internal_id"] == "6918c2f7dec8680b5fc97ffb"
+            assert result[1]["external_id"] == "4d1c7bb4-1714-4b55-933d-f37ee9fccdda"
+
+            called_endpoint = mock_client.get.call_args[0][0]
+            assert called_endpoint.endswith("/firewall/zone")
+
+    @pytest.mark.asyncio
+    async def test_list_firewall_zones_v2_handles_none_data(
+        self, local_settings: Settings
+    ) -> None:
+        """UniFiClient can return ``{"data": None}`` for empty responses;
+        the tool must not raise ``TypeError: 'NoneType' is not iterable``."""
+        from src.tools.firewall_policies import list_firewall_zones_v2
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.get.return_value = {"data": None}
+
+            result = await list_firewall_zones_v2("default", local_settings)
+            assert result == []
+
+
+class TestCreateFirewallPolicyConfirmCoercion:
+    """Regression tests for the string-truthiness confirmation bypass."""
+
+    @pytest.fixture
+    def local_settings(self, monkeypatch: pytest.MonkeyPatch) -> Settings:
+        monkeypatch.setenv("UNIFI_API_KEY", "test-api-key")
+        monkeypatch.setenv("UNIFI_API_TYPE", "local")
+        monkeypatch.setenv("UNIFI_LOCAL_HOST", "192.168.2.1")
+        return Settings()
+
+    @pytest.mark.asyncio
+    async def test_string_false_confirm_does_not_bypass(
+        self, local_settings: Settings
+    ) -> None:
+        """confirm='False' (a truthy string) must not bypass the gate."""
+        from src.tools.firewall_policies import create_firewall_policy
+
+        with pytest.raises(ValueError, match="requires confirm=True"):
+            await create_firewall_policy(
+                name="Test",
+                action="ALLOW",
+                site_id="default",
+                settings=local_settings,
+                confirm="False",
+            )
+
+    @pytest.mark.asyncio
+    async def test_string_true_confirm_is_accepted(
+        self, local_settings: Settings
+    ) -> None:
+        """confirm='true' (JSON-RPC stringified bool) must be coerced."""
+        from src.tools.firewall_policies import _zone_cache, create_firewall_policy
+
+        _zone_cache["default"] = {"zone-a": "zone-a", "zone-b": "zone-b"}
+
+        with patch("src.tools.firewall_policies.UniFiClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__.return_value = mock_client
+            mock_client.is_authenticated = True
+            mock_client.post.return_value = {
+                "_id": "new",
+                "name": "Test",
+                "action": "ALLOW",
+                "source": {"zone_id": "zone-a", "matching_target": "ANY"},
+                "destination": {"zone_id": "zone-b", "matching_target": "ANY"},
+            }
+
+            try:
+                result = await create_firewall_policy(
+                    name="Test",
+                    action="ALLOW",
+                    site_id="default",
+                    settings=local_settings,
+                    source_zone_id="zone-a",
+                    destination_zone_id="zone-b",
+                    confirm="true",
+                )
+            finally:
+                _zone_cache.pop("default", None)
+
+            assert result["id"] == "new"
+            mock_client.post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_invalid_ip_version_raises(
+        self, local_settings: Settings
+    ) -> None:
+        from src.tools.firewall_policies import create_firewall_policy
+
+        with pytest.raises(ValueError, match="Invalid ip_version"):
+            await create_firewall_policy(
+                name="Test",
+                action="ALLOW",
+                site_id="default",
+                settings=local_settings,
+                ip_version="IPV5",
+                confirm=True,
+            )

--- a/tests/unit/tools/test_firewall_zones_tools.py
+++ b/tests/unit/tools/test_firewall_zones_tools.py
@@ -366,8 +366,12 @@ class TestAssignNetworkToZone:
     async def test_assign_network_to_zone_success(self, mock_settings, sample_firewall_zones):
         from src.tools.firewall_zones import assign_network_to_zone
 
-        zone_data = {"data": {"networkIds": ["net-001"]}}
-        network_data = {"data": {"name": "NewNetwork"}}
+        # Use UUID-format IDs so _resolve_network_uuid passes through
+        # without hitting the legacy API.
+        net_existing = "aaaaaaaa-bbbb-cccc-dddd-000000000001"
+        net_new = "aaaaaaaa-bbbb-cccc-dddd-000000000099"
+        zone_data = {"networkIds": [net_existing], "name": "LAN"}
+        network_data = {"name": "NewNetwork"}
 
         with (
             patch("src.tools.firewall_zones.UniFiClient") as mock_client,
@@ -380,7 +384,7 @@ class TestAssignNetworkToZone:
             mock_instance.resolve_site_id = AsyncMock(return_value="default")
 
             def get_side_effect(endpoint):
-                if "networks/net-new" in endpoint:
+                if f"networks/{net_new}" in endpoint:
                     return network_data
                 return zone_data
 
@@ -390,22 +394,28 @@ class TestAssignNetworkToZone:
             result = await assign_network_to_zone(
                 "default",
                 "zone-001",
-                "net-new",
+                net_new,
                 mock_settings,
                 confirm=True,
             )
 
             assert result["zone_id"] == "zone-001"
-            assert result["network_id"] == "net-new"
+            assert result["network_id"] == net_new
             _, kwargs = mock_instance.put.call_args
             assert "networkIds" in kwargs["json_data"]
-            assert "net-new" in kwargs["json_data"]["networkIds"]
+            assert net_new in kwargs["json_data"]["networkIds"]
+            # Existing networks must be preserved (not overwritten)
+            assert net_existing in kwargs["json_data"]["networkIds"]
+            # name must be included in the PUT body
+            assert kwargs["json_data"]["name"] == "LAN"
 
     @pytest.mark.asyncio
     async def test_assign_network_to_zone_already_assigned(self, mock_settings):
         from src.tools.firewall_zones import assign_network_to_zone
 
-        zone_data = {"data": {"networkIds": ["net-001", "net-002"]}}
+        net_001 = "aaaaaaaa-bbbb-cccc-dddd-000000000001"
+        net_002 = "aaaaaaaa-bbbb-cccc-dddd-000000000002"
+        zone_data = {"networkIds": [net_001, net_002], "name": "LAN"}
 
         with patch("src.tools.firewall_zones.UniFiClient") as mock_client:
             mock_instance = AsyncMock()
@@ -418,19 +428,20 @@ class TestAssignNetworkToZone:
             result = await assign_network_to_zone(
                 "default",
                 "zone-001",
-                "net-001",
+                net_001,
                 mock_settings,
                 confirm=True,
             )
 
-            assert result["network_id"] == "net-001"
+            assert result["network_id"] == net_001
             mock_instance.put.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_assign_network_to_zone_dry_run(self, mock_settings):
         from src.tools.firewall_zones import assign_network_to_zone
 
-        zone_data = {"data": {"networkIds": []}}
+        net_new = "aaaaaaaa-bbbb-cccc-dddd-000000000099"
+        zone_data = {"networkIds": [], "name": "LAN"}
 
         with patch("src.tools.firewall_zones.UniFiClient") as mock_client:
             mock_instance = AsyncMock()
@@ -443,7 +454,7 @@ class TestAssignNetworkToZone:
             result = await assign_network_to_zone(
                 "default",
                 "zone-001",
-                "net-new",
+                net_new,
                 mock_settings,
                 confirm=True,
                 dry_run=True,


### PR DESCRIPTION
> **Stacked on top of #60.** This branch is based on \`feat/firewall-policies\` so the diff against \`main\` includes #60's commits too. Once #60 merges, GitHub will recompute and only show the firewall_groups commit. The new module added here uses the registration glue introduced in #60, so it depends on #60 landing first.

Adds the missing reusable-object layer that zone-based firewall policies need to express anything more granular than \"any → any\". UniFi calls these \"firewall groups\" — port-groups, address-groups, ipv6-address-groups — and they live at the legacy V1 internal endpoint \`/proxy/network/api/s/{site}/rest/firewallgroup\`. The v2 API does not expose them, but the same API key that authenticates the v2 firewall policies endpoint also works against this legacy surface, so no session login is required.

## What's new

### \`src/tools/firewall_groups.py\` (new module)

| Function | Purpose |
|---|---|
| \`list_firewall_groups(site_id, group_type=None)\` | List all groups, optionally filtered by \`port-group\` / \`address-group\` / \`ipv6-address-group\` |
| \`get_firewall_group(group_id, site_id)\` | Single lookup |
| \`create_firewall_group(name, group_type, group_members, site_id, ...)\` | Generic create |
| \`create_port_group(name, ports, site_id, ...)\` | Convenience wrapper |
| \`create_address_group(name, addresses, site_id, ...)\` | Convenience wrapper |
| \`update_firewall_group(group_id, site_id, name=, group_members=, ...)\` | GET-merge-PUT, same pattern as \`update_firewall_policy\`. Strips \`_id\` / \`site_id\` / \`external_id\` before PUT. |
| \`delete_firewall_group(group_id, site_id, ...)\` | Delete |

All gated with \`_ensure_local_api()\` — cloud users get a clear \`NotImplementedError\`. Endpoint paths use the \`/ea/sites/{site}/rest/firewallgroup\` shape that the existing client auto-translator rewrites in local mode.

### Port matching on \`create_firewall_policy\` and \`update_firewall_policy\`

The v2 firewall policy schema stores port criteria as nested fields on \`source\` / \`destination\` with a \`port_matching_type\` discriminator: \`ANY\` (no filter), \`SPECIFIC\` (use \`port\` string), or \`OBJECT\` (use \`port_group_id\`). Verified against an existing \"Allow Identity Sync\" rule on a UDM Pro that uses OBJECT mode with a port-group reference.

New parameters on both create and update (each side):

- \`source_port\` / \`destination_port\` — single port \`\"53\"\` or range \`\"9000-9010\"\`. Implies \`SPECIFIC\` mode.
- \`source_port_group_id\` / \`destination_port_group_id\` — reference a firewall port-group. Implies \`OBJECT\` mode.
- \`source_port_matching_type\` / \`destination_port_matching_type\` — explicit override (rarely needed; useful to clear existing port filters by passing \`\"ANY\"\` on update)
- \`source_match_opposite_ports\` / \`destination_match_opposite_ports\` — NOT-port semantics

The discriminator is **auto-detected** from which of \`port\` / \`port_group_id\` the caller supplies, so the LLM doesn't need to think about the mode field. Conflict guard raises \`ValueError\` if both are passed on the same side.

A shared \`_build_match_target()\` helper handles construction in \`create_firewall_policy\`. Update uses a separate \`_collect_port_overrides()\` + \`_merge_port_overrides()\` pair so port overrides land on the existing source/destination sub-dicts (preserving zone_id, matching_target, ips, etc.) and the now-unused field is cleared on mode switches — e.g. switching from OBJECT → SPECIFIC drops the stale \`port_group_id\`.

### Model updates

\`MatchTarget\` (in \`src/models/firewall_policy.py\`) gains an explicit \`port_group_id: str | None\` field. It was previously only permitted via \`extra=\"allow\"\`, which meant it wasn't visible in the schema or type-checked.

\`src/models/firewall_group.py\` (new) adds \`FirewallGroup\` / \`FirewallGroupCreate\` / \`FirewallGroupUpdate\` pydantic models with the \`group_type\` literal type.

## Testing

**Unit tests:** 1176 passing (1 pre-existing unrelated failure in \`test_security.py::test_diskcache_not_installed\`). 30 new tests:

- **\`test_firewall_groups_tools.py\` (20 tests):**
  - Local-API gate (cloud rejection)
  - List / get / create / update / delete CRUD
  - port-group and address-group create round-trips with verified body shape
  - GET-merge-PUT contract: \`_id\` / \`site_id\` / \`external_id\` stripped from PUT body
  - confirm coercion: \`confirm=\"False\"\` (truthy string) must NOT bypass the gate
  - Validation: invalid \`group_type\`, non-list \`group_members\`
  - \`dry_run\` for every mutating tool

- **\`test_firewall_policies.py\` (10 new tests under \`TestCreateFirewallPolicyPortMatching\` and \`TestUpdateFirewallPolicyPortMatching\`):**
  - SPECIFIC mode auto-set when only \`port\` is supplied
  - OBJECT mode auto-set when only \`port_group_id\` is supplied
  - Port range strings (\`\"9000-9010\"\`) accepted
  - \`match_opposite_ports\` passthrough
  - Conflict guard on \`port\` + \`port_group_id\` simultaneously
  - Update mode-switch clears stale port field (OBJECT→SPECIFIC drops \`port_group_id\`)
  - Switching to ANY clears both \`port\` and \`port_group_id\`
  - Unrelated-field update leaves existing port settings alone

**Live controller validation** (UDM Pro, UniFi Network 10.2.x, end-to-end via \`asyncio.run\`):

- \`list_firewall_groups\` returned the existing \"Allow Identity Sync Service Connection-9543\" port group
- \`create_port_group(name=\"mcp-e2e-test-group\", ports=[\"8080\", \"9000-9010\"])\` created the group; HTTP 200 on POST
- \`update_firewall_group\` merged \`[\"8080\", \"9000-9010\", \"5555\"]\`; HTTP 200 on PUT
- \`delete_firewall_group\` cleaned up; HTTP 200 on DELETE

Endpoint translator output confirms the path mapping:
\`\`\`
Endpoint translation: /ea/sites/default/rest/firewallgroup → /proxy/network/api/s/default/rest/firewallgroup
\`\`\`

## Type of Change

- [x] New feature (firewall_groups module + port matching on policies)
- [x] Backwards-compatible — all new parameters are optional. Existing \`create_firewall_policy\` / \`update_firewall_policy\` callers continue to work unchanged (port_matching_type defaults to ANY).

## Checklist

- [x] Self-reviewed
- [x] Tests added for new functionality (30 new tests)
- [x] No new warnings
- [x] Unit tests pass locally
- [x] \`sanitize_log_message()\` preserved on all touched log sites
- [x] New module follows the same \`_ensure_local_api()\` + GET-merge-PUT + \`coerce_bool\` patterns as the existing firewall_policies module
- [x] End-to-end validated against a live UDM Pro