### PR TITLE
fix(#77): add WPA3/PMF support to create_wlan for 6 GHz SSIDs

### DIFF
--- a/src/tools/wifi.py
+++ b/src/tools/wifi.py
@@ -149,6 +149,15 @@ async def create_wlan(
             f"Invalid WPA encryption '{wpa_enc}'. Must be one of: {valid_wpa_enc}"
         )
 
+    # Validate WLAN bands (mirrors the same check in update_wlan)
+    if wlan_bands is not None:
+        valid_bands = {"2g", "5g", "6g"}
+        invalid = set(wlan_bands) - valid_bands
+        if invalid:
+            raise ValidationError(f"Invalid WLAN band(s): {invalid}. Must be from: {valid_bands}")
+        if not wlan_bands:
+            raise ValidationError("wlan_bands must contain at least one band")
+
     # Validate PMF mode
     valid_pmf_modes = ["required", "optional", "disabled"]
     if pmf_mode is not None and pmf_mode not in valid_pmf_modes:
@@ -157,6 +166,8 @@ async def create_wlan(
     # Translate wpa_mode="wpa3" to the API-compatible representation.
     # UniFi controllers reject wpa_mode="wpa3" with api.err.InvalidPayload.
     # The correct payload uses wpa_mode="wpa2" with wpa3_support=True.
+    # Also default transition=False and pmf=required — a WPA3-only request
+    # should not silently produce a mixed-mode or unprotected configuration.
     effective_wpa_mode = wpa_mode
     effective_wpa3_support = wpa3_support
     effective_wpa3_transition = wpa3_transition
@@ -166,6 +177,10 @@ async def create_wlan(
         effective_wpa_mode = "wpa2"
         if effective_wpa3_support is None:
             effective_wpa3_support = True
+        if effective_wpa3_transition is None:
+            effective_wpa3_transition = False
+        if effective_pmf_mode is None:
+            effective_pmf_mode = "required"
 
     # Auto-infer WPA3 + PMF for 6 GHz (802.11ax mandate).
     # Explicit caller values always override these defaults.

--- a/src/tools/wifi.py
+++ b/src/tools/wifi.py
@@ -68,6 +68,9 @@ async def create_wlan(
     ap_group_ids: list[str] | None = None,
     ap_group_mode: str | None = None,
     wlan_bands: list[str] | None = None,
+    wpa3_support: bool | None = None,
+    wpa3_transition: bool | None = None,
+    pmf_mode: str | None = None,
     optimize_iot_wifi_connectivity: bool | None = None,
     minrate_ng_enabled: bool | None = None,
     minrate_ng_data_rate_kbps: int | None = None,
@@ -86,13 +89,23 @@ async def create_wlan(
         password: WiFi password (required for wpapsk)
         enabled: Enable the WLAN immediately
         is_guest: Mark as guest network
-        wpa_mode: WPA mode (wpa, wpa2, wpa3)
+        wpa_mode: WPA mode (wpa, wpa2, wpa3). Note: "wpa3" is translated to
+            wpa_mode="wpa2" + wpa3_support=True — UniFi controllers do not
+            accept wpa_mode="wpa3" directly.
         wpa_enc: WPA encryption (tkip, ccmp, ccmp-tkip)
         vlan_id: VLAN ID for network isolation
         networkconf_id: Network configuration ID to associate this SSID with
         ap_group_ids: List of AP group IDs to broadcast this SSID on
         ap_group_mode: AP group mode (groups, all). Required when using ap_group_ids.
-        wlan_bands: WiFi bands as list (e.g. ["2g"], ["5g"], ["2g", "5g"])
+        wlan_bands: WiFi bands as list (e.g. ["2g"], ["5g"], ["6g"], ["2g", "5g"]).
+            When "6g" is included, wpa3_support/wpa3_transition/pmf_mode are
+            auto-inferred to meet the 802.11ax 6 GHz mandate unless explicitly set.
+        wpa3_support: Enable WPA3 support. Auto-set True when wpa_mode="wpa3"
+            or wlan_bands contains "6g".
+        wpa3_transition: Enable WPA2/WPA3 transition (mixed) mode. Auto-set False
+            for 6 GHz (transition mode is not permitted on 6 GHz).
+        pmf_mode: Protected Management Frames mode ("required", "optional",
+            "disabled"). Auto-set to "required" for 6 GHz (802.11ax mandate).
         optimize_iot_wifi_connectivity: Enable IoT WiFi optimizations
         minrate_ng_enabled: Enable minimum data rate for 2.4GHz
         minrate_ng_data_rate_kbps: Minimum 2.4GHz data rate in kbps (e.g. 1000)
@@ -136,6 +149,34 @@ async def create_wlan(
             f"Invalid WPA encryption '{wpa_enc}'. Must be one of: {valid_wpa_enc}"
         )
 
+    # Validate PMF mode
+    valid_pmf_modes = ["required", "optional", "disabled"]
+    if pmf_mode is not None and pmf_mode not in valid_pmf_modes:
+        raise ValidationError(f"Invalid pmf_mode '{pmf_mode}'. Must be one of: {valid_pmf_modes}")
+
+    # Translate wpa_mode="wpa3" to the API-compatible representation.
+    # UniFi controllers reject wpa_mode="wpa3" with api.err.InvalidPayload.
+    # The correct payload uses wpa_mode="wpa2" with wpa3_support=True.
+    effective_wpa_mode = wpa_mode
+    effective_wpa3_support = wpa3_support
+    effective_wpa3_transition = wpa3_transition
+    effective_pmf_mode = pmf_mode
+
+    if wpa_mode == "wpa3":
+        effective_wpa_mode = "wpa2"
+        if effective_wpa3_support is None:
+            effective_wpa3_support = True
+
+    # Auto-infer WPA3 + PMF for 6 GHz (802.11ax mandate).
+    # Explicit caller values always override these defaults.
+    if wlan_bands and "6g" in wlan_bands:
+        if effective_wpa3_support is None:
+            effective_wpa3_support = True
+        if effective_wpa3_transition is None:
+            effective_wpa3_transition = False
+        if effective_pmf_mode is None:
+            effective_pmf_mode = "required"
+
     # Build WLAN data
     wlan_data = {
         "name": name,
@@ -148,8 +189,14 @@ async def create_wlan(
 
     if security == "wpapsk":
         wlan_data["x_passphrase"] = password
-        wlan_data["wpa_mode"] = wpa_mode
+        wlan_data["wpa_mode"] = effective_wpa_mode
         wlan_data["wpa_enc"] = wpa_enc
+        if effective_wpa3_support is not None:
+            wlan_data["wpa3_support"] = effective_wpa3_support
+        if effective_wpa3_transition is not None:
+            wlan_data["wpa3_transition"] = effective_wpa3_transition
+        if effective_pmf_mode is not None:
+            wlan_data["pmf_mode"] = effective_pmf_mode
 
     if vlan_id is not None:
         if not 1 <= vlan_id <= 4094:

--- a/tests/unit/test_main_health_check.py
+++ b/tests/unit/test_main_health_check.py
@@ -60,8 +60,7 @@ class TestHealthCheck:
             expected = "unknown"
 
         assert result["version"] == expected, (
-            f"health_check returned '{result['version']}' but "
-            f"expected '{expected}'."
+            f"health_check returned '{result['version']}' but " f"expected '{expected}'."
         )
 
     async def test_health_check_returns_required_fields(self) -> None:

--- a/tests/unit/tools/test_wifi_tools.py
+++ b/tests/unit/tools/test_wifi_tools.py
@@ -986,3 +986,54 @@ async def test_create_wlan_6g_explicit_params_override_defaults(mock_settings):
     assert payload.get("wpa3_support") is True  # still auto-inferred for 6G
     assert payload.get("wpa3_transition") is True  # caller override respected
     assert payload.get("pmf_mode") == "optional"  # caller override respected
+
+
+@pytest.mark.asyncio
+async def test_create_wlan_invalid_band_raises_validation_error(mock_settings):
+    """Band strings must be lowercase '2g'/'5g'/'6g'; '6G' or 'wifi6' must be rejected."""
+    with pytest.raises(ValidationError, match="band"):
+        await create_wlan(
+            site_id="default",
+            name="Bad Band SSID",
+            security="wpapsk",
+            settings=mock_settings,
+            password="SecurePass123!",
+            wlan_bands=["6G"],  # uppercase — invalid
+            confirm=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_wlan_wpa3_mode_also_sets_transition_and_pmf_defaults(mock_settings):
+    """wpa_mode='wpa3' must default wpa3_transition=False and pmf_mode='required'.
+
+    A WPA3-only request should not silently produce a mixed-mode or
+    unprotected (PMF-less) payload. Explicit caller values still override.
+    """
+    mock_response = {"data": [{"_id": "wlan_wpa3_full", "name": "WPA3 Full"}]}
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(wifi_module, "UniFiClient", return_value=mock_client):
+        await create_wlan(
+            site_id="default",
+            name="WPA3 Full",
+            security="wpapsk",
+            settings=mock_settings,
+            password="SecurePass123!",
+            wpa_mode="wpa3",
+            confirm=True,
+        )
+
+    payload = mock_client.post.call_args.kwargs["json_data"]
+    assert payload["wpa_mode"] == "wpa2"
+    assert payload.get("wpa3_support") is True
+    assert (
+        payload.get("wpa3_transition") is False
+    ), "wpa_mode='wpa3' must default wpa3_transition=False (WPA3-only, not mixed)"
+    assert (
+        payload.get("pmf_mode") == "required"
+    ), "wpa_mode='wpa3' must default pmf_mode='required' (WPA3 mandates PMF)"

--- a/tests/unit/tools/test_wifi_tools.py
+++ b/tests/unit/tools/test_wifi_tools.py
@@ -825,3 +825,164 @@ async def test_get_wlan_statistics_wlan_not_found(mock_settings):
 
     # Should return empty dict when specific WLAN not found
     assert result == {}
+
+
+# =============================================================================
+# WPA3 / 6 GHz payload tests (issue #77)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_create_wlan_wpa3_sends_correct_api_payload(mock_settings):
+    """wpa_mode='wpa3' must NOT be sent literally to the UniFi API.
+
+    UniFi controllers reject wpa_mode='wpa3' with api.err.InvalidPayload.
+    The correct API payload uses wpa_mode='wpa2' together with wpa3_support=True.
+    """
+    mock_response = {"data": [{"_id": "wlan_wpa3", "name": "WPA3 SSID"}]}
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(wifi_module, "UniFiClient", return_value=mock_client):
+        await create_wlan(
+            site_id="default",
+            name="WPA3 SSID",
+            security="wpapsk",
+            settings=mock_settings,
+            password="SecurePass123!",
+            wpa_mode="wpa3",
+            confirm=True,
+        )
+
+    payload = mock_client.post.call_args.kwargs["json_data"]
+    assert payload["wpa_mode"] == "wpa2", (
+        "UniFi API expects wpa_mode='wpa2', not 'wpa3'. " "WPA3 is signalled via wpa3_support=True."
+    )
+    assert payload.get("wpa3_support") is True, "wpa_mode='wpa3' must set wpa3_support=True"
+
+
+@pytest.mark.asyncio
+async def test_create_wlan_6g_band_auto_infers_wpa3_pmf(mock_settings):
+    """6 GHz SSIDs mandate WPA3 + PMF — these must be auto-inferred when not explicit.
+
+    802.11ax (Wi-Fi 6E) requires WPA3 and Protected Management Frames on 6 GHz.
+    A controller returns api.err.InvalidPayload if these fields are missing.
+    """
+    mock_response = {"data": [{"_id": "wlan_6g", "name": "6G SSID"}]}
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(wifi_module, "UniFiClient", return_value=mock_client):
+        await create_wlan(
+            site_id="default",
+            name="6G SSID",
+            security="wpapsk",
+            settings=mock_settings,
+            password="SecurePass123!",
+            wlan_bands=["6g"],
+            confirm=True,
+        )
+
+    payload = mock_client.post.call_args.kwargs["json_data"]
+    assert payload.get("wpa3_support") is True, "6G band requires wpa3_support=True"
+    assert payload.get("wpa3_transition") is False, "6G band must disable WPA2/WPA3 transition"
+    assert payload.get("pmf_mode") == "required", "6G band mandates pmf_mode='required'"
+
+
+@pytest.mark.asyncio
+async def test_create_wlan_6g_dry_run_includes_wpa3_fields(mock_settings):
+    """dry_run for a 6G SSID must preview the inferred WPA3+PMF payload fields."""
+    result = await create_wlan(
+        site_id="default",
+        name="6G SSID",
+        security="wpapsk",
+        settings=mock_settings,
+        password="SecurePass123!",
+        wlan_bands=["6g"],
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert result["dry_run"] is True
+    would_create = result["would_create"]
+    assert would_create.get("wpa3_support") is True, "dry_run should show inferred wpa3_support"
+    assert would_create.get("pmf_mode") == "required", "dry_run should show inferred pmf_mode"
+
+
+@pytest.mark.asyncio
+async def test_create_wlan_explicit_wpa3_params_are_sent(mock_settings):
+    """Explicitly provided wpa3_support/wpa3_transition/pmf_mode must be included in payload."""
+    mock_response = {"data": [{"_id": "wlan_trans", "name": "Transition SSID"}]}
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(wifi_module, "UniFiClient", return_value=mock_client):
+        await create_wlan(
+            site_id="default",
+            name="Transition SSID",
+            security="wpapsk",
+            settings=mock_settings,
+            password="SecurePass123!",
+            wpa3_support=True,
+            wpa3_transition=True,
+            pmf_mode="optional",
+            confirm=True,
+        )
+
+    payload = mock_client.post.call_args.kwargs["json_data"]
+    assert payload.get("wpa3_support") is True
+    assert payload.get("wpa3_transition") is True
+    assert payload.get("pmf_mode") == "optional"
+
+
+@pytest.mark.asyncio
+async def test_create_wlan_invalid_pmf_mode_raises_validation_error(mock_settings):
+    """An unrecognised pmf_mode value must be caught before hitting the API."""
+    with pytest.raises(ValidationError, match="pmf_mode"):
+        await create_wlan(
+            site_id="default",
+            name="Bad SSID",
+            security="wpapsk",
+            settings=mock_settings,
+            password="SecurePass123!",
+            pmf_mode="bogus_mode",
+            confirm=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_wlan_6g_explicit_params_override_defaults(mock_settings):
+    """Explicit params on a 6G SSID override auto-inferred defaults (WPA3 transition mode)."""
+    mock_response = {"data": [{"_id": "wlan_6g_t", "name": "6G Transition"}]}
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(wifi_module, "UniFiClient", return_value=mock_client):
+        await create_wlan(
+            site_id="default",
+            name="6G Transition",
+            security="wpapsk",
+            settings=mock_settings,
+            password="SecurePass123!",
+            wlan_bands=["6g"],
+            wpa3_transition=True,  # caller explicitly wants transition mode
+            pmf_mode="optional",  # caller explicitly sets optional PMF
+            confirm=True,
+        )
+
+    payload = mock_client.post.call_args.kwargs["json_data"]
+    assert payload.get("wpa3_support") is True  # still auto-inferred for 6G
+    assert payload.get("wpa3_transition") is True  # caller override respected
+    assert payload.get("pmf_mode") == "optional"  # caller override respected


### PR DESCRIPTION
## Summary

Fixes #77 — `create_wlan` failed with `api.err.InvalidPayload` when creating WPA3 or 6 GHz SSIDs.

**Root causes:**
- `wpa_mode="wpa3"` was passed literally to the UniFi API. Controllers only accept `wpa_mode="wpa2"` + `wpa3_support=True` — `"wpa3"` is a UI abstraction that must be translated client-side
- 6 GHz SSIDs require `wpa3_support=True`, `wpa3_transition=False`, and `pmf_mode="required"` (802.11ax mandate). None of these fields were included in the payload

**Changes:**
- Add `wpa3_support`, `wpa3_transition`, `pmf_mode` parameters to `create_wlan`
- Translate `wpa_mode="wpa3"` → `wpa_mode="wpa2"` + `wpa3_support=True` in the API payload
- Auto-infer 6 GHz WPA3+PMF defaults when `wlan_bands` contains `"6g"` (explicit values override)
- Validate `pmf_mode` — accepted values: `"required"`, `"optional"`, `"disabled"`
- Dry-run preview now includes WPA3/PMF fields so users can inspect the full payload before confirming

## Test plan

- [x] `test_create_wlan_wpa3_sends_correct_api_payload` — verifies `wpa_mode="wpa3"` sends `wpa_mode="wpa2"` + `wpa3_support=True`
- [x] `test_create_wlan_6g_band_auto_infers_wpa3_pmf` — verifies 6G auto-inference of all three fields
- [x] `test_create_wlan_6g_dry_run_includes_wpa3_fields` — dry-run shows inferred fields
- [x] `test_create_wlan_explicit_wpa3_params_are_sent` — explicit params passed through
- [x] `test_create_wlan_invalid_pmf_mode_raises_validation_error` — bad pmf_mode caught early
- [x] `test_create_wlan_6g_explicit_params_override_defaults` — caller overrides auto-inference
- [x] 1246 total tests, 0 failures (baseline was 1240)