### PR TITLE
feat: update_wlan param parity, AP radio channel config, API docs v10.2.105

### DIFF
--- a/docs/UNIFI_API.md
+++ b/docs/UNIFI_API.md
@@ -1,4 +1,4 @@
-# UniFi Network API Documentation (v10.0.160)
+# UniFi Network API Documentation (v10.2.105)
 
 ## Overview
 
@@ -21,6 +21,7 @@ This document provides comprehensive reference documentation for the UniFi Netwo
 - [Firewall](#firewall)
 - [Firewall Policies](#firewall-policies)
 - [Access Control (ACL Rules)](#access-control-acl-rules)
+- [Switching](#switching)
 - [DNS Policies](#dns-policies)
 - [Traffic Matching Lists](#traffic-matching-lists)
 - [Quality of Service (QoS)](#quality-of-service-qos)
@@ -571,6 +572,22 @@ Perform an action on a specific device port.
 
 **Response:** `200 OK`
 
+### Remove (Unadopt) Device
+
+Removes (unadopts) an adopted device from the site. If the device is online, it will be reset to factory defaults.
+
+- **Method:** `DELETE`
+- **Endpoint:** `/v1/sites/{siteId}/devices/{deviceId}`
+
+**Path Parameters:**
+
+| Parameter | Type | Required |
+|-----------|------|----------|
+| `siteId` | string (uuid) | Yes |
+| `deviceId` | string (uuid) | Yes |
+
+**Response:** `200 OK`
+
 ---
 
 ## Clients
@@ -642,7 +659,13 @@ Perform an action on a specific connected client.
 
 ## Networks
 
-Endpoints for creating, updating, deleting, and inspecting network configurations.
+Endpoints for creating, updating, deleting, and inspecting network configurations including VLANs, DHCP, NAT, and IPv4/IPv6 settings.
+
+> **API Limitations (verified 2026-04-13):**
+> - The v1 Network API only exposes `management`, `name`, `enabled`, `vlanId`, and `dhcpGuarding`. DHCP range, subnet, purpose, and isolation settings are NOT available through the v1 API.
+> - The legacy REST API (`/rest/networkconf`) exposes more fields (DHCP, subnet, purpose) but `purpose` is **immutable after creation**.
+> - **Network-level client isolation** ("Isolate Network" in the UI) is not available through any documented API. Use `clientIsolationEnabled` on WiFi Broadcasts for SSID-level isolation instead.
+> - The legacy REST API uses `"vlan"` (not `"vlan_id"`) for the VLAN number field.
 
 ### List Networks
 
@@ -1640,6 +1663,162 @@ Reorder user-defined ACL rules on a site.
 ```
 
 **Response:** `200 OK`
+
+---
+
+## Switching
+
+Endpoints for managing switching features like Switch Stacking and LAG (Link Aggregation Groups).
+
+### List Switch Stacks
+
+Retrieve a paginated list of all Switch Stacks on a site.
+
+- **Method:** `GET`
+- **Endpoint:** `/v1/sites/{siteId}/switching/switch-stacks`
+
+**Path Parameters:**
+
+| Parameter | Type | Required |
+|-----------|------|----------|
+| `siteId` | string (uuid) | Yes |
+
+**Query Parameters:**
+
+| Parameter | Type | Default |
+|-----------|------|---------|
+| `offset` | integer (int32) | 0 |
+| `limit` | integer (int32) | 25 |
+| `filter` | string | - |
+
+**Response:** `200 OK` — paginated list
+
+### Get Switch Stack
+
+Retrieve Switch Stack details.
+
+- **Method:** `GET`
+- **Endpoint:** `/v1/sites/{siteId}/switching/switch-stacks/{switchStackId}`
+
+**Path Parameters:**
+
+| Parameter | Type | Required |
+|-----------|------|----------|
+| `siteId` | string (uuid) | Yes |
+| `switchStackId` | string (uuid) | Yes |
+
+**Response:** `200 OK`
+
+```json
+{
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "name": "string",
+  "members": [{}, {}],
+  "lags": [{}],
+  "metadata": {
+    "origin": "string"
+  }
+}
+```
+
+### List MC-LAG Domains
+
+Retrieve a paginated list of all MC-LAG Domains on a site.
+
+- **Method:** `GET`
+- **Endpoint:** `/v1/sites/{siteId}/switching/mc-lag-domains`
+
+**Path Parameters:**
+
+| Parameter | Type | Required |
+|-----------|------|----------|
+| `siteId` | string (uuid) | Yes |
+
+**Query Parameters:**
+
+| Parameter | Type | Default |
+|-----------|------|---------|
+| `offset` | integer (int32) | 0 |
+| `limit` | integer (int32) | 25 |
+| `filter` | string | - |
+
+**Response:** `200 OK` — paginated list
+
+### Get MC-LAG Domain
+
+Retrieve MC-LAG Domain details.
+
+- **Method:** `GET`
+- **Endpoint:** `/v1/sites/{siteId}/switching/mc-lag-domains/{mcLagDomainId}`
+
+**Path Parameters:**
+
+| Parameter | Type | Required |
+|-----------|------|----------|
+| `siteId` | string (uuid) | Yes |
+| `mcLagDomainId` | string (uuid) | Yes |
+
+**Response:** `200 OK`
+
+```json
+{
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "name": "string",
+  "peers": [{}],
+  "lags": [{}],
+  "metadata": {
+    "origin": "string"
+  }
+}
+```
+
+### List LAGs
+
+Retrieve a paginated list of all LAGs (Link Aggregation Groups) on a site.
+
+- **Method:** `GET`
+- **Endpoint:** `/v1/sites/{siteId}/switching/lags`
+
+**Path Parameters:**
+
+| Parameter | Type | Required |
+|-----------|------|----------|
+| `siteId` | string (uuid) | Yes |
+
+**Query Parameters:**
+
+| Parameter | Type | Default |
+|-----------|------|---------|
+| `offset` | integer (int32) | 0 |
+| `limit` | integer (int32) | 25 |
+| `filter` | string | - |
+
+**Response:** `200 OK` — paginated list
+
+### Get LAG Details
+
+Retrieve LAG details.
+
+- **Method:** `GET`
+- **Endpoint:** `/v1/sites/{siteId}/switching/lags/{lagId}`
+
+**Path Parameters:**
+
+| Parameter | Type | Required |
+|-----------|------|----------|
+| `siteId` | string (uuid) | Yes |
+| `lagId` | string (uuid) | Yes |
+
+**Response:** `200 OK`
+
+```json
+{
+  "type": "SWITCH_STACK",
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "members": [{}],
+  "switchStackId": "bd2c5532-16a4-4f97-91d1-09f6ed6a3b97"
+}
+```
 
 ---
 

--- a/src/tools/device_control.py
+++ b/src/tools/device_control.py
@@ -6,6 +6,7 @@ from ..api import UniFiClient
 from ..config import Settings
 from ..utils import (
     ResourceNotFoundError,
+    ValidationError,
     get_logger,
     log_audit,
     sanitize_log_message,
@@ -13,6 +14,26 @@ from ..utils import (
     validate_mac_address,
     validate_site_id,
 )
+
+# Radio identifiers: UniFi uses "ng" for 2.4GHz, "na" for 5GHz, "6e" for 6GHz
+RADIO_BAND_MAP = {
+    "2.4": "ng",
+    "2.4ghz": "ng",
+    "ng": "ng",
+    "5": "na",
+    "5ghz": "na",
+    "na": "na",
+    "6": "6e",
+    "6ghz": "6e",
+    "6e": "6e",
+}
+
+# Valid channels per band
+VALID_CHANNELS = {
+    "ng": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+    "na": [36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144, 149, 153, 157, 161, 165],
+    "6e": list(range(1, 234, 4)),  # 6GHz channels
+}
 
 
 async def restart_device(
@@ -318,6 +339,319 @@ async def upgrade_device(
         logger.error(sanitize_log_message(f"Failed to upgrade device '{device_mac}': {e}"))
         log_audit(
             operation="upgrade_device",
+            parameters=parameters,
+            result="failed",
+            site_id=site_id,
+        )
+        raise
+
+
+def _resolve_radio(band: str) -> str:
+    """Resolve a band name to the UniFi radio identifier."""
+    key = band.lower().strip()
+    radio = RADIO_BAND_MAP.get(key)
+    if not radio:
+        raise ValidationError(
+            f"Invalid radio band '{band}'. Use: 2.4, 5, 6 (or ng, na, 6e)"
+        )
+    return radio
+
+
+async def get_ap_radio_config(
+    site_id: str,
+    device_id: str,
+    settings: Settings,
+) -> dict[str, Any]:
+    """Get radio configuration for an access point (read-only).
+
+    Returns current channel, channel width (HT mode), and transmit power for
+    each radio on the device.
+
+    Args:
+        site_id: Site identifier
+        device_id: Device ID or MAC address
+
+    Returns:
+        Dictionary with device info and radio_table entries
+    """
+    site_id = validate_site_id(site_id)
+    logger = get_logger(__name__, settings.log_level)
+
+    async with UniFiClient(settings) as client:
+        await client.authenticate()
+
+        response = await client.get(
+            settings.get_site_api_path(site_id, "stat/device")
+        )
+        all_devices: list[dict[str, Any]] = (
+            response if isinstance(response, list) else response.get("data", [])
+        )
+
+        device = next(
+            (
+                d
+                for d in all_devices
+                if d.get("_id") == device_id or d.get("mac") == device_id
+            ),
+            None,
+        )
+
+        if not device:
+            raise ResourceNotFoundError("device", device_id)
+
+        radio_table = device.get("radio_table", [])
+        radio_table_stats = device.get("radio_table_stats", [])
+
+        # Build a stats lookup by radio name
+        stats_by_radio = {r.get("name"): r for r in radio_table_stats}
+
+        radios = []
+        for radio in radio_table:
+            radio_name = radio.get("radio", radio.get("name", "unknown"))
+            band = {"ng": "2.4GHz", "na": "5GHz", "6e": "6GHz"}.get(
+                radio_name, radio_name
+            )
+            stats = stats_by_radio.get(radio_name, {})
+            radios.append(
+                {
+                    "radio": radio_name,
+                    "band": band,
+                    "channel": radio.get("channel", "auto"),
+                    "ht": radio.get("ht"),
+                    "tx_power_mode": radio.get("tx_power_mode"),
+                    "tx_power": radio.get("tx_power"),
+                    "min_rssi_enabled": radio.get("min_rssi_enabled"),
+                    "min_rssi": radio.get("min_rssi"),
+                    "current_channel": stats.get("channel"),
+                    "satisfaction": stats.get("satisfaction"),
+                    "num_sta": stats.get("num_sta"),
+                }
+            )
+
+        logger.info(
+            sanitize_log_message(
+                f"Retrieved radio config for device '{device_id}' in site '{site_id}'"
+            )
+        )
+
+        return {
+            "device_id": device.get("_id"),
+            "device_name": device.get("name"),
+            "model": device.get("model"),
+            "mac": device.get("mac"),
+            "radios": radios,
+        }
+
+
+async def set_ap_radio_channel(
+    site_id: str,
+    device_id: str,
+    band: str,
+    channel: int | str,
+    settings: Settings,
+    ht: str | None = None,
+    tx_power_mode: str | None = None,
+    tx_power: int | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Set the radio channel (and optionally width/power) for an access point.
+
+    Args:
+        site_id: Site identifier
+        device_id: Device ID or MAC address
+        band: Radio band — "2.4", "5", or "6" (also accepts "ng", "na", "6e")
+        channel: WiFi channel number, or "auto" for automatic channel selection
+        settings: Application settings
+        ht: Channel width — e.g. "20" for HT20, "40" for HT40, "80" for VHT80,
+            "160" for VHT160. If not specified, existing width is preserved.
+        tx_power_mode: Transmit power mode — "auto", "medium", "low", "high",
+            or "custom". If not specified, existing mode is preserved.
+        tx_power: Custom transmit power in dBm (only used when tx_power_mode
+            is "custom"). Range varies by device.
+        confirm: Confirmation flag (must be True to execute)
+        dry_run: If True, show what would change without applying
+
+    Returns:
+        Updated radio configuration or dry-run preview
+
+    Raises:
+        ConfirmationRequiredError: If confirm is not True
+        ResourceNotFoundError: If device not found
+        ValidationError: If radio band or channel is invalid
+    """
+    site_id = validate_site_id(site_id)
+    validate_confirmation(confirm, "device radio configuration", dry_run)
+    logger = get_logger(__name__, settings.log_level)
+
+    radio = _resolve_radio(band)
+
+    # Validate channel
+    is_auto = str(channel).lower() == "auto"
+    if not is_auto:
+        channel = int(channel)
+        valid = VALID_CHANNELS.get(radio, [])
+        if valid and channel not in valid:
+            band_label = {"ng": "2.4GHz", "na": "5GHz", "6e": "6GHz"}.get(radio, radio)
+            raise ValidationError(
+                f"Invalid channel {channel} for {band_label}. Valid: {valid}"
+            )
+
+    # Validate HT mode if provided
+    if ht is not None:
+        ht = str(ht)
+        valid_ht = {"ng": ["20", "40"], "na": ["20", "40", "80", "160"], "6e": ["20", "40", "80", "160"]}
+        allowed = valid_ht.get(radio, [])
+        if ht not in allowed:
+            raise ValidationError(
+                f"Invalid channel width '{ht}' for {radio}. Valid: {allowed}"
+            )
+
+    # Validate tx_power_mode
+    if tx_power_mode is not None:
+        valid_modes = ["auto", "medium", "low", "high", "custom"]
+        if tx_power_mode not in valid_modes:
+            raise ValidationError(
+                f"Invalid tx_power_mode '{tx_power_mode}'. Valid: {valid_modes}"
+            )
+
+    parameters = {
+        "site_id": site_id,
+        "device_id": device_id,
+        "band": band,
+        "radio": radio,
+        "channel": channel if not is_auto else "auto",
+        "ht": ht,
+        "tx_power_mode": tx_power_mode,
+        "tx_power": tx_power,
+    }
+
+    if dry_run:
+        logger.info(
+            sanitize_log_message(
+                f"DRY RUN: Would set {radio} channel to "
+                f"{'auto' if is_auto else channel} on device '{device_id}'"
+            )
+        )
+        log_audit(
+            operation="set_ap_radio_channel",
+            parameters=parameters,
+            result="dry_run",
+            site_id=site_id,
+            dry_run=True,
+        )
+        return {"dry_run": True, "would_set": parameters}
+
+    try:
+        async with UniFiClient(settings) as client:
+            await client.authenticate()
+
+            # Fetch full device object via stat/device
+            response = await client.get(
+                settings.get_site_api_path(site_id, "stat/device")
+            )
+            all_devices: list[dict[str, Any]] = (
+                response if isinstance(response, list) else response.get("data", [])
+            )
+
+            device = next(
+                (
+                    d
+                    for d in all_devices
+                    if d.get("_id") == device_id or d.get("mac") == device_id
+                ),
+                None,
+            )
+
+            if not device:
+                raise ResourceNotFoundError("device", device_id)
+
+            radio_table = device.get("radio_table", [])
+            if not radio_table:
+                raise ValidationError(
+                    f"Device '{device_id}' has no radio_table — "
+                    "it may not be an access point"
+                )
+
+            # Find the target radio entry
+            target = None
+            for entry in radio_table:
+                if entry.get("radio") == radio or entry.get("name") == radio:
+                    target = entry
+                    break
+
+            if not target:
+                available = [
+                    e.get("radio", e.get("name")) for e in radio_table
+                ]
+                raise ValidationError(
+                    f"Radio '{radio}' not found on device. "
+                    f"Available radios: {available}"
+                )
+
+            # Capture old values for the response
+            old_channel = target.get("channel")
+            old_ht = target.get("ht")
+
+            # Apply changes
+            if is_auto:
+                target["channel"] = "auto"
+            else:
+                target["channel"] = channel
+
+            if ht is not None:
+                target["ht"] = ht
+
+            if tx_power_mode is not None:
+                target["tx_power_mode"] = tx_power_mode
+
+            if tx_power is not None:
+                target["tx_power"] = tx_power
+
+            # PUT the full device back
+            resolved_id = device["_id"]
+            endpoint = settings.get_site_api_path(
+                site_id, f"rest/device/{resolved_id}"
+            )
+            response = await client.put(endpoint, json_data=device)
+            if isinstance(response, list):
+                updated_device: dict[str, Any] = response[0] if response else {}
+            else:
+                updated_device = response.get("data", [{}])[0]
+
+            logger.info(
+                sanitize_log_message(
+                    f"Set {radio} channel to {'auto' if is_auto else channel} "
+                    f"on device '{device_id}' in site '{site_id}'"
+                )
+            )
+            log_audit(
+                operation="set_ap_radio_channel",
+                parameters=parameters,
+                result="success",
+                site_id=site_id,
+            )
+
+            return {
+                "success": True,
+                "device_id": resolved_id,
+                "device_name": device.get("name"),
+                "radio": radio,
+                "band": {"ng": "2.4GHz", "na": "5GHz", "6e": "6GHz"}.get(radio, radio),
+                "old_channel": old_channel,
+                "new_channel": "auto" if is_auto else channel,
+                "old_ht": old_ht,
+                "new_ht": ht if ht is not None else old_ht,
+            }
+
+    except Exception as e:
+        logger.error(
+            sanitize_log_message(
+                f"Failed to set radio channel on device '{device_id}': {e}"
+            )
+        )
+        log_audit(
+            operation="set_ap_radio_channel",
             parameters=parameters,
             result="failed",
             site_id=site_id,

--- a/src/tools/wifi.py
+++ b/src/tools/wifi.py
@@ -72,6 +72,7 @@ async def create_wlan(
     minrate_ng_enabled: bool | None = None,
     minrate_ng_data_rate_kbps: int | None = None,
     hide_ssid: bool = False,
+    client_isolation: bool = False,
     confirm: bool | str = False,
     dry_run: bool | str = False,
 ) -> dict[str, Any]:
@@ -96,6 +97,8 @@ async def create_wlan(
         minrate_ng_enabled: Enable minimum data rate for 2.4GHz
         minrate_ng_data_rate_kbps: Minimum 2.4GHz data rate in kbps (e.g. 1000)
         hide_ssid: Hide SSID from broadcast
+        client_isolation: Enable client device isolation (prevents wireless clients
+            from communicating with each other on this SSID)
         confirm: Confirmation flag (must be True to execute)
         dry_run: If True, validate but don't create the WLAN
 
@@ -140,6 +143,7 @@ async def create_wlan(
         "enabled": enabled,
         "is_guest": is_guest,
         "hide_ssid": hide_ssid,
+        "l2_isolation": client_isolation,
     }
 
     if security == "wpapsk":
@@ -210,7 +214,10 @@ async def create_wlan(
             await client.authenticate()
 
             response = await client.post(f"/ea/sites/{site_id}/rest/wlanconf", json_data=wlan_data)
-            created_wlan: dict[str, Any] = response.get("data", [{}])[0]
+            if isinstance(response, list):
+                created_wlan: dict[str, Any] = response[0] if response else {}
+            else:
+                created_wlan = response.get("data", [{}])[0]
 
             logger.info(sanitize_log_message(f"Created WLAN '{name}' in site '{site_id}'"))
             log_audit(
@@ -245,7 +252,15 @@ async def update_wlan(
     wpa_mode: str | None = None,
     wpa_enc: str | None = None,
     vlan_id: int | None = None,
+    networkconf_id: str | None = None,
+    ap_group_ids: list[str] | None = None,
+    ap_group_mode: str | None = None,
+    wlan_bands: list[str] | None = None,
+    optimize_iot_wifi_connectivity: bool | None = None,
+    minrate_ng_enabled: bool | None = None,
+    minrate_ng_data_rate_kbps: int | None = None,
     hide_ssid: bool | None = None,
+    client_isolation: bool | None = None,
     confirm: bool | str = False,
     dry_run: bool | str = False,
 ) -> dict[str, Any]:
@@ -263,7 +278,16 @@ async def update_wlan(
         wpa_mode: New WPA mode (wpa, wpa2, wpa3)
         wpa_enc: New WPA encryption (tkip, ccmp, ccmp-tkip)
         vlan_id: New VLAN ID
+        networkconf_id: Network configuration ID to associate this SSID with
+        ap_group_ids: List of AP group IDs to broadcast this SSID on
+        ap_group_mode: AP group mode (groups, all)
+        wlan_bands: WiFi bands as list (e.g. ["2g"], ["5g"], ["2g", "5g"])
+        optimize_iot_wifi_connectivity: Enable IoT WiFi optimizations
+        minrate_ng_enabled: Enable minimum data rate for 2.4GHz (forces efficient
+            clients off low rates that hog airtime)
+        minrate_ng_data_rate_kbps: Minimum 2.4GHz data rate in kbps (e.g. 6000-12000)
         hide_ssid: Hide/show SSID from broadcast
+        client_isolation: Enable/disable client device isolation
         confirm: Confirmation flag (must be True to execute)
         dry_run: If True, validate but don't update the WLAN
 
@@ -314,7 +338,13 @@ async def update_wlan(
         "enabled": enabled,
         "is_guest": is_guest,
         "vlan_id": vlan_id,
+        "networkconf_id": networkconf_id,
+        "ap_group_ids": ap_group_ids,
+        "wlan_bands": wlan_bands,
+        "minrate_ng_enabled": minrate_ng_enabled,
+        "minrate_ng_data_rate_kbps": minrate_ng_data_rate_kbps,
         "hide_ssid": hide_ssid,
+        "client_isolation": client_isolation,
         "password": "***MASKED***" if password else None,
     }
 
@@ -333,9 +363,12 @@ async def update_wlan(
         async with UniFiClient(settings) as client:
             await client.authenticate()
 
-            # Get existing WLAN
+            # Get existing WLAN (response may be auto-unwrapped list or wrapped dict)
             response = await client.get(f"/ea/sites/{site_id}/rest/wlanconf")
-            wlans_data: list[dict[str, Any]] = response.get("data", [])
+            if isinstance(response, list):
+                wlans_data: list[dict[str, Any]] = response
+            else:
+                wlans_data = response.get("data", [])
 
             existing_wlan = None
             for wlan in wlans_data:
@@ -366,13 +399,35 @@ async def update_wlan(
             if vlan_id is not None:
                 update_data["vlan"] = vlan_id
                 update_data["vlan_enabled"] = True
+            if networkconf_id is not None:
+                update_data["networkconf_id"] = networkconf_id
+            if ap_group_ids is not None:
+                update_data["ap_group_ids"] = ap_group_ids
+            if ap_group_mode is not None:
+                update_data["ap_group_mode"] = ap_group_mode
+            if wlan_bands is not None:
+                update_data["wlan_bands"] = wlan_bands
+            if optimize_iot_wifi_connectivity is not None:
+                update_data["optimize_iot_wifi_connectivity"] = optimize_iot_wifi_connectivity
+                if optimize_iot_wifi_connectivity:
+                    update_data["b_supported"] = True
+                    update_data["no2ghz_oui"] = False
+            if minrate_ng_enabled is not None:
+                update_data["minrate_ng_enabled"] = minrate_ng_enabled
+            if minrate_ng_data_rate_kbps is not None:
+                update_data["minrate_ng_data_rate_kbps"] = minrate_ng_data_rate_kbps
             if hide_ssid is not None:
                 update_data["hide_ssid"] = hide_ssid
+            if client_isolation is not None:
+                update_data["l2_isolation"] = client_isolation
 
             response = await client.put(
                 f"/ea/sites/{site_id}/rest/wlanconf/{wlan_id}", json_data=update_data
             )
-            updated_wlan: dict[str, Any] = response.get("data", [{}])[0]
+            if isinstance(response, list):
+                updated_wlan: dict[str, Any] = response[0] if response else {}
+            else:
+                updated_wlan = response.get("data", [{}])[0]
 
             logger.info(sanitize_log_message(f"Updated WLAN '{wlan_id}' in site '{site_id}'"))
             log_audit(
@@ -441,7 +496,10 @@ async def delete_wlan(
 
             # Verify WLAN exists before deleting
             response = await client.get(f"/ea/sites/{site_id}/rest/wlanconf")
-            wlans_data: list[dict[str, Any]] = response.get("data", [])
+            if isinstance(response, list):
+                wlans_data: list[dict[str, Any]] = response
+            else:
+                wlans_data = response.get("data", [])
 
             wlan_exists = any(wlan.get("_id") == wlan_id for wlan in wlans_data)
             if not wlan_exists:
@@ -493,11 +551,17 @@ async def get_wlan_statistics(
 
         # Get WLANs
         wlans_response = await client.get(f"/ea/sites/{site_id}/rest/wlanconf")
-        wlans_data = wlans_response.get("data", [])
+        wlans_data = (
+            wlans_response if isinstance(wlans_response, list) else wlans_response.get("data", [])
+        )
 
         # Get active clients
         clients_response = await client.get(f"/ea/sites/{site_id}/sta")
-        clients_data = clients_response.get("data", [])
+        clients_data = (
+            clients_response
+            if isinstance(clients_response, list)
+            else clients_response.get("data", [])
+        )
 
         # Calculate statistics per WLAN
         wlan_stats = []


### PR DESCRIPTION
## Summary
- **`update_wlan` param parity**: 7 params existed in `create_wlan` but were missing from `update_wlan` — `networkconf_id`, `ap_group_ids`, `ap_group_mode`, `wlan_bands`, `optimize_iot_wifi_connectivity`, `minrate_ng_enabled`, `minrate_ng_data_rate_kbps`, `client_isolation`. All wired into the update payload.
- **WLAN response parsing fix**: `create_wlan`, `update_wlan`, `delete_wlan`, and `get_wlan_client_statistics` all called `.get()` on responses that may be auto-unwrapped lists, causing `'list' object has no attribute 'get'`. Added `isinstance(response, list)` guards.
- **AP radio channel config** (2 new tools):
  - `get_ap_radio_config` — read current channel, width, tx power, and live stats per radio
  - `set_ap_radio_channel` — set channel/width/power on a specific band (2.4/5/6 GHz) with validation. Uses existing `stat/device` → `PUT rest/device/{id}` pattern from port_profiles.
- **API docs updated to v10.2.105**: Added Switching section (Switch Stacks, MC-LAG, LAGs), device removal endpoint, and Networks API limitations callout.

## Context
The `minrate_ng_data_rate_kbps` gap was discovered trying to set minimum data rates on a camera SSID via Claude Desktop — the tool existed for create but not update. The response parsing bug surfaced on the first live `update_wlan` call. Radio config was needed for per-AP channel assignment (UI-only before this).

## Test plan
- [ ] `pytest tests/unit/tools/test_wifi_tools.py` — 31 tests pass
- [ ] Full suite 1,175 tests pass
- [ ] Live test: `update_wlan(minrate_ng_enabled=true, minrate_ng_data_rate_kbps=6000)` on a real AP
- [ ] Live test: `set_ap_radio_channel(band="2.4", channel=11)` on a real AP