### PR TITLE
fix(wan): relax WANConnection so Integration v1 responses validate

### DIFF
--- a/API.md
+++ b/API.md
@@ -912,10 +912,11 @@ Array of WAN connection objects.
 Only `id` and `name` are guaranteed. The Integration v1
 `/sites/{site_id}/wans` endpoint returns just those two fields and offers no
 per-WAN detail route, so every other key — including `site_id`, `wan_type`,
-`interface`, `status`, `dns_servers` and `is_backup` — is `null` when the
-controller omits it. Consumers must treat those fields as nullable rather than
-assuming they are always populated. A `null` means "not reported", never "empty"
-or "false".
+`interface`, `status`, `dns_servers` and `is_backup` — may be missing. Fields
+the controller does not report are omitted from the object rather than returned
+as `null`, so consumers must look keys up defensively instead of assuming they
+are always present. An absent key means "not reported", never "empty" or
+"false".
 
 **Example:**
 
@@ -923,6 +924,9 @@ or "false".
 result = await mcp.call_tool("list_wan_connections", {
     "site_id": "default"
 })
+# A sparse controller response:
+# [{"id": "<uuid-1>", "name": "Internet 1"},
+#  {"id": "<uuid-2>", "name": "Internet 2"}]
 ```
 
 #### `list_dynamic_dns`

--- a/API.md
+++ b/API.md
@@ -909,6 +909,14 @@ List WAN connections for a site.
 **Returns:**
 Array of WAN connection objects.
 
+Only `id` and `name` are guaranteed. The Integration v1
+`/sites/{site_id}/wans` endpoint returns just those two fields and offers no
+per-WAN detail route, so every other key — including `site_id`, `wan_type`,
+`interface`, `status`, `dns_servers` and `is_backup` — is `null` when the
+controller omits it. Consumers must treat those fields as nullable rather than
+assuming they are always populated. A `null` means "not reported", never "empty"
+or "false".
+
 **Example:**
 
 ```python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`list_wan_connections` on Integration v1 (issue #100)**: `GET /integration/v1/sites/{site_id}/wans` returns only `id` and `name`, but `WANConnection` required `site_id`, `wan_type`, `interface` and `status`, so every response raised `ValidationError` and the tool was unusable in local API mode. Those four fields are now optional. There is no per-WAN detail route to enrich the sparse record from, so relaxing the model is the only fix.
+
+### Changed
+
+- **`list_wan_connections` output contract**: optional fields now default to `None` instead of `[]`/`False` (`dns_servers`, `is_backup`), and the tool dumps with `exclude_none=True`, so fields the controller does not report are omitted rather than emitted as `null`. An absent key means "not reported", never "empty" or "false" — consumers must look keys up defensively. Documented in `API.md`.
+
 ## [0.4.0] - 2026-07-19
 
 ### Added

--- a/src/models/wan.py
+++ b/src/models/wan.py
@@ -6,13 +6,17 @@ from pydantic import BaseModel, ConfigDict, Field
 class WANConnection(BaseModel):
     """WAN connection model."""
 
+    # Only ``id`` and ``name`` are guaranteed: the Integration v1
+    # ``/sites/{site_id}/wans`` endpoint returns just those two fields, and
+    # there is no per-WAN detail route to enrich them from. Everything below is
+    # optional so a sparse response validates instead of raising.
     id: str = Field(..., alias="_id", description="WAN connection identifier")
-    site_id: str = Field(..., description="Site identifier")
+    site_id: str | None = Field(None, description="Site identifier")
     name: str = Field(..., description="WAN connection name")
 
     # Connection type
-    wan_type: str = Field(..., description="WAN type (dhcp/static/pppoe)")
-    interface: str = Field(..., description="Physical interface (eth0/eth1/etc)")
+    wan_type: str | None = Field(None, description="WAN type (dhcp/static/pppoe)")
+    interface: str | None = Field(None, description="Physical interface (eth0/eth1/etc)")
 
     # IP configuration
     ip_address: str | None = Field(None, description="WAN IP address")
@@ -21,7 +25,7 @@ class WANConnection(BaseModel):
     dns_servers: list[str] = Field(default_factory=list, description="DNS server IPs")
 
     # Connection status
-    status: str = Field(..., description="Connection status (online/offline/connecting)")
+    status: str | None = Field(None, description="Connection status (online/offline/connecting)")
     uptime: int | None = Field(None, description="Connection uptime in seconds")
 
     # Statistics

--- a/src/models/wan.py
+++ b/src/models/wan.py
@@ -9,7 +9,9 @@ class WANConnection(BaseModel):
     # Only ``id`` and ``name`` are guaranteed: the Integration v1
     # ``/sites/{site_id}/wans`` endpoint returns just those two fields, and
     # there is no per-WAN detail route to enrich them from. Everything below is
-    # optional so a sparse response validates instead of raising.
+    # optional so a sparse response validates instead of raising, and every
+    # optional field defaults to ``None`` rather than to a concrete value, so an
+    # omitted field is never reported as an empty list or a ``False`` flag.
     id: str = Field(..., alias="_id", description="WAN connection identifier")
     site_id: str | None = Field(None, description="Site identifier")
     name: str = Field(..., description="WAN connection name")
@@ -22,7 +24,7 @@ class WANConnection(BaseModel):
     ip_address: str | None = Field(None, description="WAN IP address")
     netmask: str | None = Field(None, description="Subnet mask")
     gateway: str | None = Field(None, description="Gateway IP")
-    dns_servers: list[str] = Field(default_factory=list, description="DNS server IPs")
+    dns_servers: list[str] | None = Field(None, description="DNS server IPs")
 
     # Connection status
     status: str | None = Field(None, description="Connection status (online/offline/connecting)")
@@ -44,7 +46,7 @@ class WANConnection(BaseModel):
     failover_priority: int | None = Field(
         None, description="Failover priority (lower = higher priority)"
     )
-    is_backup: bool = Field(False, description="Whether this is a backup WAN")
+    is_backup: bool | None = Field(None, description="Whether this is a backup WAN")
 
     # ISP information
     isp_name: str | None = Field(None, description="ISP name")

--- a/src/tools/wans.py
+++ b/src/tools/wans.py
@@ -245,7 +245,10 @@ async def list_wan_connections(site_id: str, settings: Settings) -> list[dict]:
         settings: Application settings
 
     Returns:
-        List of WAN connections
+        List of WAN connections. Fields the controller does not report are
+        omitted rather than returned as ``null``: the Integration v1 list route
+        supplies only ``id`` and ``name``, so keeping the nulls would bury those
+        two under 20 empty keys.
     """
     async with UniFiClient(settings) as client:
         logger.info(sanitize_log_message(f"Listing WAN connections for site {site_id}"))
@@ -256,7 +259,7 @@ async def list_wan_connections(site_id: str, settings: Settings) -> list[dict]:
         response = await client.get(f"/integration/v1/sites/{site_id}/wans")
         data = response if isinstance(response, list) else response.get("data", [])
 
-        return [WANConnection(**wan).model_dump() for wan in data]
+        return [WANConnection(**wan).model_dump(exclude_none=True) for wan in data]
 
 
 async def list_dynamic_dns(site_id: str, settings: Settings) -> list[dict[str, Any]]:

--- a/tests/unit/tools/test_wans_tools.py
+++ b/tests/unit/tools/test_wans_tools.py
@@ -32,6 +32,8 @@ def make_wan(wan_id="wan-1"):
         "wan_type": "dhcp",
         "interface": "eth0",
         "status": "online",
+        "dns_servers": ["1.1.1.1", "8.8.8.8"],
+        "is_backup": True,
     }
 
 
@@ -111,11 +113,15 @@ class TestListWanConnections:
         assert len(result) == 1
         assert result[0]["id"] == "wan-1"
         assert result[0]["name"] == "Internet 1"
-        # Absent fields surface as None rather than failing validation.
+        # Absent fields surface as None rather than failing validation. No field
+        # carries a concrete default, so "omitted by the controller" is never
+        # reported as an empty list or a False flag.
         assert result[0]["site_id"] is None
         assert result[0]["wan_type"] is None
         assert result[0]["interface"] is None
         assert result[0]["status"] is None
+        assert result[0]["dns_servers"] is None
+        assert result[0]["is_backup"] is None
 
     async def test_populated_optional_fields_are_preserved(self, mock_settings):
         """Relaxing the model must not drop values when they are present."""
@@ -127,6 +133,8 @@ class TestListWanConnections:
         assert result[0]["wan_type"] == "dhcp"
         assert result[0]["interface"] == "eth0"
         assert result[0]["status"] == "online"
+        assert result[0]["dns_servers"] == ["1.1.1.1", "8.8.8.8"]
+        assert result[0]["is_backup"] is True
 
 
 class TestDynamicDNS:

--- a/tests/unit/tools/test_wans_tools.py
+++ b/tests/unit/tools/test_wans_tools.py
@@ -35,6 +35,15 @@ def make_wan(wan_id="wan-1"):
     }
 
 
+def make_sparse_wan(wan_id="wan-1"):
+    """A WAN exactly as Integration v1 ``/sites/{site_id}/wans`` returns it.
+
+    That endpoint reports only ``id`` and ``name``; there is no per-WAN detail
+    route to enrich the record from.
+    """
+    return {"id": wan_id, "name": "Internet 1"}
+
+
 def create_mock_client(return_value):
     mock_client = AsyncMock()
     mock_client.get = AsyncMock(return_value=return_value)
@@ -92,6 +101,32 @@ class TestListWanConnections:
         with patch("src.tools.wans.UniFiClient", return_value=mock_client):
             await list_wan_connections("default", mock_settings)
         mock_client.authenticate.assert_called_once()
+
+    async def test_accepts_sparse_integration_api_response(self, mock_settings):
+        """Integration v1 returns only id and name; that must not raise."""
+        mock_client = create_mock_client({"data": [make_sparse_wan()]})
+        with patch("src.tools.wans.UniFiClient", return_value=mock_client):
+            result = await list_wan_connections("default", mock_settings)
+
+        assert len(result) == 1
+        assert result[0]["id"] == "wan-1"
+        assert result[0]["name"] == "Internet 1"
+        # Absent fields surface as None rather than failing validation.
+        assert result[0]["site_id"] is None
+        assert result[0]["wan_type"] is None
+        assert result[0]["interface"] is None
+        assert result[0]["status"] is None
+
+    async def test_populated_optional_fields_are_preserved(self, mock_settings):
+        """Relaxing the model must not drop values when they are present."""
+        mock_client = create_mock_client({"data": [make_wan()]})
+        with patch("src.tools.wans.UniFiClient", return_value=mock_client):
+            result = await list_wan_connections("default", mock_settings)
+
+        assert result[0]["site_id"] == "default"
+        assert result[0]["wan_type"] == "dhcp"
+        assert result[0]["interface"] == "eth0"
+        assert result[0]["status"] == "online"
 
 
 class TestDynamicDNS:

--- a/tests/unit/tools/test_wans_tools.py
+++ b/tests/unit/tools/test_wans_tools.py
@@ -38,10 +38,16 @@ def make_wan(wan_id="wan-1"):
 
 
 def make_sparse_wan(wan_id="wan-1"):
-    """A WAN exactly as Integration v1 ``/sites/{site_id}/wans`` returns it.
+    """Build a WAN exactly as Integration v1 ``/sites/{site_id}/wans`` returns it.
 
     That endpoint reports only ``id`` and ``name``; there is no per-WAN detail
     route to enrich the record from.
+
+    Args:
+        wan_id: Identifier to report as ``id``
+
+    Returns:
+        The two-field WAN record the sparse endpoint sends
     """
     return {"id": wan_id, "name": "Internet 1"}
 

--- a/tests/unit/tools/test_wans_tools.py
+++ b/tests/unit/tools/test_wans_tools.py
@@ -110,18 +110,11 @@ class TestListWanConnections:
         with patch("src.tools.wans.UniFiClient", return_value=mock_client):
             result = await list_wan_connections("default", mock_settings)
 
-        assert len(result) == 1
-        assert result[0]["id"] == "wan-1"
-        assert result[0]["name"] == "Internet 1"
-        # Absent fields surface as None rather than failing validation. No field
-        # carries a concrete default, so "omitted by the controller" is never
-        # reported as an empty list or a False flag.
-        assert result[0]["site_id"] is None
-        assert result[0]["wan_type"] is None
-        assert result[0]["interface"] is None
-        assert result[0]["status"] is None
-        assert result[0]["dns_servers"] is None
-        assert result[0]["is_backup"] is None
+        # Absent fields are dropped from the output rather than failing
+        # validation or padding the record with 20 nulls. No field carries a
+        # concrete default, so "omitted by the controller" is never reported as
+        # an empty list or a False flag either.
+        assert result == [{"id": "wan-1", "name": "Internet 1"}]
 
     async def test_populated_optional_fields_are_preserved(self, mock_settings):
         """Relaxing the model must not drop values when they are present."""
@@ -135,6 +128,9 @@ class TestListWanConnections:
         assert result[0]["status"] == "online"
         assert result[0]["dns_servers"] == ["1.1.1.1", "8.8.8.8"]
         assert result[0]["is_backup"] is True
+        # Only what the controller reported: is_backup=True survives the
+        # exclude_none filter, but a field nobody sent stays out.
+        assert "ip_address" not in result[0]
 
 
 class TestDynamicDNS:


### PR DESCRIPTION
Fixes #100.

## Problem

`GET /integration/v1/sites/{site_id}/wans` returns only `id` and `name`:

```json
{"offset":0,"limit":25,"count":2,"totalCount":2,
 "data":[{"id":"<uuid-1>","name":"Internet 1"},
         {"id":"<uuid-2>","name":"Internet 2"}]}
```

`WANConnection` required `site_id`, `wan_type`, `interface` and `status`, so
every response raised `ValidationError` and `list_wan_connections` was unusable
in local API mode. The HTTP call itself succeeds with `200` — only parsing
fails, so the data is fetched and then discarded.

## Why relax rather than backfill

There is no per-WAN detail route to enrich the sparse record from:

```console
$ curl -sk -H "X-API-KEY: $KEY" "https://<controller>/proxy/network/integration/v1/sites/<SITE-UUID>/wans/<WAN-UUID>"
{"statusCode":404,"statusName":"NOT_FOUND","code":"api.request.error",
 "message":"No endpoint GET /integration/v1/sites/<SITE-UUID>/wans/<WAN-UUID>."}
```

`id` and `name` stay required since they are always present. The model already
sets `extra="allow"`, so richer payloads from other sources are unaffected.

## Output contract change

This PR **does** change the shape of `list_wan_connections` output, in two ways:

1. Optional fields default to `None` rather than to a concrete value —
   `dns_servers` was `default_factory=list` and `is_backup` was `False`. A field
   the controller never sent was being reported as an empty list or a `False`
   flag, which is a stronger claim than the controller actually made.
2. `src/tools/wans.py` dumps with `model_dump(exclude_none=True)`. Without it a
   sparse response emits 22 keys of which 20 are `null`, burying `id` and
   `name`.

Net effect: **absent keys are omitted rather than emitted as `null`**. An absent
key means "not reported", never "empty" or "false", so consumers must look keys
up defensively. Documented in `API.md` and `CHANGELOG.md`.

This is consistent with existing repo convention — `src/tools/switching.py` and
`src/tools/port_profiles.py` already dump sparse Integration v1 records with
`exclude_none=True`. Making it the default for *all* list responses is a
reasonable follow-up, but it is a wider blast radius than this fix and belongs
in its own PR.

No in-repo consumer parses `list_wan_connections` results; the only other
mentions are documentation tables (`API.md`, `skills/unifi-network.md`,
`docs/AI-Coding/CODE_DEVELOPMENT_PLAN.md`).

## Tests

Two cases added to `TestListWanConnections`, covering both directions:

- `test_accepts_sparse_integration_api_response` — the real `{id, name}` shape
  validates, the absent fields are dropped from the output, and nothing is
  padded with a concrete default
- `test_populated_optional_fields_are_preserved` — a fully populated payload
  still round-trips every value, so relaxing the model drops nothing

```console
$ uv run pytest tests/unit -q
1412 passed, 38 warnings in 5.62s

$ uvx ruff check src/models/wan.py src/tools/wans.py tests/unit/tools/test_wans_tools.py
All checks passed!

$ uvx ruff format --check src/models/wan.py src/tools/wans.py tests/unit/tools/test_wans_tools.py
3 files already formatted
```

Verified end-to-end against a UDM Pro SE (firmware 5.1.26.33914, two WANs,
`UNIFI_API_TYPE=local`): `list_wan_connections` returns both WANs instead of
raising.
