### PR TITLE
fix(api): restore site UUID translation for local v2 endpoints

### DIFF
--- a/src/api/client.py
+++ b/src/api/client.py
@@ -7,8 +7,10 @@ from typing import Any
 from uuid import UUID
 
 import httpx
+from pydantic import ValidationError as PydanticValidationError
 
 from ..config import APIType, Settings
+from ..models.site import SiteReference
 from ..utils import (
     APIError,
     AuthenticationError,
@@ -256,14 +258,17 @@ class UniFiClient:
             raise AuthenticationError(f"Failed to authenticate with UniFi API: {e}") from e
 
     @staticmethod
-    def _extract_site_list(response: Any) -> list[dict[str, Any]] | None:
-        """Pull the site list out of an /ea/sites response.
+    def _extract_site_list(response: Any) -> list[Any] | None:
+        """Pull the site list out of an /ea/sites response envelope.
+
+        Envelope handling only: the entries themselves are validated as
+        :class:`SiteReference` in :meth:`_build_site_uuid_map`.
 
         Args:
             response: Raw response, either a bare list or ``{"data": [...]}``
 
         Returns:
-            The list of site objects, or None if the response carries none
+            The list of site entries, or None if the response carries none
         """
         if isinstance(response, list):
             return response
@@ -273,24 +278,26 @@ class UniFiClient:
                 return data
         return None
 
-    def _build_site_uuid_map(self, sites: list[dict[str, Any]]) -> None:
+    def _build_site_uuid_map(self, sites: list[Any]) -> None:
         """Build a mapping of site UUIDs to internal reference names.
 
         This is required for local API, which uses site names (e.g., 'default')
-        instead of UUIDs in endpoint paths.
+        instead of UUIDs in endpoint paths. Entries are validated through
+        :class:`SiteReference`; one malformed entry is skipped rather than
+        failing authentication for every other site.
 
         Args:
             sites: List of site objects from /ea/sites endpoint
         """
         self._site_uuid_to_name.clear()
         for site in sites:
-            if not isinstance(site, dict):
-                self.logger.warning(f"Skipping non-dict site entry: {type(site).__name__}")
+            try:
+                reference = SiteReference.model_validate(site)
+            except PydanticValidationError as exc:
+                self.logger.warning(f"Skipping unparsable site entry: {exc}")
                 continue
-            site_id = site.get("id")
-            internal_ref = site.get("internalReference")
-            if site_id and internal_ref:
-                self._site_uuid_to_name[site_id] = internal_ref
+            if reference.internal_reference:
+                self._site_uuid_to_name[reference.id] = reference.internal_reference
 
         self.logger.info(f"Built site UUID mapping: {len(self._site_uuid_to_name)} sites")
 

--- a/src/api/client.py
+++ b/src/api/client.py
@@ -176,6 +176,21 @@ class UniFiClient:
                 self.logger.debug(f"Translated site ID: {site_id} -> {site_name}")
             return f"/proxy/network/api/s/{site_name}/self"
 
+        # Pattern: /proxy/network/v2/api/site/{site_id}/{rest}
+        # The v2 API keys off the site short name and rejects UUIDs with
+        # {"errorCode":404,"message":"Site does not exist"}. Callers normally
+        # hold the UUID that list_sites returns, so translate centrally here
+        # rather than relying on every call site to remember. The lookup is
+        # idempotent -- a short name maps to itself -- so callers that already
+        # normalize are unaffected.
+        match = re.match(r"^(/proxy/network/v2/api/site/)([^/]+)(/.*)?$", endpoint)
+        if match:
+            prefix, site_id, rest = match.groups()
+            site_name = self._site_uuid_to_name.get(site_id, site_id)
+            if site_id != site_name:
+                self.logger.debug(f"Translated v2 site ID: {site_id} -> {site_name}")
+            return f"{prefix}{site_name}{rest or ''}"
+
         # If no pattern matches, check if it's already a local endpoint
         if endpoint.startswith("/proxy/network/"):
             return endpoint
@@ -214,9 +229,6 @@ class UniFiClient:
             if isinstance(response, list):
                 # List response means we got data successfully (local API)
                 self._authenticated = True
-                # Build site UUID -> name mapping for local API
-                if self.settings.api_type == APIType.LOCAL:
-                    self._build_site_uuid_map(response)
             elif isinstance(response, dict):
                 # Dict response - check for success indicators
                 self._authenticated = (
@@ -227,12 +239,39 @@ class UniFiClient:
             else:
                 self._authenticated = False
 
+            # Build site UUID -> name mapping for local API.
+            # /ea/sites arrives either as a bare list or wrapped as {"data": [...]},
+            # depending on how _request normalizes the payload. Accept both, or the
+            # map silently stays empty and every UUID -> site name lookup no-ops.
+            if self.settings.api_type == APIType.LOCAL:
+                sites = self._extract_site_list(response)
+                if sites is not None:
+                    self._build_site_uuid_map(sites)
+
             self.logger.info(
                 f"Successfully authenticated with UniFi API (response type: {type(response).__name__})"
             )
         except Exception as e:
             self.logger.error(f"Authentication failed: {e}")
             raise AuthenticationError(f"Failed to authenticate with UniFi API: {e}") from e
+
+    @staticmethod
+    def _extract_site_list(response: Any) -> list[dict[str, Any]] | None:
+        """Pull the site list out of an /ea/sites response.
+
+        Args:
+            response: Raw response, either a bare list or ``{"data": [...]}``
+
+        Returns:
+            The list of site objects, or None if the response carries none
+        """
+        if isinstance(response, list):
+            return response
+        if isinstance(response, dict):
+            data = response.get("data")
+            if isinstance(data, list):
+                return data
+        return None
 
     def _build_site_uuid_map(self, sites: list[dict[str, Any]]) -> None:
         """Build a mapping of site UUIDs to internal reference names.

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -66,7 +66,7 @@ from .protect_nvr import ProtectNVR
 from .qos_profile import MatchCriteria, RouteAction, RouteSchedule, TrafficRoute
 from .radius import RADIUSProfile
 from .reference_data import DeviceTag
-from .site import Site
+from .site import Site, SiteReference
 from .site_manager import (
     CrossSiteStatistics,
     InternetHealthMetrics,
@@ -87,6 +87,7 @@ from .zbf_matrix import ApplicationBlockRule, ZoneNetworkAssignment, ZonePolicy,
 
 __all__ = [
     "Site",
+    "SiteReference",
     "Device",
     "Client",
     "Network",

--- a/src/models/site.py
+++ b/src/models/site.py
@@ -57,3 +57,22 @@ class Site(BaseModel):
         if self.name is None or self.name == "":
             self.name = f"Site {self.id}"
         return self
+
+
+class SiteReference(BaseModel):
+    """A site entry from the local ``/ea/sites`` listing.
+
+    Only the two fields needed to translate a site UUID into the short name the
+    local API's path segments expect. ``internalReference`` is the short name
+    ("default"); it is optional because older controllers omit it, in which case
+    the site simply cannot be translated.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    id: str = Field(..., description="Site UUID as returned by /ea/sites")
+    internal_reference: str | None = Field(
+        None,
+        description="Site short name used in local API paths",
+        validation_alias=AliasChoices("internalReference", "internal_reference"),
+    )

--- a/tests/unit/api/test_client.py
+++ b/tests/unit/api/test_client.py
@@ -1,13 +1,14 @@
 """Unit tests for UniFi API client."""
 
 import asyncio
+from types import MethodType
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
 from src.api.client import RateLimiter, UniFiClient
-from src.config import APIType
+from src.config import APIType, Settings
 from src.utils.exceptions import (
     APIError,
     AuthenticationError,
@@ -332,6 +333,102 @@ class TestUniFiClientAuthentication:
         assert client._site_uuid_to_name["uuid-1"] == "default"
         assert client._site_uuid_to_name["uuid-2"] == "office"
         await client.close()
+
+    @pytest.mark.asyncio
+    async def test_build_site_uuid_map_skips_unparsable_entries(self, mock_settings_local):
+        """A malformed entry must not cost every other site its mapping."""
+        client = UniFiClient(mock_settings_local)
+
+        sites = [
+            {"id": "uuid-1", "internalReference": "default"},
+            "not-a-site",
+            {"internalReference": "office"},  # no id
+        ]
+
+        client._build_site_uuid_map(sites)
+
+        assert client._site_uuid_to_name == {"uuid-1": "default"}
+        await client.close()
+
+
+class TestLocalV2SiteTranslationEndToEnd:
+    """The v2 rewrite must hold for a real request, not just the helper."""
+
+    @staticmethod
+    def _response(payload, status_code=200):
+        """Build a stub httpx response carrying a JSON payload.
+
+        Args:
+            payload: Object returned by ``response.json()``
+            status_code: HTTP status code to report
+
+        Returns:
+            A MagicMock shaped like the httpx response the client expects
+        """
+        response = MagicMock()
+        response.status_code = status_code
+        response.text = "{}"
+        response.json = MagicMock(return_value=payload)
+        response.headers = {}
+        return response
+
+    @pytest.fixture
+    def local_client(self, mock_settings_local):
+        """A local client whose ``get_v2_api_path`` is the real implementation.
+
+        Args:
+            mock_settings_local: Local-mode settings fixture
+
+        Returns:
+            An un-authenticated UniFiClient in local mode
+        """
+        mock_settings_local.get_v2_api_path = MethodType(
+            Settings.get_v2_api_path, mock_settings_local
+        )
+        return UniFiClient(mock_settings_local)
+
+    @pytest.mark.asyncio
+    async def test_v2_call_with_a_uuid_from_list_sites_hits_the_short_name(self, local_client):
+        """A UUID straight out of list_sites must reach the controller as a name."""
+        sites = [{"id": "abc-123-uuid", "internalReference": "default", "name": "Default"}]
+
+        with patch.object(local_client.client, "request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = self._response({"data": sites})
+            await local_client.authenticate()
+
+            # Exactly the identifier list_sites hands back to a caller.
+            site_id = sites[0]["id"]
+            mock_request.return_value = self._response({"data": []})
+            await local_client.get(
+                f"{local_client.settings.get_v2_api_path(site_id)}/firewall/zone"
+            )
+
+        assert (
+            mock_request.call_args.kwargs["url"]
+            == "https://192.168.2.1/proxy/network/v2/api/site/default/firewall/zone"
+        )
+        await local_client.close()
+
+    @pytest.mark.asyncio
+    async def test_v2_call_with_an_unmapped_site_reports_the_upstream_error(self, local_client):
+        """An unknown site is passed through so the controller's 404 surfaces."""
+        sites = [{"id": "abc-123-uuid", "internalReference": "default", "name": "Default"}]
+
+        with patch.object(local_client.client, "request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = self._response({"data": sites})
+            await local_client.authenticate()
+
+            mock_request.return_value = self._response({"message": "Site does not exist"}, 404)
+            with pytest.raises(ResourceNotFoundError):
+                await local_client.get(
+                    f"{local_client.settings.get_v2_api_path('unmapped-uuid')}/firewall/zone"
+                )
+
+        # Passed through verbatim rather than rewritten to something wrong.
+        assert mock_request.call_args.kwargs["url"].endswith(
+            "/proxy/network/v2/api/site/unmapped-uuid/firewall/zone"
+        )
+        await local_client.close()
 
 
 class TestUniFiClientHttpMethods:

--- a/tests/unit/api/test_client.py
+++ b/tests/unit/api/test_client.py
@@ -175,6 +175,67 @@ class TestUniFiClientEndpointTranslation:
 
         await client.close()
 
+    @pytest.mark.asyncio
+    async def test_translate_v2_uuid_to_site_name(self, mock_settings_local):
+        """The v2 API rejects UUIDs, so they must be mapped to the short name."""
+        client = UniFiClient(mock_settings_local)
+        client._site_uuid_to_name = {"abc-123-uuid": "default"}
+
+        result = client._translate_endpoint("/proxy/network/v2/api/site/abc-123-uuid/traffic-flows")
+        assert result == "/proxy/network/v2/api/site/default/traffic-flows"
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_translate_v2_nested_path_is_preserved(self, mock_settings_local):
+        """Everything after the site segment must survive the rewrite intact."""
+        client = UniFiClient(mock_settings_local)
+        client._site_uuid_to_name = {"abc-123-uuid": "default"}
+
+        result = client._translate_endpoint(
+            "/proxy/network/v2/api/site/abc-123-uuid/firewall-policies/pol-1"
+        )
+        assert result == "/proxy/network/v2/api/site/default/firewall-policies/pol-1"
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_translate_v2_short_name_is_idempotent(self, mock_settings_local):
+        """Callers that already normalize must not be broken by the rewrite."""
+        client = UniFiClient(mock_settings_local)
+        client._site_uuid_to_name = {"abc-123-uuid": "default"}
+
+        result = client._translate_endpoint("/proxy/network/v2/api/site/default/traffic-flows")
+        assert result == "/proxy/network/v2/api/site/default/traffic-flows"
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_translate_v2_unknown_site_passes_through(self, mock_settings_local):
+        """An unmapped id is left alone so the API can report the real error."""
+        client = UniFiClient(mock_settings_local)
+        client._site_uuid_to_name = {}
+
+        result = client._translate_endpoint(
+            "/proxy/network/v2/api/site/unmapped-uuid/traffic-flows"
+        )
+        assert result == "/proxy/network/v2/api/site/unmapped-uuid/traffic-flows"
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_translate_non_v2_proxy_path_unchanged(self, mock_settings_local):
+        """Only the v2 site pattern is rewritten; other local paths pass through."""
+        client = UniFiClient(mock_settings_local)
+        client._site_uuid_to_name = {"abc-123-uuid": "default"}
+
+        result = client._translate_endpoint(
+            "/proxy/network/integration/v1/sites/abc-123-uuid/devices"
+        )
+        assert result == "/proxy/network/integration/v1/sites/abc-123-uuid/devices"
+
+        await client.close()
+
 
 class TestUniFiClientAuthentication:
     @pytest.mark.asyncio
@@ -207,6 +268,42 @@ class TestUniFiClientAuthentication:
             await client.authenticate()
 
         assert client._authenticated is True
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_authenticate_builds_site_map_from_dict_response(self, mock_settings_local):
+        """A wrapped {"data": [...]} payload must still populate the UUID map."""
+        client = UniFiClient(mock_settings_local)
+        sites = [{"id": "abc-123-uuid", "internalReference": "default", "name": "Default"}]
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "{}"
+        mock_response.json = MagicMock(return_value={"data": sites})
+
+        with patch.object(client.client, "request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = mock_response
+            await client.authenticate()
+
+        assert client._site_uuid_to_name == {"abc-123-uuid": "default"}
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_authenticate_builds_site_map_from_list_response(self, mock_settings_local):
+        """The bare-list shape must keep working."""
+        client = UniFiClient(mock_settings_local)
+        sites = [{"id": "abc-123-uuid", "internalReference": "default", "name": "Default"}]
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "[]"
+        mock_response.json = MagicMock(return_value=sites)
+
+        with patch.object(client.client, "request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = mock_response
+            await client.authenticate()
+
+        assert client._site_uuid_to_name == {"abc-123-uuid": "default"}
         await client.close()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Refs #99. Please read this in preference to the issue — investigating the fix
turned up a different, larger root cause than I originally reported there, and
I have corrected the issue accordingly.

## Symptom

Every v2 tool rejects the site UUID that `list_sites` returns:

```
{"errorCode":404,"message":"Site does not exist"}
```

Passing the short name `"default"` works. Since `list_sites` hands back the
UUID as `id`, the natural call pattern is the broken one.

## Root cause 1 — the site UUID map is never built

`authenticate()` calls `_build_site_uuid_map()` only from the
`isinstance(response, list)` branch. But `_request()` now normalizes every
payload to a dict:

```python
# previously
return data if isinstance(data, list) else {"data": data}
# currently
return {"data": data}
```

`/ea/sites` therefore arrives as `{"data": [...]}`, the list branch is
unreachable, and `_site_uuid_to_name` stays empty. Confirmed against a live
controller:

| | `_request("/ea/sites")` | `_site_uuid_to_name` |
|---|---|---|
| 0.2.5 (PyPI) | `list` | `{"<uuid>": "default"}` |
| `main` | `dict` | `{}` |

This is the part that makes the bug hard to see. Every lookup is
`_site_uuid_to_name.get(site_id, site_id)` — the fallback is the input, so an
empty map degrades silently to "no translation" rather than raising. It
disables the seven call sites that normalize by hand *and* the long-standing
`/ea/sites/{uuid}/...` rewrite.

Fixed by extracting the site list from either shape (`_extract_site_list`).

## Root cause 2 — v2 paths bypass translation

`_translate_endpoint()` returns early for anything starting with
`/proxy/network/`, so `/proxy/network/v2/api/site/{uuid}/...` was never
rewritten even once the map is populated. It now maps the site segment and
preserves the rest of the path.

Handling this centrally covers all fourteen `get_v2_api_path()` callers —
seven of which never normalized:

| Normalized by hand | Not normalized |
|---|---|
| `traffic_flows.py:84` | `content_filtering.py:262` |
| `firewall.py:53` | `firewall_policies.py:241, 323, 462, 736, 1138, 1237` |
| `content_filtering.py:55, 87, 175` | |
| `firewall_policies.py:393, 1032` | |

The lookup is idempotent — a short name maps to itself — so the existing manual
normalization keeps working and simply becomes redundant. I left those call
sites alone to keep this diff reviewable; happy to remove them in a follow-up
if you want the invariant in one place.

## Verification

End-to-end against a UDM Pro SE (firmware 5.1.26.33914, `UNIFI_API_TYPE=local`),
calling `_load_zone_index()` with a site UUID:

```
before:  ResourceNotFoundError: resource '/proxy/network/v2/api/site/<uuid>/firewall/zone' not found
after:   firewall/zone with UUID -> OK, 18 zone entries
```

Seven unit tests added — five for the v2 path rewrite (UUID mapping, nested
path preservation, idempotence on short names, pass-through for unmapped ids,
and non-v2 `/proxy/network/` paths left alone) and two for map construction
from both the list and dict response shapes.

```console
$ uv run pytest tests/unit -q
1417 passed, 39 warnings in 5.44s

$ uvx ruff check src/api/client.py tests/unit/api/test_client.py
All checks passed!

$ uvx ruff format --check src/api/client.py tests/unit/api/test_client.py
2 files already formatted
```