### PR TITLE
fix: deduplicate duplicate tool registration

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -128,6 +128,7 @@ _LOCAL_TOOL_MODULES = [
     dhcp_tools,
     dns_tools,
     devices_tools,
+    ref_tools,
     dpi_tools,
     dpi_new_tools,
     firewall_tools,

--- a/src/tool_registry.py
+++ b/src/tool_registry.py
@@ -22,6 +22,30 @@ from fastmcp import FastMCP
 from .config import Settings
 
 
+def _get_registered_tool_names(mcp: FastMCP) -> set[str]:
+    """Return the tool names already registered on this MCP instance.
+
+    FastMCP's duplicate-component warnings are emitted when the same tool name
+    is registered more than once on a live server instance.  We keep a per-
+    instance registry so repeated registration passes can safely skip names that
+    were already seen, instead of relying on FastMCP's warning path.
+    """
+    try:
+        registry = mcp.__dict__
+    except AttributeError:
+        registered = getattr(mcp, "_registered_tool_names", None)
+        if registered is None:
+            registered = set()
+            setattr(mcp, "_registered_tool_names", registered)
+        return registered
+
+    registered = registry.get("_registered_tool_names")
+    if registered is None:
+        registered = set()
+        registry["_registered_tool_names"] = registered
+    return registered
+
+
 def _make_tool_wrapper(fn: Any, settings: Settings) -> Any:
     """Return an async wrapper for *fn* with ``settings`` bound.
 
@@ -91,6 +115,7 @@ def register_module_tools(
     """
     registered: list[str] = []
     exclude_set = set(exclude or [])
+    registered_names = _get_registered_tool_names(mcp)
 
     for name, obj in inspect.getmembers(module, inspect.isfunction):
         # Skip private / dunder names
@@ -112,7 +137,13 @@ def register_module_tools(
         else:
             tool_fn = obj
 
+        if name in registered_names:
+            # Keep the first registered variant when multiple modules define the
+            # same public tool name.
+            continue
+
         mcp.tool()(tool_fn)
+        registered_names.add(name)
         registered.append(name)
 
     return registered

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -1,0 +1,75 @@
+"""Unit tests for tool registry behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from types import ModuleType
+from typing import Any, Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+if importlib.util.find_spec("fastmcp") is None:
+    fastmcp_stub = ModuleType("fastmcp")
+
+    class FastMCP:  # type: ignore[too-many-ancestors]
+        pass
+
+    setattr(fastmcp_stub, "FastMCP", FastMCP)
+    sys.modules["fastmcp"] = fastmcp_stub
+
+from src.tool_registry import register_module_tools
+from src.tools import dpi_tools, reference_data
+
+
+class FakeMCP:
+    """Minimal FastMCP stand-in for registry tests."""
+
+    def __init__(self) -> None:
+        self.registered: list[str] = []
+
+    def tool(self) -> Callable[[Any], Any]:
+        def decorator(fn: Any) -> Any:
+            self.registered.append(fn.__name__)
+            return fn
+
+        return decorator
+
+
+@pytest.fixture
+def settings() -> MagicMock:
+    """Create mock settings for registry tests."""
+    mock = MagicMock()
+    mock.log_level = "INFO"
+    return mock
+
+
+def test_register_module_tools_skips_duplicate_names(settings: MagicMock) -> None:
+    """Duplicate public tool names should only be registered once per MCP instance."""
+    mcp: Any = FakeMCP()
+
+    first = register_module_tools(mcp, reference_data, settings)
+    second = register_module_tools(mcp, dpi_tools, settings)
+
+    assert "list_countries" in first
+    assert "list_radius_profiles" in first
+    assert "list_countries" not in second
+    assert "list_radius_profiles" not in second
+
+    assert mcp.registered.count("list_countries") == 1
+    assert mcp.registered.count("list_radius_profiles") == 1
+    assert mcp.registered.count("list_dpi_categories") == 1
+    assert mcp.registered.count("list_dpi_applications") == 1
+    assert len(mcp.registered) == len(set(mcp.registered))
+
+
+def test_register_module_tools_tracks_names_on_mcp_instance(settings: MagicMock) -> None:
+    """The registry should persist per FastMCP instance."""
+    mcp: Any = FakeMCP()
+
+    register_module_tools(mcp, reference_data, settings)
+
+    assert hasattr(mcp, "_registered_tool_names")
+    assert "list_countries" in mcp._registered_tool_names
+    assert "list_radius_profiles" in mcp._registered_tool_names


### PR DESCRIPTION
Closes #91.

Summary:
- Prevent repeated registration of duplicate public tool names on the same MCP instance.
- Skip re-registering already-seen tool names to avoid FastMCP duplicate-component warnings.
- Add regression coverage for duplicate registration behavior.

Validation:
- pytest -q tests/unit/test_tool_registry.py
- pytest -q tests/unit/tools/test_reference_data_tools.py tests/unit/tools/test_dpi_tools.py
- python -m py_compile src/tool_registry.py tests/unit/test_tool_registry.py