### PR TITLE
fix: network vlan model alias, API field name, remove immutable purpose param

### DIFF
--- a/src/models/network.py
+++ b/src/models/network.py
@@ -11,8 +11,8 @@ class Network(BaseModel):
     purpose: str = Field(..., description="Network purpose (corporate, guest, etc.)")
 
     # Network configuration
-    vlan: int | None = Field(None, description="VLAN ID", alias="vlan_enabled")
-    vlan_id: int | None = Field(None, description="VLAN number")
+    vlan_enabled: bool | None = Field(None, description="VLAN assignment enabled")
+    vlan_id: int | None = Field(None, description="VLAN ID number", alias="vlan")
     enabled: bool | None = Field(None, description="Whether network is enabled")
 
     # IP configuration
@@ -52,7 +52,7 @@ class Network(BaseModel):
                 "name": "LAN",
                 "purpose": "corporate",
                 "vlan_enabled": True,
-                "vlan_id": 1,
+                "vlan": 1,
                 "ip_subnet": "192.168.1.0/24",
                 "dhcpd_enabled": True,
                 "dhcpd_start": "192.168.2.100",

--- a/src/tools/network_config.py
+++ b/src/tools/network_config.py
@@ -164,7 +164,6 @@ async def update_network(
     name: str | None = None,
     vlan_id: int | None = None,
     subnet: str | None = None,
-    purpose: str | None = None,
     dhcp_enabled: bool | None = None,
     dhcp_start: str | None = None,
     dhcp_stop: str | None = None,
@@ -178,6 +177,9 @@ async def update_network(
 ) -> dict[str, Any]:
     """Update an existing network.
 
+    Note: Network purpose (corporate, guest, vlan-only) cannot be changed after
+    creation. To change purpose, delete and recreate the network.
+
     Args:
         site_id: Site identifier
         network_id: Network ID
@@ -185,7 +187,6 @@ async def update_network(
         name: New network name
         vlan_id: New VLAN ID (1-4094)
         subnet: New subnet in CIDR notation
-        purpose: New purpose (corporate, guest, vlan-only)
         dhcp_enabled: Enable/disable DHCP
         dhcp_start: New DHCP range start IP
         dhcp_stop: New DHCP range stop IP
@@ -210,12 +211,6 @@ async def update_network(
     if vlan_id is not None and not 1 <= vlan_id <= 4094:
         raise ValidationError(f"Invalid VLAN ID {vlan_id}. Must be between 1 and 4094")
 
-    # Validate purpose if provided
-    if purpose is not None:
-        valid_purposes = ["corporate", "guest", "vlan-only", "wan"]
-        if purpose not in valid_purposes:
-            raise ValidationError(f"Invalid purpose '{purpose}'. Must be one of: {valid_purposes}")
-
     # Validate subnet format if provided
     if subnet is not None and "/" not in subnet:
         raise ValidationError(f"Invalid subnet '{subnet}'. Must be in CIDR notation")
@@ -226,7 +221,6 @@ async def update_network(
         "name": name,
         "vlan_id": vlan_id,
         "subnet": subnet,
-        "purpose": purpose,
         "dhcp_enabled": dhcp_enabled,
     }
 
@@ -271,8 +265,6 @@ async def update_network(
                 update_data["vlan"] = vlan_id
             if subnet is not None:
                 update_data["ip_subnet"] = subnet
-            if purpose is not None:
-                update_data["purpose"] = purpose
             if dhcp_enabled is not None:
                 update_data["dhcpd_enabled"] = dhcp_enabled
             if dhcp_start is not None:

--- a/tests/unit/tools/test_network_config_tools.py
+++ b/tests/unit/tools/test_network_config_tools.py
@@ -596,21 +596,6 @@ async def test_update_network_invalid_vlan(mock_settings):
 
 
 @pytest.mark.asyncio
-async def test_update_network_invalid_purpose(mock_settings):
-    """Test update network with invalid purpose."""
-    with pytest.raises(ValidationError) as excinfo:
-        await update_network(
-            site_id="default",
-            network_id="network123",
-            settings=mock_settings,
-            purpose="invalid",
-            confirm=True,
-        )
-
-    assert "purpose" in str(excinfo.value).lower()
-
-
-@pytest.mark.asyncio
 async def test_update_network_invalid_subnet(mock_settings):
     """Test update network with invalid subnet format."""
     with pytest.raises(ValidationError) as excinfo:
@@ -645,7 +630,7 @@ async def test_update_network_multiple_fields(mock_settings):
             {
                 "_id": "network123",
                 "name": "New Name",
-                "purpose": "guest",
+                "purpose": "corporate",
                 "vlan": 20,
                 "ip_subnet": "192.168.20.0/24",
                 "dhcpd_enabled": False,
@@ -666,7 +651,6 @@ async def test_update_network_multiple_fields(mock_settings):
             network_id="network123",
             settings=mock_settings,
             name="New Name",
-            purpose="guest",
             vlan_id=20,
             subnet="192.168.20.0/24",
             dhcp_enabled=False,
@@ -674,7 +658,7 @@ async def test_update_network_multiple_fields(mock_settings):
         )
 
     assert result["name"] == "New Name"
-    assert result["purpose"] == "guest"
+    assert result["purpose"] == "corporate"
     assert result["vlan"] == 20
     assert result["dhcpd_enabled"] is False
 


### PR DESCRIPTION
## Summary
- **Network model `vlan_id` alias fix**: The Pydantic `Network` model's `vlan_id` field had no alias, so `get_network_details` deserialized the API's `"vlan": 50` as `null`. Added `alias="vlan"` to match the actual legacy REST API field name (verified from live controller response).
- **Model `vlan_enabled` type fix**: Was `int | None` with alias `"vlan_enabled"` — corrected to `bool | None` matching the API's boolean field.
- **`purpose` removed from `update_network`**: Confirmed immutable after network creation. The UniFi API silently ignores purpose changes on PUT. Parameter removed; docstring documents the constraint.
- **Test updates**: Assertions corrected to match verified API field names.

## Context
Discovered during live testing against a UDM Pro running Network 10.2.105. The `update_network` tool appeared to not apply `vlan_id` or `purpose` changes — root cause was a model alias mismatch (vlan) and an API constraint (purpose).

## Test plan
- [ ] `pytest tests/unit/tools/test_network_config_tools.py` — 30 tests pass
- [ ] Full suite 1,175 tests pass (excluding pre-existing `test_diskcache_not_installed`)