### PR TITLE
fix(network_config): coerce dry_run bool and include DNS fields in parameters

### DIFF
--- a/src/tools/network_config.py
+++ b/src/tools/network_config.py
@@ -7,6 +7,7 @@ from ..config import Settings
 from ..utils import (
     ResourceNotFoundError,
     ValidationError,
+    coerce_bool,
     get_logger,
     log_audit,
     sanitize_log_message,
@@ -62,6 +63,7 @@ async def create_network(
     """
     site_id = validate_site_id(site_id)
     validate_confirmation(confirm, "network configuration operation", dry_run)
+    dry_run = coerce_bool(dry_run)
     logger = get_logger(__name__, settings.log_level)
 
     # Validate VLAN ID
@@ -212,6 +214,7 @@ async def update_network(
     """
     site_id = validate_site_id(site_id)
     validate_confirmation(confirm, "network configuration operation", dry_run)
+    dry_run = coerce_bool(dry_run)
     logger = get_logger(__name__, settings.log_level)
 
     # Validate VLAN ID if provided
@@ -229,6 +232,13 @@ async def update_network(
         "vlan_id": vlan_id,
         "subnet": subnet,
         "dhcp_enabled": dhcp_enabled,
+        "dhcp_start": dhcp_start,
+        "dhcp_stop": dhcp_stop,
+        "dhcp_dns_1": dhcp_dns_1,
+        "dhcp_dns_2": dhcp_dns_2,
+        "dhcp_dns_3": dhcp_dns_3,
+        "dhcp_dns_4": dhcp_dns_4,
+        "domain_name": domain_name,
     }
 
     if dry_run:
@@ -347,6 +357,7 @@ async def delete_network(
     """
     site_id = validate_site_id(site_id)
     validate_confirmation(confirm, "network configuration operation", dry_run)
+    dry_run = coerce_bool(dry_run)
     logger = get_logger(__name__, settings.log_level)
 
     parameters = {"site_id": site_id, "network_id": network_id}


### PR DESCRIPTION
## Summary

Fixes #86 — two bugs in `src/tools/network_config.py` that caused `update_network` to always behave as a dry run and silently drop DNS parameters.

- **`dry_run` coercion**: MCP clients serialize booleans as strings, so `if dry_run:` on the raw value evaluated `True` for the string `"false"`. Added `dry_run = coerce_bool(dry_run)` after `validate_confirmation()` in `create_network`, `update_network`, and `delete_network`. `coerce_bool` was already used internally by `validate_confirmation` and already exported from `..utils`.
- **Missing DNS fields in `parameters`**: Added `dhcp_start`, `dhcp_stop`, `dhcp_dns_1`–`4`, and `domain_name` to the `parameters` dict in `update_network` so they appear in `would_update` during dry-run previews and in audit logs on failure.

## Changes

- `src/tools/network_config.py` — 11 lines added, 0 removed:
  - Import `coerce_bool` from `..utils`
  - `create_network`: `dry_run = coerce_bool(dry_run)` after `validate_confirmation`
  - `update_network`: same coercion + 7 DNS/DHCP fields added to `parameters`
  - `delete_network`: same coercion

## Test plan

- [ ] Call `update_network` with `dry_run=False, confirm=True` and DNS params — verify the PUT is executed and `get_subnet_info` reflects the new DNS values
- [ ] Call with `dry_run=True` — verify `would_update` now includes `dhcp_dns_1` / `dhcp_dns_2`
- [ ] Call with `dry_run="false"` (string) — verify it is treated as `False` and the update executes
- [ ] Existing unit tests pass: `pytest tests/unit/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)