### PR TITLE
Find and complete the TODO item in the codebase

### DIFF
--- a/API.md
+++ b/API.md
@@ -756,6 +756,119 @@ result = await mcp.call_tool("get_network_statistics", {
 }
 ```
 
+### WAN and Dynamic DNS Tools
+
+#### `list_wan_connections`
+
+List WAN connections for a site.
+
+**Parameters:**
+
+- `site_id` (string, required): Site identifier
+
+**Returns:**
+Array of WAN connection objects.
+
+**Example:**
+
+```python
+result = await mcp.call_tool("list_wan_connections", {
+    "site_id": "default"
+})
+```
+
+#### `list_dynamic_dns`
+
+List Dynamic DNS records for a site. This local API tool redacts stored password
+material and returns `password_configured` instead.
+
+**Parameters:**
+
+- `site_id` (string, required): Site identifier
+
+**Returns:**
+Array of Dynamic DNS records.
+
+**Example:**
+
+```python
+result = await mcp.call_tool("list_dynamic_dns", {
+    "site_id": "default"
+})
+```
+
+#### `get_dynamic_dns`
+
+Get one Dynamic DNS record by ID.
+
+**Parameters:**
+
+- `dynamic_dns_id` (string, required): Dynamic DNS record ID
+- `site_id` (string, required): Site identifier
+
+**Returns:**
+Dynamic DNS record details.
+
+#### `create_dynamic_dns`
+
+Create a Dynamic DNS record. Mutating operation; requires `confirm=true` unless
+`dry_run=true`.
+
+**Parameters:**
+
+- `site_id` (string, required): Site identifier
+- `host_name` (string, required): Hostname to update
+- `service` (string, optional): Provider service name, default `custom`
+- `interface` (string, optional): WAN interface identifier, default `wan`
+- `login` (string, optional): Provider login or username
+- `password` (string, optional): Provider password or token, sent as `x_password`
+- `server` (string, optional): Provider server for custom configurations
+- `custom_service` (string, optional): Custom provider protocol/service label
+- `options` (array, optional): Provider-specific options
+- `confirm` (boolean/string, required for execution): Set true to apply
+- `dry_run` (boolean/string, optional): Preview without applying
+
+**Example:**
+
+```python
+result = await mcp.call_tool("create_dynamic_dns", {
+    "site_id": "default",
+    "host_name": "vpn.example.com",
+    "service": "custom",
+    "server": "updates.example.com",
+    "custom_service": "dyndns",
+    "login": "api-user",
+    "password": "provider-token",
+    "confirm": True
+})
+```
+
+#### `update_dynamic_dns`
+
+Update a Dynamic DNS record. Mutating operation; requires `confirm=true` unless
+`dry_run=true`.
+
+**Parameters:**
+
+- `dynamic_dns_id` (string, required): Dynamic DNS record ID
+- `site_id` (string, required): Site identifier
+- `host_name`, `service`, `interface`, `login`, `password`, `server`,
+  `custom_service`, `options` (optional): Fields to update
+- `confirm` (boolean/string, required for execution): Set true to apply
+- `dry_run` (boolean/string, optional): Preview without applying
+
+#### `delete_dynamic_dns`
+
+Delete a Dynamic DNS record. Mutating operation; requires `confirm=true` unless
+`dry_run=true`.
+
+**Parameters:**
+
+- `dynamic_dns_id` (string, required): Dynamic DNS record ID
+- `site_id` (string, required): Site identifier
+- `confirm` (boolean/string, required for execution): Set true to apply
+- `dry_run` (boolean/string, optional): Preview without applying
+
 ### Site Management Tools
 
 #### `get_site_details`

--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -81,7 +81,7 @@ All items from the previous revision (D1–D7) are resolved as of Phase 0 comple
 
 | # | Gap | Notes |
 |---|-----|-------|
-| G4 | **Dynamic DNS full CRUD** | GET exists; PUT/POST/DELETE for custom providers missing. |
+| G4 | **Dynamic DNS full CRUD** | Completed in `src/tools/wans.py` with local `rest/dynamicdns` list/get/create/update/delete tools. |
 | G5 | **Tagged MAC Management** | `/rest/tag` endpoints. Low priority. |
 | G6 | **Device Migration** | `/cmd/devmgr/migrate`, `/cmd/devmgr/cancel-migrate`. Low priority. |
 
@@ -186,7 +186,7 @@ This is a new application domain requiring new API client context, models, and t
 
 #### 4.1 Minor Gap Closure
 
-- Dynamic DNS full CRUD (`src/tools/wans.py` extension)
+- Dynamic DNS full CRUD (`src/tools/wans.py` extension) - complete
 - Tagged MAC management (`src/tools/devices.py` extension or new module)
 - Device migration tools
 - Access API foundational research (door/credential list tools as preview)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,7 @@ Goal: harden the server, close the remaining small gaps, and add AI-friendly ope
 ### Deliverables
 
 - Full test coverage for new Phase 1–3 modules
-- Dynamic DNS full CRUD
+- Dynamic DNS full CRUD - complete
 - Tagged MAC management
 - Device migration tools
 - `NETWORK_PLAYBOOK.md` runbook library

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # UniFi MCP Server — Active TODO
 
-**Last Updated:** 2026-06-20
-**Current Codebase:** ~215 async tool functions across 40+ modules
+**Last Updated:** 2026-06-22
+**Current Codebase:** ~220 async tool functions across 40+ modules
 **Current Posture:** Phase 3 active; Phase 4 and Phase 5 queued
 
 This TODO mirrors `DEVELOPMENT_PLAN.md` and tracks the work that is still open in the repo.
@@ -26,7 +26,7 @@ This TODO mirrors `DEVELOPMENT_PLAN.md` and tracks the work that is still open i
 ### Phase 4 — Testing, polish, minor gaps, developer experience
 
 - [ ] Add tests for all new Phase 1–3 modules
-- [ ] Close remaining minor gaps: Dynamic DNS full CRUD
+- [x] Close remaining minor gaps: Dynamic DNS full CRUD
 - [ ] Close remaining minor gaps: Tagged MAC management
 - [ ] Close remaining minor gaps: Device migration tools
 - [ ] Add `NETWORK_PLAYBOOK.md` runbook library

--- a/src/tools/wans.py
+++ b/src/tools/wans.py
@@ -1,11 +1,92 @@
 """WAN connection management tools."""
 
+from typing import Any
+
 from ..api.client import UniFiClient
-from ..config import Settings
+from ..config import APIType, Settings
 from ..models import WANConnection
-from ..utils import get_logger, sanitize_log_message
+from ..utils import APIError, get_logger, log_audit, sanitize_log_message
+from ..utils.validators import coerce_bool, validate_confirmation
 
 logger = get_logger(__name__)
+
+
+def _ensure_local_api(settings: Settings) -> None:
+    if settings.api_type != APIType.LOCAL:
+        raise NotImplementedError("Dynamic DNS tools require UNIFI_API_TYPE='local'.")
+
+
+def _unwrap_response(response: Any) -> list[dict[str, Any]]:
+    if isinstance(response, list):
+        return [item for item in response if isinstance(item, dict)]
+    if isinstance(response, dict):
+        data = response.get("data")
+        if isinstance(data, list):
+            return [item for item in data if isinstance(item, dict)]
+        if isinstance(data, dict):
+            return [data]
+    return []
+
+
+def _dynamic_dns_endpoint(site_id: str, dynamic_dns_id: str | None = None) -> str:
+    endpoint = f"/ea/sites/{site_id}/rest/dynamicdns"
+    if dynamic_dns_id:
+        endpoint = f"{endpoint}/{dynamic_dns_id}"
+    return endpoint
+
+
+def _normalize_dynamic_dns(item: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a Dynamic DNS API record without returning stored secrets."""
+    return {
+        "id": item.get("_id") or item.get("id"),
+        "_id": item.get("_id") or item.get("id"),
+        "host_name": item.get("host_name"),
+        "service": item.get("service"),
+        "custom_service": item.get("custom_service"),
+        "server": item.get("server"),
+        "interface": item.get("interface"),
+        "login": item.get("login"),
+        "options": item.get("options", []),
+        "password_configured": bool(item.get("x_password")),
+    }
+
+
+def _dynamic_dns_payload(
+    *,
+    host_name: str | None = None,
+    service: str | None = None,
+    interface: str | None = None,
+    login: str | None = None,
+    password: str | None = None,
+    server: str | None = None,
+    custom_service: str | None = None,
+    options: list[str] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    if host_name is not None:
+        payload["host_name"] = host_name
+    if service is not None:
+        payload["service"] = service
+    if interface is not None:
+        payload["interface"] = interface
+    if login is not None:
+        payload["login"] = login
+    if password is not None:
+        payload["x_password"] = password
+    if server is not None:
+        payload["server"] = server
+    if custom_service is not None:
+        payload["custom_service"] = custom_service
+    if options is not None:
+        payload["options"] = list(options)
+    return payload
+
+
+def _redact_dynamic_dns_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    redacted = dict(payload)
+    if "x_password" in redacted:
+        redacted["x_password"] = "***REDACTED***"
+    return redacted
 
 
 async def list_wan_connections(site_id: str, settings: Settings) -> list[dict]:
@@ -28,3 +109,247 @@ async def list_wan_connections(site_id: str, settings: Settings) -> list[dict]:
         data = response if isinstance(response, list) else response.get("data", [])
 
         return [WANConnection(**wan).model_dump() for wan in data]
+
+
+async def list_dynamic_dns(site_id: str, settings: Settings) -> list[dict[str, Any]]:
+    """List Dynamic DNS configurations for a site.
+
+    Dynamic DNS is exposed by the local UniFi Network legacy REST API under
+    ``rest/dynamicdns``. Returned records redact password material and expose
+    ``password_configured`` instead.
+    """
+    _ensure_local_api(settings)
+
+    async with UniFiClient(settings) as client:
+        logger.info(sanitize_log_message(f"Listing Dynamic DNS records for site {site_id}"))
+
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            response = await client.get(_dynamic_dns_endpoint(site_id))
+        except APIError:
+            logger.exception(
+                sanitize_log_message(f"Failed to list Dynamic DNS records for site {site_id}")
+            )
+            raise
+
+        return [_normalize_dynamic_dns(item) for item in _unwrap_response(response)]
+
+
+async def get_dynamic_dns(
+    dynamic_dns_id: str,
+    site_id: str,
+    settings: Settings,
+) -> dict[str, Any]:
+    """Get one Dynamic DNS configuration by ID."""
+    _ensure_local_api(settings)
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(f"Getting Dynamic DNS record {dynamic_dns_id} for site {site_id}")
+        )
+
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            response = await client.get(_dynamic_dns_endpoint(site_id, dynamic_dns_id))
+        except APIError:
+            logger.exception(
+                sanitize_log_message(f"Failed to get Dynamic DNS record {dynamic_dns_id}")
+            )
+            raise
+
+        items = _unwrap_response(response)
+        return _normalize_dynamic_dns(items[0] if items else {})
+
+
+async def create_dynamic_dns(
+    site_id: str,
+    settings: Settings,
+    host_name: str,
+    service: str = "custom",
+    interface: str = "wan",
+    login: str | None = None,
+    password: str | None = None,
+    server: str = "",
+    custom_service: str | None = None,
+    options: list[str] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Create a Dynamic DNS configuration.
+
+    Args:
+        site_id: Site identifier
+        settings: Application settings (must be local)
+        host_name: Dynamic DNS hostname to update
+        service: Provider service name. Use ``"custom"`` with
+            ``custom_service``/``server``/``options`` for custom providers.
+        interface: WAN interface identifier used by UniFi (commonly ``wan``)
+        login: Provider username/login
+        password: Provider password or token, sent as ``x_password``
+        server: Provider server for custom configurations
+        custom_service: Custom provider protocol/service label
+        options: Provider-specific options
+        confirm: REQUIRED True
+        dry_run: Preview without applying
+    """
+    _ensure_local_api(settings)
+    validate_confirmation(confirm, "create_dynamic_dns", dry_run)
+
+    payload = _dynamic_dns_payload(
+        host_name=host_name,
+        service=service,
+        interface=interface,
+        login=login,
+        password=password,
+        server=server,
+        custom_service=custom_service,
+        options=options,
+    )
+
+    if coerce_bool(dry_run):
+        return {
+            "dry_run": True,
+            "would_create": _redact_dynamic_dns_payload(payload),
+        }
+
+    async with UniFiClient(settings) as client:
+        logger.info(sanitize_log_message(f"Creating Dynamic DNS record for site {site_id}"))
+
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            response = await client.post(_dynamic_dns_endpoint(site_id), json_data=payload)
+        except APIError:
+            logger.exception(
+                sanitize_log_message(f"Failed to create Dynamic DNS record for site {site_id}")
+            )
+            raise
+
+        log_audit(
+            operation="create_dynamic_dns",
+            parameters={"site_id": site_id, **_redact_dynamic_dns_payload(payload)},
+            result="success",
+            site_id=site_id,
+        )
+
+        items = _unwrap_response(response)
+        return _normalize_dynamic_dns(items[0] if items else {})
+
+
+async def update_dynamic_dns(
+    dynamic_dns_id: str,
+    site_id: str,
+    settings: Settings,
+    host_name: str | None = None,
+    service: str | None = None,
+    interface: str | None = None,
+    login: str | None = None,
+    password: str | None = None,
+    server: str | None = None,
+    custom_service: str | None = None,
+    options: list[str] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Update a Dynamic DNS configuration."""
+    _ensure_local_api(settings)
+    validate_confirmation(confirm, "update_dynamic_dns", dry_run)
+
+    payload = _dynamic_dns_payload(
+        host_name=host_name,
+        service=service,
+        interface=interface,
+        login=login,
+        password=password,
+        server=server,
+        custom_service=custom_service,
+        options=options,
+    )
+
+    if coerce_bool(dry_run):
+        return {
+            "dry_run": True,
+            "dynamic_dns_id": dynamic_dns_id,
+            "would_update": _redact_dynamic_dns_payload(payload),
+        }
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(f"Updating Dynamic DNS record {dynamic_dns_id} for site {site_id}")
+        )
+
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            response = await client.put(
+                _dynamic_dns_endpoint(site_id, dynamic_dns_id),
+                json_data=payload,
+            )
+        except APIError:
+            logger.exception(
+                sanitize_log_message(f"Failed to update Dynamic DNS record {dynamic_dns_id}")
+            )
+            raise
+
+        log_audit(
+            operation="update_dynamic_dns",
+            parameters={
+                "site_id": site_id,
+                "dynamic_dns_id": dynamic_dns_id,
+                **_redact_dynamic_dns_payload(payload),
+            },
+            result="success",
+            site_id=site_id,
+        )
+
+        items = _unwrap_response(response)
+        return _normalize_dynamic_dns(items[0] if items else {})
+
+
+async def delete_dynamic_dns(
+    dynamic_dns_id: str,
+    site_id: str,
+    settings: Settings,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
+    """Delete a Dynamic DNS configuration."""
+    _ensure_local_api(settings)
+    validate_confirmation(confirm, "delete_dynamic_dns", dry_run)
+
+    if coerce_bool(dry_run):
+        return {
+            "dry_run": True,
+            "would_delete": dynamic_dns_id,
+        }
+
+    async with UniFiClient(settings) as client:
+        logger.info(
+            sanitize_log_message(f"Deleting Dynamic DNS record {dynamic_dns_id} for site {site_id}")
+        )
+
+        if not client.is_authenticated:
+            await client.authenticate()
+
+        try:
+            response = await client.delete(_dynamic_dns_endpoint(site_id, dynamic_dns_id))
+        except APIError:
+            logger.exception(
+                sanitize_log_message(f"Failed to delete Dynamic DNS record {dynamic_dns_id}")
+            )
+            raise
+
+        log_audit(
+            operation="delete_dynamic_dns",
+            parameters={"site_id": site_id, "dynamic_dns_id": dynamic_dns_id},
+            result="success",
+            site_id=site_id,
+        )
+
+        return {"status": "deleted", "dynamic_dns_id": dynamic_dns_id, "response": response}

--- a/src/tools/wans.py
+++ b/src/tools/wans.py
@@ -1,26 +1,56 @@
 """WAN connection management tools."""
 
+import re
 from typing import Any
 
 from ..api.client import UniFiClient
 from ..config import APIType, Settings
 from ..models import WANConnection
-from ..utils import APIError, get_logger, log_audit, sanitize_log_message
-from ..utils.validators import coerce_bool, validate_confirmation
+from ..utils import (
+    APIError,
+    ResourceNotFoundError,
+    ValidationError,
+    get_logger,
+    log_audit,
+    sanitize_log_message,
+)
+from ..utils.validators import coerce_bool, validate_confirmation, validate_site_id
 
 logger = get_logger(__name__)
+_HOSTNAME_RE = re.compile(
+    r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(?:\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$"
+)
+_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
 
 
 def _ensure_local_api(settings: Settings) -> None:
+    """Ensure the current UniFi API mode supports Dynamic DNS tools.
+
+    Args:
+        settings: Application settings.
+
+    Raises:
+        NotImplementedError: If the configured API type is not local.
+    """
     if settings.api_type != APIType.LOCAL:
         raise NotImplementedError("Dynamic DNS tools require UNIFI_API_TYPE='local'.")
 
 
 def _unwrap_response(response: Any) -> list[dict[str, Any]]:
+    """Normalize UniFi list, data-wrapped, and direct object responses.
+
+    Args:
+        response: Raw UniFi client response.
+
+    Returns:
+        List of dictionary response items.
+    """
     if isinstance(response, list):
         return [item for item in response if isinstance(item, dict)]
     if isinstance(response, dict):
-        data = response.get("data")
+        if "data" not in response:
+            return [response]
+        data = response["data"]
         if isinstance(data, list):
             return [item for item in data if isinstance(item, dict)]
         if isinstance(data, dict):
@@ -29,10 +59,105 @@ def _unwrap_response(response: Any) -> list[dict[str, Any]]:
 
 
 def _dynamic_dns_endpoint(site_id: str, dynamic_dns_id: str | None = None) -> str:
+    """Build the local Network API endpoint for Dynamic DNS records.
+
+    Args:
+        site_id: Validated UniFi site identifier.
+        dynamic_dns_id: Optional validated Dynamic DNS record ID.
+
+    Returns:
+        Legacy REST API endpoint path.
+    """
     endpoint = f"/ea/sites/{site_id}/rest/dynamicdns"
     if dynamic_dns_id:
         endpoint = f"{endpoint}/{dynamic_dns_id}"
     return endpoint
+
+
+def _validate_path_segment(value: str, field_name: str) -> str:
+    """Validate a value before using it as a URL path segment.
+
+    Args:
+        value: User-provided path segment value.
+        field_name: Field name to include in validation errors.
+
+    Returns:
+        The validated value.
+
+    Raises:
+        ValidationError: If the value is empty or contains unsafe characters.
+    """
+    if not value or not isinstance(value, str):
+        raise ValidationError(f"{field_name} cannot be empty")
+    if not _PATH_SEGMENT_RE.match(value):
+        raise ValidationError(f"Invalid {field_name} format: {value}")
+    return value
+
+
+def _validate_hostname(host_name: str) -> str:
+    """Validate a Dynamic DNS hostname.
+
+    Args:
+        host_name: Hostname to validate.
+
+    Returns:
+        The validated hostname.
+
+    Raises:
+        ValidationError: If the hostname is empty or malformed.
+    """
+    if not host_name or not isinstance(host_name, str):
+        raise ValidationError("host_name cannot be empty")
+    if not _HOSTNAME_RE.match(host_name):
+        raise ValidationError(f"Invalid host_name format: {host_name}")
+    return host_name
+
+
+def _audit_user(settings: Settings) -> str | None:
+    """Return an optional audit actor configured on settings.
+
+    Args:
+        settings: Application settings.
+
+    Returns:
+        Configured actor identity, when available.
+    """
+    audit_user = getattr(settings, "audit_user", None)
+    if isinstance(audit_user, str) and audit_user:
+        return audit_user
+    return None
+
+
+def _audit_dynamic_dns(
+    *,
+    operation: str,
+    settings: Settings,
+    site_id: str,
+    parameters: dict[str, Any],
+    result: str,
+    dry_run: bool = False,
+    error: str | None = None,
+) -> None:
+    """Write a Dynamic DNS audit event.
+
+    Args:
+        operation: Audit operation name.
+        settings: Application settings.
+        site_id: UniFi site identifier.
+        parameters: Redacted operation parameters.
+        result: Audit result value.
+        dry_run: Whether this event represents a dry run.
+        error: Optional error detail for failed operations.
+    """
+    log_audit(
+        operation=operation,
+        parameters=parameters,
+        result=result,
+        site_id=site_id,
+        user=_audit_user(settings),
+        dry_run=dry_run,
+        error=error,
+    )
 
 
 def _normalize_dynamic_dns(item: dict[str, Any]) -> dict[str, Any]:
@@ -62,9 +187,24 @@ def _dynamic_dns_payload(
     custom_service: str | None = None,
     options: list[str] | None = None,
 ) -> dict[str, Any]:
+    """Build a Dynamic DNS API payload from optional fields.
+
+    Args:
+        host_name: Dynamic DNS hostname.
+        service: Provider service name.
+        interface: WAN interface identifier.
+        login: Provider login or username.
+        password: Provider password or token.
+        server: Provider server for custom configurations.
+        custom_service: Custom provider protocol/service label.
+        options: Provider-specific options.
+
+    Returns:
+        Payload with only fields explicitly provided by the caller.
+    """
     payload: dict[str, Any] = {}
     if host_name is not None:
-        payload["host_name"] = host_name
+        payload["host_name"] = _validate_hostname(host_name)
     if service is not None:
         payload["service"] = service
     if interface is not None:
@@ -83,6 +223,14 @@ def _dynamic_dns_payload(
 
 
 def _redact_dynamic_dns_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of a Dynamic DNS payload with secret material redacted.
+
+    Args:
+        payload: Dynamic DNS API payload.
+
+    Returns:
+        Redacted payload copy.
+    """
     redacted = dict(payload)
     if "x_password" in redacted:
         redacted["x_password"] = "***REDACTED***"
@@ -119,6 +267,7 @@ async def list_dynamic_dns(site_id: str, settings: Settings) -> list[dict[str, A
     ``password_configured`` instead.
     """
     _ensure_local_api(settings)
+    site_id = validate_site_id(site_id)
 
     async with UniFiClient(settings) as client:
         logger.info(sanitize_log_message(f"Listing Dynamic DNS records for site {site_id}"))
@@ -144,6 +293,8 @@ async def get_dynamic_dns(
 ) -> dict[str, Any]:
     """Get one Dynamic DNS configuration by ID."""
     _ensure_local_api(settings)
+    site_id = validate_site_id(site_id)
+    dynamic_dns_id = _validate_path_segment(dynamic_dns_id, "dynamic_dns_id")
 
     async with UniFiClient(settings) as client:
         logger.info(
@@ -162,7 +313,9 @@ async def get_dynamic_dns(
             raise
 
         items = _unwrap_response(response)
-        return _normalize_dynamic_dns(items[0] if items else {})
+        if not items:
+            raise ResourceNotFoundError("dynamic_dns", dynamic_dns_id)
+        return _normalize_dynamic_dns(items[0])
 
 
 async def create_dynamic_dns(
@@ -197,6 +350,7 @@ async def create_dynamic_dns(
         dry_run: Preview without applying
     """
     _ensure_local_api(settings)
+    site_id = validate_site_id(site_id)
     validate_confirmation(confirm, "create_dynamic_dns", dry_run)
 
     payload = _dynamic_dns_payload(
@@ -209,8 +363,17 @@ async def create_dynamic_dns(
         custom_service=custom_service,
         options=options,
     )
+    audit_parameters = {"site_id": site_id, **_redact_dynamic_dns_payload(payload)}
 
     if coerce_bool(dry_run):
+        _audit_dynamic_dns(
+            operation="create_dynamic_dns",
+            settings=settings,
+            site_id=site_id,
+            parameters=audit_parameters,
+            result="dry_run",
+            dry_run=True,
+        )
         return {
             "dry_run": True,
             "would_create": _redact_dynamic_dns_payload(payload),
@@ -224,17 +387,26 @@ async def create_dynamic_dns(
 
         try:
             response = await client.post(_dynamic_dns_endpoint(site_id), json_data=payload)
-        except APIError:
+        except APIError as err:
             logger.exception(
                 sanitize_log_message(f"Failed to create Dynamic DNS record for site {site_id}")
             )
+            _audit_dynamic_dns(
+                operation="create_dynamic_dns",
+                settings=settings,
+                site_id=site_id,
+                parameters=audit_parameters,
+                result="failed",
+                error=str(err),
+            )
             raise
 
-        log_audit(
+        _audit_dynamic_dns(
             operation="create_dynamic_dns",
-            parameters={"site_id": site_id, **_redact_dynamic_dns_payload(payload)},
-            result="success",
+            settings=settings,
             site_id=site_id,
+            parameters=audit_parameters,
+            result="success",
         )
 
         items = _unwrap_response(response)
@@ -258,6 +430,8 @@ async def update_dynamic_dns(
 ) -> dict[str, Any]:
     """Update a Dynamic DNS configuration."""
     _ensure_local_api(settings)
+    site_id = validate_site_id(site_id)
+    dynamic_dns_id = _validate_path_segment(dynamic_dns_id, "dynamic_dns_id")
     validate_confirmation(confirm, "update_dynamic_dns", dry_run)
 
     payload = _dynamic_dns_payload(
@@ -270,8 +444,24 @@ async def update_dynamic_dns(
         custom_service=custom_service,
         options=options,
     )
+    if not payload:
+        raise ValidationError("At least one field must be provided to update_dynamic_dns")
+
+    audit_parameters = {
+        "site_id": site_id,
+        "dynamic_dns_id": dynamic_dns_id,
+        **_redact_dynamic_dns_payload(payload),
+    }
 
     if coerce_bool(dry_run):
+        _audit_dynamic_dns(
+            operation="update_dynamic_dns",
+            settings=settings,
+            site_id=site_id,
+            parameters=audit_parameters,
+            result="dry_run",
+            dry_run=True,
+        )
         return {
             "dry_run": True,
             "dynamic_dns_id": dynamic_dns_id,
@@ -291,25 +481,40 @@ async def update_dynamic_dns(
                 _dynamic_dns_endpoint(site_id, dynamic_dns_id),
                 json_data=payload,
             )
-        except APIError:
+        except APIError as err:
             logger.exception(
                 sanitize_log_message(f"Failed to update Dynamic DNS record {dynamic_dns_id}")
             )
+            _audit_dynamic_dns(
+                operation="update_dynamic_dns",
+                settings=settings,
+                site_id=site_id,
+                parameters=audit_parameters,
+                result="failed",
+                error=str(err),
+            )
             raise
 
-        log_audit(
-            operation="update_dynamic_dns",
-            parameters={
-                "site_id": site_id,
-                "dynamic_dns_id": dynamic_dns_id,
-                **_redact_dynamic_dns_payload(payload),
-            },
-            result="success",
-            site_id=site_id,
-        )
-
         items = _unwrap_response(response)
-        return _normalize_dynamic_dns(items[0] if items else {})
+        if not items:
+            _audit_dynamic_dns(
+                operation="update_dynamic_dns",
+                settings=settings,
+                site_id=site_id,
+                parameters=audit_parameters,
+                result="failed",
+                error=f"dynamic_dns '{dynamic_dns_id}' not found",
+            )
+            raise ResourceNotFoundError("dynamic_dns", dynamic_dns_id)
+
+        _audit_dynamic_dns(
+            operation="update_dynamic_dns",
+            settings=settings,
+            site_id=site_id,
+            parameters=audit_parameters,
+            result="success",
+        )
+        return _normalize_dynamic_dns(items[0])
 
 
 async def delete_dynamic_dns(
@@ -321,9 +526,20 @@ async def delete_dynamic_dns(
 ) -> dict[str, Any]:
     """Delete a Dynamic DNS configuration."""
     _ensure_local_api(settings)
+    site_id = validate_site_id(site_id)
+    dynamic_dns_id = _validate_path_segment(dynamic_dns_id, "dynamic_dns_id")
     validate_confirmation(confirm, "delete_dynamic_dns", dry_run)
+    audit_parameters = {"site_id": site_id, "dynamic_dns_id": dynamic_dns_id}
 
     if coerce_bool(dry_run):
+        _audit_dynamic_dns(
+            operation="delete_dynamic_dns",
+            settings=settings,
+            site_id=site_id,
+            parameters=audit_parameters,
+            result="dry_run",
+            dry_run=True,
+        )
         return {
             "dry_run": True,
             "would_delete": dynamic_dns_id,
@@ -338,18 +554,27 @@ async def delete_dynamic_dns(
             await client.authenticate()
 
         try:
-            response = await client.delete(_dynamic_dns_endpoint(site_id, dynamic_dns_id))
-        except APIError:
+            await client.delete(_dynamic_dns_endpoint(site_id, dynamic_dns_id))
+        except APIError as err:
             logger.exception(
                 sanitize_log_message(f"Failed to delete Dynamic DNS record {dynamic_dns_id}")
             )
+            _audit_dynamic_dns(
+                operation="delete_dynamic_dns",
+                settings=settings,
+                site_id=site_id,
+                parameters=audit_parameters,
+                result="failed",
+                error=str(err),
+            )
             raise
 
-        log_audit(
+        _audit_dynamic_dns(
             operation="delete_dynamic_dns",
-            parameters={"site_id": site_id, "dynamic_dns_id": dynamic_dns_id},
-            result="success",
+            settings=settings,
             site_id=site_id,
+            parameters=audit_parameters,
+            result="success",
         )
 
-        return {"status": "deleted", "dynamic_dns_id": dynamic_dns_id, "response": response}
+        return {"status": "deleted", "dynamic_dns_id": dynamic_dns_id, "site_id": site_id}

--- a/tests/unit/tools/test_wans_tools.py
+++ b/tests/unit/tools/test_wans_tools.py
@@ -13,7 +13,7 @@ from src.tools.wans import (
     list_wan_connections,
     update_dynamic_dns,
 )
-from src.utils.exceptions import ValidationError
+from src.utils.exceptions import APIError, ResourceNotFoundError, ValidationError
 
 
 @pytest.fixture
@@ -128,6 +128,22 @@ class TestDynamicDNS:
         assert result["id"] == "ddns-1"
         assert "x_password" not in result
 
+    async def test_get_dynamic_dns_handles_direct_dict_response(self, mock_settings):
+        mock_client = create_mock_client(make_dynamic_dns())
+
+        with patch("src.tools.wans.UniFiClient", return_value=mock_client):
+            result = await get_dynamic_dns("ddns-1", "default", mock_settings)
+
+        assert result["id"] == "ddns-1"
+        assert result["host_name"] == "vpn.example.com"
+
+    async def test_get_dynamic_dns_empty_response_raises_not_found(self, mock_settings):
+        mock_client = create_mock_client({"data": []})
+
+        with patch("src.tools.wans.UniFiClient", return_value=mock_client):
+            with pytest.raises(ResourceNotFoundError):
+                await get_dynamic_dns("ddns-1", "default", mock_settings)
+
     async def test_create_dynamic_dns_posts_custom_provider_payload(self, mock_settings):
         mock_client = create_mock_client({"data": [make_dynamic_dns()]})
 
@@ -166,6 +182,34 @@ class TestDynamicDNS:
         assert audit_parameters["x_password"] == "***REDACTED***"
         assert result["password_configured"] is True
 
+    async def test_create_dynamic_dns_invalid_hostname_raises(self, mock_settings):
+        with pytest.raises(ValidationError, match="host_name"):
+            await create_dynamic_dns(
+                site_id="default",
+                settings=mock_settings,
+                host_name="../bad",
+                confirm=True,
+            )
+
+    async def test_create_dynamic_dns_failure_is_audited(self, mock_settings):
+        mock_client = create_mock_client({})
+        mock_client.post = AsyncMock(side_effect=APIError("create failed"))
+
+        with (
+            patch("src.tools.wans.UniFiClient", return_value=mock_client),
+            patch("src.tools.wans.log_audit") as mock_audit,
+        ):
+            with pytest.raises(APIError):
+                await create_dynamic_dns(
+                    site_id="default",
+                    settings=mock_settings,
+                    host_name="vpn.example.com",
+                    confirm=True,
+                )
+
+        assert mock_audit.call_args.kwargs["result"] == "failed"
+        assert mock_audit.call_args.kwargs["error"] == "create failed"
+
     async def test_create_dynamic_dns_requires_confirm(self, mock_settings):
         with pytest.raises(ValidationError):
             await create_dynamic_dns(
@@ -175,17 +219,20 @@ class TestDynamicDNS:
             )
 
     async def test_create_dynamic_dns_dry_run_redacts_password(self, mock_settings):
-        result = await create_dynamic_dns(
-            site_id="default",
-            settings=mock_settings,
-            host_name="vpn.example.com",
-            password="secret-token",
-            confirm=False,
-            dry_run=True,
-        )
+        with patch("src.tools.wans.log_audit") as mock_audit:
+            result = await create_dynamic_dns(
+                site_id="default",
+                settings=mock_settings,
+                host_name="vpn.example.com",
+                password="secret-token",
+                confirm=False,
+                dry_run=True,
+            )
 
         assert result["dry_run"] is True
         assert result["would_create"]["x_password"] == "***REDACTED***"
+        assert mock_audit.call_args.kwargs["result"] == "dry_run"
+        assert mock_audit.call_args.kwargs["dry_run"] is True
 
     async def test_update_dynamic_dns_puts_partial_payload(self, mock_settings):
         mock_client = create_mock_client(
@@ -221,8 +268,38 @@ class TestDynamicDNS:
         assert result["host_name"] == "new.example.com"
         assert result["password_configured"] is False
 
+    async def test_update_dynamic_dns_empty_payload_raises(self, mock_settings):
+        with pytest.raises(ValidationError, match="At least one field"):
+            await update_dynamic_dns(
+                dynamic_dns_id="ddns-1",
+                site_id="default",
+                settings=mock_settings,
+                confirm=True,
+            )
+
+    async def test_update_dynamic_dns_empty_response_raises_not_found(self, mock_settings):
+        mock_client = create_mock_client({"data": []})
+
+        with (
+            patch("src.tools.wans.UniFiClient", return_value=mock_client),
+            patch("src.tools.wans.log_audit") as mock_audit,
+        ):
+            with pytest.raises(ResourceNotFoundError):
+                await update_dynamic_dns(
+                    dynamic_dns_id="ddns-1",
+                    site_id="default",
+                    settings=mock_settings,
+                    host_name="new.example.com",
+                    confirm=True,
+                )
+
+        assert mock_audit.call_args.kwargs["result"] == "failed"
+
     async def test_update_dynamic_dns_dry_run_skips_api_call(self, mock_settings):
-        with patch("src.tools.wans.UniFiClient") as mock_client_cls:
+        with (
+            patch("src.tools.wans.UniFiClient") as mock_client_cls,
+            patch("src.tools.wans.log_audit") as mock_audit,
+        ):
             result = await update_dynamic_dns(
                 dynamic_dns_id="ddns-1",
                 site_id="default",
@@ -237,6 +314,7 @@ class TestDynamicDNS:
             "login": "new-user",
             "x_password": "***REDACTED***",
         }
+        assert mock_audit.call_args.kwargs["result"] == "dry_run"
 
     async def test_delete_dynamic_dns(self, mock_settings):
         mock_client = create_mock_client({})
@@ -254,14 +332,29 @@ class TestDynamicDNS:
 
         mock_client.delete.assert_called_once_with("/ea/sites/default/rest/dynamicdns/ddns-1")
         assert mock_audit.call_args.kwargs["operation"] == "delete_dynamic_dns"
-        assert result["status"] == "deleted"
+        assert result == {
+            "status": "deleted",
+            "dynamic_dns_id": "ddns-1",
+            "site_id": "default",
+        }
 
     async def test_delete_dynamic_dns_dry_run(self, mock_settings):
-        result = await delete_dynamic_dns(
-            dynamic_dns_id="ddns-1",
-            site_id="default",
-            settings=mock_settings,
-            dry_run=True,
-        )
+        with patch("src.tools.wans.log_audit") as mock_audit:
+            result = await delete_dynamic_dns(
+                dynamic_dns_id="ddns-1",
+                site_id="default",
+                settings=mock_settings,
+                dry_run=True,
+            )
 
         assert result == {"dry_run": True, "would_delete": "ddns-1"}
+        assert mock_audit.call_args.kwargs["result"] == "dry_run"
+
+    async def test_delete_dynamic_dns_invalid_id_raises(self, mock_settings):
+        with pytest.raises(ValidationError, match="dynamic_dns_id"):
+            await delete_dynamic_dns(
+                dynamic_dns_id="../ddns-1",
+                site_id="default",
+                settings=mock_settings,
+                confirm=True,
+            )

--- a/tests/unit/tools/test_wans_tools.py
+++ b/tests/unit/tools/test_wans_tools.py
@@ -4,13 +4,23 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.tools.wans import list_wan_connections
+from src.config import APIType
+from src.tools.wans import (
+    create_dynamic_dns,
+    delete_dynamic_dns,
+    get_dynamic_dns,
+    list_dynamic_dns,
+    list_wan_connections,
+    update_dynamic_dns,
+)
+from src.utils.exceptions import ValidationError
 
 
 @pytest.fixture
 def mock_settings():
     settings = MagicMock()
     settings.log_level = "INFO"
+    settings.api_type = APIType.LOCAL
     return settings
 
 
@@ -28,11 +38,28 @@ def make_wan(wan_id="wan-1"):
 def create_mock_client(return_value):
     mock_client = AsyncMock()
     mock_client.get = AsyncMock(return_value=return_value)
+    mock_client.post = AsyncMock(return_value=return_value)
+    mock_client.put = AsyncMock(return_value=return_value)
+    mock_client.delete = AsyncMock(return_value={"meta": {"rc": "ok"}})
     mock_client.authenticate = AsyncMock()
     mock_client.is_authenticated = False
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
     return mock_client
+
+
+def make_dynamic_dns(dynamic_dns_id="ddns-1"):
+    return {
+        "_id": dynamic_dns_id,
+        "host_name": "vpn.example.com",
+        "service": "custom",
+        "custom_service": "dyndns",
+        "server": "updates.example.com",
+        "interface": "wan",
+        "login": "api-user",
+        "x_password": "secret-token",
+        "options": ["ssl=yes"],
+    }
 
 
 class TestListWanConnections:
@@ -65,3 +92,176 @@ class TestListWanConnections:
         with patch("src.tools.wans.UniFiClient", return_value=mock_client):
             await list_wan_connections("default", mock_settings)
         mock_client.authenticate.assert_called_once()
+
+
+class TestDynamicDNS:
+    async def test_list_dynamic_dns_redacts_password(self, mock_settings):
+        record = make_dynamic_dns()
+        mock_client = create_mock_client({"data": [record]})
+
+        with patch("src.tools.wans.UniFiClient", return_value=mock_client):
+            result = await list_dynamic_dns("default", mock_settings)
+
+        mock_client.get.assert_called_once_with("/ea/sites/default/rest/dynamicdns")
+        assert result == [
+            {
+                "id": "ddns-1",
+                "_id": "ddns-1",
+                "host_name": "vpn.example.com",
+                "service": "custom",
+                "custom_service": "dyndns",
+                "server": "updates.example.com",
+                "interface": "wan",
+                "login": "api-user",
+                "options": ["ssl=yes"],
+                "password_configured": True,
+            }
+        ]
+
+    async def test_get_dynamic_dns(self, mock_settings):
+        mock_client = create_mock_client({"data": [make_dynamic_dns()]})
+
+        with patch("src.tools.wans.UniFiClient", return_value=mock_client):
+            result = await get_dynamic_dns("ddns-1", "default", mock_settings)
+
+        mock_client.get.assert_called_once_with("/ea/sites/default/rest/dynamicdns/ddns-1")
+        assert result["id"] == "ddns-1"
+        assert "x_password" not in result
+
+    async def test_create_dynamic_dns_posts_custom_provider_payload(self, mock_settings):
+        mock_client = create_mock_client({"data": [make_dynamic_dns()]})
+
+        with (
+            patch("src.tools.wans.UniFiClient", return_value=mock_client),
+            patch("src.tools.wans.log_audit") as mock_audit,
+        ):
+            result = await create_dynamic_dns(
+                site_id="default",
+                settings=mock_settings,
+                host_name="vpn.example.com",
+                service="custom",
+                interface="wan",
+                login="api-user",
+                password="secret-token",
+                server="updates.example.com",
+                custom_service="dyndns",
+                options=["ssl=yes"],
+                confirm=True,
+            )
+
+        mock_client.post.assert_called_once_with(
+            "/ea/sites/default/rest/dynamicdns",
+            json_data={
+                "host_name": "vpn.example.com",
+                "service": "custom",
+                "interface": "wan",
+                "login": "api-user",
+                "x_password": "secret-token",
+                "server": "updates.example.com",
+                "custom_service": "dyndns",
+                "options": ["ssl=yes"],
+            },
+        )
+        audit_parameters = mock_audit.call_args.kwargs["parameters"]
+        assert audit_parameters["x_password"] == "***REDACTED***"
+        assert result["password_configured"] is True
+
+    async def test_create_dynamic_dns_requires_confirm(self, mock_settings):
+        with pytest.raises(ValidationError):
+            await create_dynamic_dns(
+                site_id="default",
+                settings=mock_settings,
+                host_name="vpn.example.com",
+            )
+
+    async def test_create_dynamic_dns_dry_run_redacts_password(self, mock_settings):
+        result = await create_dynamic_dns(
+            site_id="default",
+            settings=mock_settings,
+            host_name="vpn.example.com",
+            password="secret-token",
+            confirm=False,
+            dry_run=True,
+        )
+
+        assert result["dry_run"] is True
+        assert result["would_create"]["x_password"] == "***REDACTED***"
+
+    async def test_update_dynamic_dns_puts_partial_payload(self, mock_settings):
+        mock_client = create_mock_client(
+            {
+                "data": [
+                    {
+                        **make_dynamic_dns(),
+                        "host_name": "new.example.com",
+                        "x_password": "",
+                    }
+                ]
+            }
+        )
+
+        with (
+            patch("src.tools.wans.UniFiClient", return_value=mock_client),
+            patch("src.tools.wans.log_audit") as mock_audit,
+        ):
+            result = await update_dynamic_dns(
+                dynamic_dns_id="ddns-1",
+                site_id="default",
+                settings=mock_settings,
+                host_name="new.example.com",
+                server="new-updates.example.com",
+                confirm=True,
+            )
+
+        mock_client.put.assert_called_once_with(
+            "/ea/sites/default/rest/dynamicdns/ddns-1",
+            json_data={"host_name": "new.example.com", "server": "new-updates.example.com"},
+        )
+        assert mock_audit.call_args.kwargs["operation"] == "update_dynamic_dns"
+        assert result["host_name"] == "new.example.com"
+        assert result["password_configured"] is False
+
+    async def test_update_dynamic_dns_dry_run_skips_api_call(self, mock_settings):
+        with patch("src.tools.wans.UniFiClient") as mock_client_cls:
+            result = await update_dynamic_dns(
+                dynamic_dns_id="ddns-1",
+                site_id="default",
+                settings=mock_settings,
+                login="new-user",
+                password="new-secret",
+                dry_run=True,
+            )
+
+        mock_client_cls.assert_not_called()
+        assert result["would_update"] == {
+            "login": "new-user",
+            "x_password": "***REDACTED***",
+        }
+
+    async def test_delete_dynamic_dns(self, mock_settings):
+        mock_client = create_mock_client({})
+
+        with (
+            patch("src.tools.wans.UniFiClient", return_value=mock_client),
+            patch("src.tools.wans.log_audit") as mock_audit,
+        ):
+            result = await delete_dynamic_dns(
+                dynamic_dns_id="ddns-1",
+                site_id="default",
+                settings=mock_settings,
+                confirm=True,
+            )
+
+        mock_client.delete.assert_called_once_with("/ea/sites/default/rest/dynamicdns/ddns-1")
+        assert mock_audit.call_args.kwargs["operation"] == "delete_dynamic_dns"
+        assert result["status"] == "deleted"
+
+    async def test_delete_dynamic_dns_dry_run(self, mock_settings):
+        result = await delete_dynamic_dns(
+            dynamic_dns_id="ddns-1",
+            site_id="default",
+            settings=mock_settings,
+            dry_run=True,
+        )
+
+        assert result == {"dry_run": True, "would_delete": "ddns-1"}


### PR DESCRIPTION
## Implement full CRUD for Dynamic DNS

Completes the outstanding TODO item by adding `list`, `get`, `create`, `update`, and `delete` operations for Dynamic DNS configurations in `src/tools/wans.py`, closing the G4 gap tracked in `DEVELOPMENT_PLAN.md`.

## Changes

- **`src/tools/wans.py`**: Added five new async tool functions (`list_dynamic_dns`, `get_dynamic_dns`, `create_dynamic_dns`, `update_dynamic_dns`, `delete_dynamic_dns`) targeting the local UniFi Network `rest/dynamicdns` API
- **Security**: `x_password` is redacted from all returned data and audit log entries; callers receive a `password_configured` boolean instead
- **Safety guards**: All mutating operations (`create`, `update`, `delete`) require `confirm=True` or `dry_run=True`; dry-run mode returns a preview without making API calls
- **Tests**: Added `TestDynamicDNS` class in `tests/unit/tools/test_wans_tools.py` covering happy paths, password redaction, dry-run behavior, and missing-confirm validation
- **Docs**: Updated `API.md` with full parameter/example documentation for all five tools; marked the item complete in `TODO.md`, `DEVELOPMENT_PLAN.md`, and `ROADMAP.md`

## Reviewer Notes

- These tools require `UNIFI_API_TYPE=local`; a `NotImplementedError` is raised early if the setting is not set correctly
- The `_normalize_dynamic_dns` helper ensures consistent field shapes across list/get/create/update responses regardless of API response envelope format

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/TLWFpbPTjzDm/implementations/7FQQCkpHLjm7) | [Guided Review](https://www.superconductor.com/tickets/TLWFpbPTjzDm/implementations/7FQQCkpHLjm7?tab=guided_review)

<!-- created-by-superconductor -->