### PR TITLE
feat(phase-2): add Cloud Connector proxy tools (10 tools)

### DIFF
--- a/src/api/site_manager_client.py
+++ b/src/api/site_manager_client.py
@@ -116,6 +116,74 @@ class SiteManagerClient:
             self.logger.error(f"Unexpected error in Site Manager API request: {e}")
             raise APIError(f"Unexpected error: {e}") from e
 
+    async def _mutate(
+        self,
+        method: str,
+        endpoint: str,
+        json_data: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Make a mutating (POST/PUT/PATCH/DELETE) request to Site Manager API.
+
+        Args:
+            method: HTTP method (post, put, patch, delete)
+            endpoint: API endpoint path (without /v1/ prefix)
+            json_data: Optional request body
+
+        Returns:
+            Response data as dictionary
+
+        Raises:
+            APIError: If API returns an error
+            AuthenticationError: If authentication fails
+        """
+        if not self._authenticated:
+            await self.authenticate()
+
+        try:
+            endpoint = endpoint.lstrip("/")
+            http_method = getattr(self.client, method)
+            if json_data is not None:
+                response = await http_method(endpoint, json=json_data)
+            else:
+                response = await http_method(endpoint)
+            response.raise_for_status()
+
+            if response.content:
+                return cast(dict[str, Any], response.json())
+            return {}
+
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                raise AuthenticationError("Site Manager API authentication failed") from e
+            elif e.response.status_code == 404:
+                raise ResourceNotFoundError("resource", endpoint) from e
+            else:
+                raise APIError(
+                    message=f"Site Manager API error: {e.response.text}",
+                    status_code=e.response.status_code,
+                ) from e
+        except httpx.NetworkError as e:
+            raise NetworkError(f"Network communication failed: {e}") from e
+        except Exception as e:
+            self.logger.error(f"Unexpected error in Site Manager API request: {e}")
+            raise APIError(f"Unexpected error: {e}") from e
+
+    async def post(self, endpoint: str, json_data: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Make a POST request to Site Manager API."""
+        return await self._mutate("post", endpoint, json_data)
+
+    async def put(self, endpoint: str, json_data: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Make a PUT request to Site Manager API."""
+        return await self._mutate("put", endpoint, json_data)
+
+    async def patch(self, endpoint: str, json_data: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Make a PATCH request to Site Manager API."""
+        return await self._mutate("patch", endpoint, json_data)
+
+    async def delete(self, endpoint: str) -> dict[str, Any]:
+        """Make a DELETE request to Site Manager API."""
+        return await self._mutate("delete", endpoint)
+
     async def list_sites(
         self, limit: int | None = None, offset: int | None = None
     ) -> dict[str, Any]:

--- a/src/main.py
+++ b/src/main.py
@@ -23,6 +23,7 @@ from .tools import application as application_tools
 from .tools import backups as backups_tools
 from .tools import client_management as client_mgmt_tools
 from .tools import clients as clients_tools
+from .tools import connector as connector_tools
 from .tools import content_filtering as content_filtering_tools
 from .tools import device_control as device_control_tools
 from .tools import devices as devices_tools
@@ -110,6 +111,7 @@ if os.getenv("AGNOST_ENABLED", "false").lower() in ("true", "1", "yes"):
 _CLOUD_TOOL_MODULES = [
     sites_tools,
     site_manager_tools,
+    connector_tools,
 ]
 
 _LOCAL_TOOL_MODULES = [

--- a/src/tools/connector.py
+++ b/src/tools/connector.py
@@ -16,24 +16,11 @@ project's safety convention for any operation that can change controller state.
 
 from __future__ import annotations
 
-from functools import wraps
 from typing import Any
 
 from ..api.site_manager_client import SiteManagerClient
 from ..config import Settings
 from ..utils import ValidationError, get_logger, validate_confirmation
-
-
-def _require_site_manager(func: Any) -> Any:
-    """Raise ValueError if Site Manager API is not enabled."""
-
-    @wraps(func)
-    async def wrapper(settings: Settings, *args: Any, **kwargs: Any) -> Any:
-        if not settings.site_manager_enabled:
-            raise ValueError("Site Manager API is not enabled. Set UNIFI_SITE_MANAGER_ENABLED=true")
-        return await func(settings, *args, **kwargs)
-
-    return wrapper
 
 
 def _validate_connector_params(console_id: str, path: str) -> str:

--- a/src/tools/connector.py
+++ b/src/tools/connector.py
@@ -1,0 +1,425 @@
+"""Cloud Connector proxy tools for remote UniFi controller access.
+
+The UniFi Cloud Connector allows reaching into a locally-managed UniFi
+controller through Ubiquiti's cloud relay without requiring a public IP or VPN.
+
+Endpoint pattern:
+  Network:  /v1/connector/{console_id}/proxy/network/{path}
+  Protect:  /v1/connector/{console_id}/proxy/protect/{path}
+
+The ``console_id`` is the host identifier returned by ``list_hosts``.
+These tools require ``UNIFI_SITE_MANAGER_ENABLED=true``.
+
+Mutating tools (POST, PUT, PATCH, DELETE) require ``confirm=True`` per the
+project's safety convention for any operation that can change controller state.
+"""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any
+
+from ..api.site_manager_client import SiteManagerClient
+from ..config import Settings
+from ..utils import ValidationError, get_logger, validate_confirmation
+
+
+def _require_site_manager(func: Any) -> Any:
+    """Raise ValueError if Site Manager API is not enabled."""
+
+    @wraps(func)
+    async def wrapper(settings: Settings, *args: Any, **kwargs: Any) -> Any:
+        if not settings.site_manager_enabled:
+            raise ValueError("Site Manager API is not enabled. Set UNIFI_SITE_MANAGER_ENABLED=true")
+        return await func(settings, *args, **kwargs)
+
+    return wrapper
+
+
+def _validate_connector_params(console_id: str, path: str) -> str:
+    """Validate console_id and path, return normalised path (no leading slash)."""
+    if not console_id or not console_id.strip():
+        raise ValidationError("console_id must not be empty")
+    if not path or not path.strip():
+        raise ValidationError("path must not be empty")
+    return path.lstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Network proxy tools
+# ---------------------------------------------------------------------------
+
+
+async def connector_network_get(
+    console_id: str,
+    path: str,
+    settings: Settings,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Proxy a GET request to the Network Application via Cloud Connector.
+
+    Forwards the request to
+    ``https://api.ui.com/v1/connector/{console_id}/proxy/network/{path}``
+    and returns the raw response.
+
+    Args:
+        console_id: UniFi console/host identifier (from list_hosts)
+        path: Network API sub-path, e.g. ``api/s/default/stat/device``
+        settings: Application settings (UNIFI_SITE_MANAGER_ENABLED required)
+        params: Optional query parameters
+
+    Returns:
+        Raw response from the proxied Network API endpoint
+
+    Raises:
+        ValidationError: If console_id or path is empty
+        ValueError: If Site Manager API is not enabled
+    """
+    if not settings.site_manager_enabled:
+        raise ValueError("Site Manager API is not enabled. Set UNIFI_SITE_MANAGER_ENABLED=true")
+
+    path = _validate_connector_params(console_id, path)
+    logger = get_logger(__name__, settings.log_level)
+
+    async with SiteManagerClient(settings) as client:
+        endpoint = f"connector/{console_id}/proxy/network/{path}"
+        logger.info(f"Connector network GET: {endpoint}")
+        return await client.get(endpoint, params=params)
+
+
+async def connector_network_post(
+    console_id: str,
+    path: str,
+    settings: Settings,
+    body: dict[str, Any] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Proxy a POST request to the Network Application via Cloud Connector.
+
+    Args:
+        console_id: UniFi console/host identifier (from list_hosts)
+        path: Network API sub-path, e.g. ``api/s/default/rest/wlanconf``
+        settings: Application settings
+        body: Optional request body to forward
+        confirm: Must be True to execute (mutating operation)
+        dry_run: If True, preview the request without sending it
+
+    Returns:
+        Raw response or dry-run preview
+
+    Raises:
+        ValidationError: If console_id/path is empty or confirm not provided
+        ValueError: If Site Manager API is not enabled
+    """
+    if not settings.site_manager_enabled:
+        raise ValueError("Site Manager API is not enabled. Set UNIFI_SITE_MANAGER_ENABLED=true")
+
+    validate_confirmation(confirm, "connector_network_post", dry_run)
+    path = _validate_connector_params(console_id, path)
+    logger = get_logger(__name__, settings.log_level)
+    endpoint = f"connector/{console_id}/proxy/network/{path}"
+
+    if dry_run:
+        return {"dry_run": True, "would_post_to": endpoint, "body": body}
+
+    async with SiteManagerClient(settings) as client:
+        logger.info(f"Connector network POST: {endpoint}")
+        return await client.post(endpoint, json_data=body)
+
+
+async def connector_network_put(
+    console_id: str,
+    path: str,
+    settings: Settings,
+    body: dict[str, Any] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Proxy a PUT request to the Network Application via Cloud Connector.
+
+    Args:
+        console_id: UniFi console/host identifier
+        path: Network API sub-path
+        settings: Application settings
+        body: Optional request body
+        confirm: Must be True to execute
+        dry_run: Preview without sending
+
+    Returns:
+        Raw response or dry-run preview
+    """
+    if not settings.site_manager_enabled:
+        raise ValueError("Site Manager API is not enabled. Set UNIFI_SITE_MANAGER_ENABLED=true")
+
+    validate_confirmation(confirm, "connector_network_put", dry_run)
+    path = _validate_connector_params(console_id, path)
+    logger = get_logger(__name__, settings.log_level)
+    endpoint = f"connector/{console_id}/proxy/network/{path}"
+
+    if dry_run:
+        return {"dry_run": True, "would_put_to": endpoint, "body": body}
+
+    async with SiteManagerClient(settings) as client:
+        logger.info(f"Connector network PUT: {endpoint}")
+        return await client.put(endpoint, json_data=body)
+
+
+async def connector_network_patch(
+    console_id: str,
+    path: str,
+    settings: Settings,
+    body: dict[str, Any] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Proxy a PATCH request to the Network Application via Cloud Connector.
+
+    Args:
+        console_id: UniFi console/host identifier
+        path: Network API sub-path
+        settings: Application settings
+        body: Optional request body
+        confirm: Must be True to execute
+        dry_run: Preview without sending
+
+    Returns:
+        Raw response or dry-run preview
+    """
+    if not settings.site_manager_enabled:
+        raise ValueError("Site Manager API is not enabled. Set UNIFI_SITE_MANAGER_ENABLED=true")
+
+    validate_confirmation(confirm, "connector_network_patch", dry_run)
+    path = _validate_connector_params(console_id, path)
+    logger = get_logger(__name__, settings.log_level)
+    endpoint = f"connector/{console_id}/proxy/network/{path}"
+
+    if dry_run:
+        return {"dry_run": True, "would_patch_to": endpoint, "body": body}
+
+    async with SiteManagerClient(settings) as client:
+        logger.info(f"Connector network PATCH: {endpoint}")
+        return await client.patch(endpoint, json_data=body)
+
+
+async def connector_network_delete(
+    console_id: str,
+    path: str,
+    settings: Settings,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Proxy a DELETE request to the Network Application via Cloud Connector.
+
+    Args:
+        console_id: UniFi console/host identifier
+        path: Network API sub-path
+        settings: Application settings
+        confirm: Must be True to execute
+        dry_run: Preview without sending
+
+    Returns:
+        Raw response or dry-run preview
+    """
+    if not settings.site_manager_enabled:
+        raise ValueError("Site Manager API is not enabled. Set UNIFI_SITE_MANAGER_ENABLED=true")
+
+    validate_confirmation(confirm, "connector_network_delete", dry_run)
+    path = _validate_connector_params(console_id, path)
+    logger = get_logger(__name__, settings.log_level)
+    endpoint = f"connector/{console_id}/proxy/network/{path}"
+
+    if dry_run:
+        return {"dry_run": True, "would_delete": endpoint}
+
+    async with SiteManagerClient(settings) as client:
+        logger.info(f"Connector network DELETE: {endpoint}")
+        return await client.delete(endpoint)
+
+
+# ---------------------------------------------------------------------------
+# Protect proxy tools
+# ---------------------------------------------------------------------------
+
+
+async def connector_protect_get(
+    console_id: str,
+    path: str,
+    settings: Settings,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Proxy a GET request to the Protect Application via Cloud Connector.
+
+    Forwards the request to
+    ``https://api.ui.com/v1/connector/{console_id}/proxy/protect/{path}``
+    and returns the raw response.
+
+    Args:
+        console_id: UniFi console/host identifier (from list_hosts)
+        path: Protect API sub-path, e.g. ``v1/cameras``
+        settings: Application settings (UNIFI_SITE_MANAGER_ENABLED required)
+        params: Optional query parameters
+
+    Returns:
+        Raw response from the proxied Protect API endpoint
+
+    Raises:
+        ValidationError: If console_id or path is empty
+        ValueError: If Site Manager API is not enabled
+    """
+    if not settings.site_manager_enabled:
+        raise ValueError("Site Manager API is not enabled. Set UNIFI_SITE_MANAGER_ENABLED=true")
+
+    path = _validate_connector_params(console_id, path)
+    logger = get_logger(__name__, settings.log_level)
+
+    async with SiteManagerClient(settings) as client:
+        endpoint = f"connector/{console_id}/proxy/protect/{path}"
+        logger.info(f"Connector protect GET: {endpoint}")
+        return await client.get(endpoint, params=params)
+
+
+async def connector_protect_post(
+    console_id: str,
+    path: str,
+    settings: Settings,
+    body: dict[str, Any] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Proxy a POST request to the Protect Application via Cloud Connector.
+
+    Args:
+        console_id: UniFi console/host identifier
+        path: Protect API sub-path, e.g. ``v1/cameras/{id}/snapshot``
+        settings: Application settings
+        body: Optional request body
+        confirm: Must be True to execute
+        dry_run: Preview without sending
+
+    Returns:
+        Raw response or dry-run preview
+    """
+    if not settings.site_manager_enabled:
+        raise ValueError("Site Manager API is not enabled. Set UNIFI_SITE_MANAGER_ENABLED=true")
+
+    validate_confirmation(confirm, "connector_protect_post", dry_run)
+    path = _validate_connector_params(console_id, path)
+    logger = get_logger(__name__, settings.log_level)
+    endpoint = f"connector/{console_id}/proxy/protect/{path}"
+
+    if dry_run:
+        return {"dry_run": True, "would_post_to": endpoint, "body": body}
+
+    async with SiteManagerClient(settings) as client:
+        logger.info(f"Connector protect POST: {endpoint}")
+        return await client.post(endpoint, json_data=body)
+
+
+async def connector_protect_put(
+    console_id: str,
+    path: str,
+    settings: Settings,
+    body: dict[str, Any] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Proxy a PUT request to the Protect Application via Cloud Connector.
+
+    Args:
+        console_id: UniFi console/host identifier
+        path: Protect API sub-path
+        settings: Application settings
+        body: Optional request body
+        confirm: Must be True to execute
+        dry_run: Preview without sending
+
+    Returns:
+        Raw response or dry-run preview
+    """
+    if not settings.site_manager_enabled:
+        raise ValueError("Site Manager API is not enabled. Set UNIFI_SITE_MANAGER_ENABLED=true")
+
+    validate_confirmation(confirm, "connector_protect_put", dry_run)
+    path = _validate_connector_params(console_id, path)
+    logger = get_logger(__name__, settings.log_level)
+    endpoint = f"connector/{console_id}/proxy/protect/{path}"
+
+    if dry_run:
+        return {"dry_run": True, "would_put_to": endpoint, "body": body}
+
+    async with SiteManagerClient(settings) as client:
+        logger.info(f"Connector protect PUT: {endpoint}")
+        return await client.put(endpoint, json_data=body)
+
+
+async def connector_protect_patch(
+    console_id: str,
+    path: str,
+    settings: Settings,
+    body: dict[str, Any] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Proxy a PATCH request to the Protect Application via Cloud Connector.
+
+    Args:
+        console_id: UniFi console/host identifier
+        path: Protect API sub-path
+        settings: Application settings
+        body: Optional request body
+        confirm: Must be True to execute
+        dry_run: Preview without sending
+
+    Returns:
+        Raw response or dry-run preview
+    """
+    if not settings.site_manager_enabled:
+        raise ValueError("Site Manager API is not enabled. Set UNIFI_SITE_MANAGER_ENABLED=true")
+
+    validate_confirmation(confirm, "connector_protect_patch", dry_run)
+    path = _validate_connector_params(console_id, path)
+    logger = get_logger(__name__, settings.log_level)
+    endpoint = f"connector/{console_id}/proxy/protect/{path}"
+
+    if dry_run:
+        return {"dry_run": True, "would_patch_to": endpoint, "body": body}
+
+    async with SiteManagerClient(settings) as client:
+        logger.info(f"Connector protect PATCH: {endpoint}")
+        return await client.patch(endpoint, json_data=body)
+
+
+async def connector_protect_delete(
+    console_id: str,
+    path: str,
+    settings: Settings,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Proxy a DELETE request to the Protect Application via Cloud Connector.
+
+    Args:
+        console_id: UniFi console/host identifier
+        path: Protect API sub-path
+        settings: Application settings
+        confirm: Must be True to execute
+        dry_run: Preview without sending
+
+    Returns:
+        Raw response or dry-run preview
+    """
+    if not settings.site_manager_enabled:
+        raise ValueError("Site Manager API is not enabled. Set UNIFI_SITE_MANAGER_ENABLED=true")
+
+    validate_confirmation(confirm, "connector_protect_delete", dry_run)
+    path = _validate_connector_params(console_id, path)
+    logger = get_logger(__name__, settings.log_level)
+    endpoint = f"connector/{console_id}/proxy/protect/{path}"
+
+    if dry_run:
+        return {"dry_run": True, "would_delete": endpoint}
+
+    async with SiteManagerClient(settings) as client:
+        logger.info(f"Connector protect DELETE: {endpoint}")
+        return await client.delete(endpoint)

--- a/tests/unit/tools/test_connector_tools.py
+++ b/tests/unit/tools/test_connector_tools.py
@@ -1,0 +1,389 @@
+"""Unit tests for Cloud Connector proxy tools."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import src.tools.connector as connector_module
+from src.tools.connector import (
+    connector_network_delete,
+    connector_network_get,
+    connector_network_patch,
+    connector_network_post,
+    connector_network_put,
+    connector_protect_delete,
+    connector_protect_get,
+    connector_protect_patch,
+    connector_protect_post,
+    connector_protect_put,
+)
+from src.utils.exceptions import ValidationError
+
+
+@pytest.fixture
+def mock_settings():
+    settings = MagicMock()
+    settings.log_level = "INFO"
+    settings.site_manager_enabled = True
+    settings.request_timeout = 30
+    settings.api_key = "test-key"
+    settings.get_headers.return_value = {"X-API-KEY": "test-key"}
+    return settings
+
+
+@pytest.fixture
+def mock_settings_disabled():
+    settings = MagicMock()
+    settings.log_level = "INFO"
+    settings.site_manager_enabled = False
+    return settings
+
+
+def make_mock_client(response: dict | None = None):
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=response or {"data": []})
+    client.post = AsyncMock(return_value=response or {"data": {}})
+    client.put = AsyncMock(return_value=response or {"data": {}})
+    client.patch = AsyncMock(return_value=response or {"data": {}})
+    client.delete = AsyncMock(return_value=response or {})
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+# =============================================================================
+# connector_network_get
+# =============================================================================
+
+
+class TestConnectorNetworkGet:
+    @pytest.mark.asyncio
+    async def test_success_builds_correct_endpoint(self, mock_settings):
+        """GET must proxy to connector/{console_id}/proxy/network/{path}."""
+        response = {"data": [{"_id": "wlan1"}]}
+        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+            mock_cls.return_value = make_mock_client(response)
+            result = await connector_network_get(
+                console_id="console-abc",
+                path="api/s/default/rest/wlanconf",
+                settings=mock_settings,
+            )
+        mock_cls.return_value.get.assert_called_once_with(
+            "connector/console-abc/proxy/network/api/s/default/rest/wlanconf",
+            params=None,
+        )
+        assert result == response
+
+    @pytest.mark.asyncio
+    async def test_strips_leading_slash_from_path(self, mock_settings):
+        """Leading slash in path must be stripped before building endpoint."""
+        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+            mock_cls.return_value = make_mock_client({})
+            await connector_network_get(
+                console_id="console-abc",
+                path="/api/s/default/stat/device",
+                settings=mock_settings,
+            )
+        mock_cls.return_value.get.assert_called_once_with(
+            "connector/console-abc/proxy/network/api/s/default/stat/device",
+            params=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_passes_params(self, mock_settings):
+        """Query params must be forwarded to the underlying GET call."""
+        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+            mock_cls.return_value = make_mock_client({})
+            await connector_network_get(
+                console_id="c1",
+                path="api/s/default/rest/wlanconf",
+                settings=mock_settings,
+                params={"_limit": "10"},
+            )
+        mock_cls.return_value.get.assert_called_once_with(
+            "connector/c1/proxy/network/api/s/default/rest/wlanconf",
+            params={"_limit": "10"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_console_id_raises(self, mock_settings):
+        with pytest.raises(ValidationError, match="console_id"):
+            await connector_network_get(
+                console_id="", path="api/s/default/stat/device", settings=mock_settings
+            )
+
+    @pytest.mark.asyncio
+    async def test_empty_path_raises(self, mock_settings):
+        with pytest.raises(ValidationError, match="path"):
+            await connector_network_get(console_id="c1", path="", settings=mock_settings)
+
+    @pytest.mark.asyncio
+    async def test_site_manager_disabled_raises(self, mock_settings_disabled):
+        with pytest.raises(ValueError, match="Site Manager"):
+            await connector_network_get(
+                console_id="c1",
+                path="api/s/default/stat/device",
+                settings=mock_settings_disabled,
+            )
+
+
+# =============================================================================
+# connector_network_post / put / patch / delete (mutating — need confirm)
+# =============================================================================
+
+
+class TestConnectorNetworkPost:
+    @pytest.mark.asyncio
+    async def test_success(self, mock_settings):
+        response = {"data": {"_id": "new-wlan"}}
+        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+            mock_cls.return_value = make_mock_client(response)
+            result = await connector_network_post(
+                console_id="c1",
+                path="api/s/default/rest/wlanconf",
+                settings=mock_settings,
+                body={"name": "Test", "security": "wpapsk"},
+                confirm=True,
+            )
+        mock_cls.return_value.post.assert_called_once_with(
+            "connector/c1/proxy/network/api/s/default/rest/wlanconf",
+            json_data={"name": "Test", "security": "wpapsk"},
+        )
+        assert result == response
+
+    @pytest.mark.asyncio
+    async def test_requires_confirm(self, mock_settings):
+        with pytest.raises(ValidationError):
+            await connector_network_post(
+                console_id="c1",
+                path="api/s/default/rest/wlanconf",
+                settings=mock_settings,
+                body={},
+                confirm=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_dry_run_skips_api_call(self, mock_settings):
+        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+            mock_cls.return_value = make_mock_client({})
+            result = await connector_network_post(
+                console_id="c1",
+                path="api/s/default/rest/wlanconf",
+                settings=mock_settings,
+                body={"name": "Test"},
+                confirm=True,
+                dry_run=True,
+            )
+        mock_cls.return_value.post.assert_not_called()
+        assert result["dry_run"] is True
+        assert "connector/c1/proxy/network" in result["would_post_to"]
+
+
+class TestConnectorNetworkPut:
+    @pytest.mark.asyncio
+    async def test_success(self, mock_settings):
+        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+            mock_cls.return_value = make_mock_client({"data": {}})
+            await connector_network_put(
+                console_id="c1",
+                path="api/s/default/rest/wlanconf/wlan-123",
+                settings=mock_settings,
+                body={"name": "Updated"},
+                confirm=True,
+            )
+        mock_cls.return_value.put.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_requires_confirm(self, mock_settings):
+        with pytest.raises(ValidationError):
+            await connector_network_put(
+                console_id="c1",
+                path="api/s/default/rest/wlanconf/wlan-123",
+                settings=mock_settings,
+                body={},
+                confirm=False,
+            )
+
+
+class TestConnectorNetworkPatch:
+    @pytest.mark.asyncio
+    async def test_success(self, mock_settings):
+        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+            mock_cls.return_value = make_mock_client({"data": {}})
+            await connector_network_patch(
+                console_id="c1",
+                path="api/s/default/rest/wlanconf/wlan-123",
+                settings=mock_settings,
+                body={"enabled": False},
+                confirm=True,
+            )
+        mock_cls.return_value.patch.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_requires_confirm(self, mock_settings):
+        with pytest.raises(ValidationError):
+            await connector_network_patch(
+                console_id="c1",
+                path="api/s/default/rest/wlanconf/wlan-123",
+                settings=mock_settings,
+                body={},
+                confirm=False,
+            )
+
+
+class TestConnectorNetworkDelete:
+    @pytest.mark.asyncio
+    async def test_success(self, mock_settings):
+        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+            mock_cls.return_value = make_mock_client({})
+            result = await connector_network_delete(
+                console_id="c1",
+                path="api/s/default/rest/wlanconf/wlan-123",
+                settings=mock_settings,
+                confirm=True,
+            )
+        mock_cls.return_value.delete.assert_called_once_with(
+            "connector/c1/proxy/network/api/s/default/rest/wlanconf/wlan-123"
+        )
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_requires_confirm(self, mock_settings):
+        with pytest.raises(ValidationError):
+            await connector_network_delete(
+                console_id="c1",
+                path="api/s/default/rest/wlanconf/wlan-123",
+                settings=mock_settings,
+                confirm=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_dry_run(self, mock_settings):
+        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+            mock_cls.return_value = make_mock_client({})
+            result = await connector_network_delete(
+                console_id="c1",
+                path="api/s/default/rest/wlanconf/wlan-123",
+                settings=mock_settings,
+                confirm=True,
+                dry_run=True,
+            )
+        mock_cls.return_value.delete.assert_not_called()
+        assert result["dry_run"] is True
+
+
+# =============================================================================
+# Protect proxy tools (same structure as network)
+# =============================================================================
+
+
+class TestConnectorProtectGet:
+    @pytest.mark.asyncio
+    async def test_success_builds_protect_endpoint(self, mock_settings):
+        """GET must proxy to connector/{console_id}/proxy/protect/{path}."""
+        response = {"data": [{"id": "cam-1"}]}
+        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+            mock_cls.return_value = make_mock_client(response)
+            result = await connector_protect_get(
+                console_id="console-xyz",
+                path="v1/cameras",
+                settings=mock_settings,
+            )
+        mock_cls.return_value.get.assert_called_once_with(
+            "connector/console-xyz/proxy/protect/v1/cameras",
+            params=None,
+        )
+        assert result == response
+
+    @pytest.mark.asyncio
+    async def test_empty_console_id_raises(self, mock_settings):
+        with pytest.raises(ValidationError, match="console_id"):
+            await connector_protect_get(console_id="", path="v1/cameras", settings=mock_settings)
+
+    @pytest.mark.asyncio
+    async def test_site_manager_disabled_raises(self, mock_settings_disabled):
+        with pytest.raises(ValueError, match="Site Manager"):
+            await connector_protect_get(
+                console_id="c1", path="v1/cameras", settings=mock_settings_disabled
+            )
+
+
+class TestConnectorProtectPost:
+    @pytest.mark.asyncio
+    async def test_success(self, mock_settings):
+        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+            mock_cls.return_value = make_mock_client({"data": {}})
+            await connector_protect_post(
+                console_id="c1",
+                path="v1/cameras/cam-1/snapshot",
+                settings=mock_settings,
+                body={},
+                confirm=True,
+            )
+        mock_cls.return_value.post.assert_called_once_with(
+            "connector/c1/proxy/protect/v1/cameras/cam-1/snapshot",
+            json_data={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_requires_confirm(self, mock_settings):
+        with pytest.raises(ValidationError):
+            await connector_protect_post(
+                console_id="c1",
+                path="v1/cameras/cam-1/snapshot",
+                settings=mock_settings,
+                body={},
+                confirm=False,
+            )
+
+
+class TestConnectorProtectPut:
+    @pytest.mark.asyncio
+    async def test_requires_confirm(self, mock_settings):
+        with pytest.raises(ValidationError):
+            await connector_protect_put(
+                console_id="c1",
+                path="v1/cameras/cam-1",
+                settings=mock_settings,
+                body={},
+                confirm=False,
+            )
+
+
+class TestConnectorProtectPatch:
+    @pytest.mark.asyncio
+    async def test_requires_confirm(self, mock_settings):
+        with pytest.raises(ValidationError):
+            await connector_protect_patch(
+                console_id="c1",
+                path="v1/cameras/cam-1",
+                settings=mock_settings,
+                body={},
+                confirm=False,
+            )
+
+
+class TestConnectorProtectDelete:
+    @pytest.mark.asyncio
+    async def test_success(self, mock_settings):
+        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+            mock_cls.return_value = make_mock_client({})
+            await connector_protect_delete(
+                console_id="c1",
+                path="v1/cameras/cam-1",
+                settings=mock_settings,
+                confirm=True,
+            )
+        mock_cls.return_value.delete.assert_called_once_with(
+            "connector/c1/proxy/protect/v1/cameras/cam-1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_requires_confirm(self, mock_settings):
+        with pytest.raises(ValidationError):
+            await connector_protect_delete(
+                console_id="c1",
+                path="v1/cameras/cam-1",
+                settings=mock_settings,
+                confirm=False,
+            )

--- a/tests/unit/tools/test_connector_tools.py
+++ b/tests/unit/tools/test_connector_tools.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-import src.tools.connector as connector_module
 from src.tools.connector import (
     connector_network_delete,
     connector_network_get,
@@ -61,7 +60,7 @@ class TestConnectorNetworkGet:
     async def test_success_builds_correct_endpoint(self, mock_settings):
         """GET must proxy to connector/{console_id}/proxy/network/{path}."""
         response = {"data": [{"_id": "wlan1"}]}
-        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+        with patch("src.tools.connector.SiteManagerClient") as mock_cls:
             mock_cls.return_value = make_mock_client(response)
             result = await connector_network_get(
                 console_id="console-abc",
@@ -77,7 +76,7 @@ class TestConnectorNetworkGet:
     @pytest.mark.asyncio
     async def test_strips_leading_slash_from_path(self, mock_settings):
         """Leading slash in path must be stripped before building endpoint."""
-        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+        with patch("src.tools.connector.SiteManagerClient") as mock_cls:
             mock_cls.return_value = make_mock_client({})
             await connector_network_get(
                 console_id="console-abc",
@@ -92,7 +91,7 @@ class TestConnectorNetworkGet:
     @pytest.mark.asyncio
     async def test_passes_params(self, mock_settings):
         """Query params must be forwarded to the underlying GET call."""
-        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+        with patch("src.tools.connector.SiteManagerClient") as mock_cls:
             mock_cls.return_value = make_mock_client({})
             await connector_network_get(
                 console_id="c1",
@@ -136,7 +135,7 @@ class TestConnectorNetworkPost:
     @pytest.mark.asyncio
     async def test_success(self, mock_settings):
         response = {"data": {"_id": "new-wlan"}}
-        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+        with patch("src.tools.connector.SiteManagerClient") as mock_cls:
             mock_cls.return_value = make_mock_client(response)
             result = await connector_network_post(
                 console_id="c1",
@@ -164,7 +163,7 @@ class TestConnectorNetworkPost:
 
     @pytest.mark.asyncio
     async def test_dry_run_skips_api_call(self, mock_settings):
-        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+        with patch("src.tools.connector.SiteManagerClient") as mock_cls:
             mock_cls.return_value = make_mock_client({})
             result = await connector_network_post(
                 console_id="c1",
@@ -182,7 +181,7 @@ class TestConnectorNetworkPost:
 class TestConnectorNetworkPut:
     @pytest.mark.asyncio
     async def test_success(self, mock_settings):
-        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+        with patch("src.tools.connector.SiteManagerClient") as mock_cls:
             mock_cls.return_value = make_mock_client({"data": {}})
             await connector_network_put(
                 console_id="c1",
@@ -208,7 +207,7 @@ class TestConnectorNetworkPut:
 class TestConnectorNetworkPatch:
     @pytest.mark.asyncio
     async def test_success(self, mock_settings):
-        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+        with patch("src.tools.connector.SiteManagerClient") as mock_cls:
             mock_cls.return_value = make_mock_client({"data": {}})
             await connector_network_patch(
                 console_id="c1",
@@ -234,7 +233,7 @@ class TestConnectorNetworkPatch:
 class TestConnectorNetworkDelete:
     @pytest.mark.asyncio
     async def test_success(self, mock_settings):
-        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+        with patch("src.tools.connector.SiteManagerClient") as mock_cls:
             mock_cls.return_value = make_mock_client({})
             result = await connector_network_delete(
                 console_id="c1",
@@ -259,7 +258,7 @@ class TestConnectorNetworkDelete:
 
     @pytest.mark.asyncio
     async def test_dry_run(self, mock_settings):
-        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+        with patch("src.tools.connector.SiteManagerClient") as mock_cls:
             mock_cls.return_value = make_mock_client({})
             result = await connector_network_delete(
                 console_id="c1",
@@ -282,7 +281,7 @@ class TestConnectorProtectGet:
     async def test_success_builds_protect_endpoint(self, mock_settings):
         """GET must proxy to connector/{console_id}/proxy/protect/{path}."""
         response = {"data": [{"id": "cam-1"}]}
-        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+        with patch("src.tools.connector.SiteManagerClient") as mock_cls:
             mock_cls.return_value = make_mock_client(response)
             result = await connector_protect_get(
                 console_id="console-xyz",
@@ -311,7 +310,7 @@ class TestConnectorProtectGet:
 class TestConnectorProtectPost:
     @pytest.mark.asyncio
     async def test_success(self, mock_settings):
-        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+        with patch("src.tools.connector.SiteManagerClient") as mock_cls:
             mock_cls.return_value = make_mock_client({"data": {}})
             await connector_protect_post(
                 console_id="c1",
@@ -366,7 +365,7 @@ class TestConnectorProtectPatch:
 class TestConnectorProtectDelete:
     @pytest.mark.asyncio
     async def test_success(self, mock_settings):
-        with patch.object(connector_module, "SiteManagerClient") as mock_cls:
+        with patch("src.tools.connector.SiteManagerClient") as mock_cls:
             mock_cls.return_value = make_mock_client({})
             await connector_protect_delete(
                 console_id="c1",


### PR DESCRIPTION
## Summary

Implements Phase 2 of the development plan: Cloud Connector proxy support, enabling remote management of locally-managed UniFi controllers through Ubiquiti's cloud relay (`api.ui.com/v1/connector/`) without requiring a public IP or VPN.

- **10 new MCP tools** in `src/tools/connector.py`
- **`SiteManagerClient` extended** with `post()`, `put()`, `patch()`, `delete()` methods
- All tools gated behind `UNIFI_SITE_MANAGER_ENABLED=true`
- Mutating tools require `confirm=True` per project safety convention
- Dry-run mode on all mutating tools

### New tools

| Group | Tools |
|-------|-------|
| Network proxy | `connector_network_get/post/put/patch/delete` |
| Protect proxy | `connector_protect_get/post/put/patch/delete` |

**Endpoint pattern:** `https://api.ui.com/v1/connector/{console_id}/proxy/{network|protect}/{path}`

The `console_id` is the host identifier returned by the existing `list_hosts` tool.

## Test plan

- [x] 25 new unit tests in `tests/unit/tools/test_connector_tools.py`
- [x] Endpoint construction verified (correct path, leading slash stripped)
- [x] Param forwarding on GET
- [x] `confirm=True` enforcement on all 8 mutating tools
- [x] Dry-run skips API call, returns preview dict
- [x] Empty `console_id` / `path` → `ValidationError`
- [x] `site_manager_enabled=False` → `ValueError`
- [x] 1273 total tests, 0 failures (baseline 1248, +25)