### PR TITLE
fix(topology): resolve device uplinks, online state and hop depth

### DIFF
--- a/src/tools/topology.py
+++ b/src/tools/topology.py
@@ -8,14 +8,33 @@ from typing import Any, Literal, cast
 from src.api.client import UniFiClient
 from src.config import Settings
 from src.models.topology import NetworkDiagram, TopologyConnection, TopologyNode
-from src.utils.exceptions import ValidationError
+from src.utils.exceptions import (
+    APIError,
+    AuthenticationError,
+    NetworkError,
+    RateLimitError,
+    ValidationError,
+)
 
 # The Integration API reports "ONLINE"; older/legacy payloads use "CONNECTED".
 _ONLINE_DEVICE_STATES = frozenset({"ONLINE", "CONNECTED"})
 
+# Upper bound on in-flight per-device detail lookups. The enrichment pass issues
+# one request per device, so a large site would otherwise queue hundreds of
+# requests behind the client's rate limiter at once.
+_UPLINK_DETAIL_CONCURRENCY = 8
+
 
 def _extract_device_detail(response: Any) -> dict[str, Any] | None:
-    """Unwrap a per-device detail response into the device object."""
+    """Unwrap a per-device detail response into the device object.
+
+    Args:
+        response: Raw detail response, either the device itself or wrapped in
+            ``data`` as an object or a single-element list
+
+    Returns:
+        The device object, or None if the response carries none
+    """
     if isinstance(response, dict):
         data = response.get("data")
         if isinstance(data, dict):
@@ -33,24 +52,47 @@ async def _merge_device_uplinks(
 
     The device *list* endpoint omits ``uplink`` entirely, so a topology built
     from it alone contains no device-to-device edges. The detail route does
-    carry it, as ``{"deviceId": ...}``. Lookups run concurrently; a device whose
-    lookup fails keeps no uplink rather than failing the whole graph.
+    carry it, as ``{"deviceId": ...}``.
+
+    Lookups run concurrently, bounded by ``_UPLINK_DETAIL_CONCURRENCY``. A
+    device whose lookup fails with a per-device API error keeps no uplink rather
+    than failing the whole graph, but a systemic failure — an authentication
+    rejection or an exhausted rate limit, which every other lookup is hitting
+    too — propagates instead of quietly yielding a graph with missing edges.
 
     Args:
         client: Authenticated API client
         devices_endpoint: Base devices endpoint for the resolved site
         devices: Device dicts to enrich in place
+
+    Raises:
+        AuthenticationError: If the controller rejects the credentials
+        RateLimitError: If the rate limit is exhausted after retries
     """
+    semaphore = asyncio.Semaphore(_UPLINK_DETAIL_CONCURRENCY)
 
     async def fetch(device: dict[str, Any]) -> None:
+        """Fetch one device's detail record and copy its uplink onto ``device``.
+
+        Args:
+            device: Device dict to enrich in place; skipped when it already
+                carries an ``uplink`` or has no ``id``
+        """
         device_id = device.get("id")
         if not device_id or isinstance(device.get("uplink"), dict):
             return
-        try:
-            response = await client.get(f"{devices_endpoint}/{device_id}")
-        except Exception as exc:  # noqa: BLE001 - one bad device must not sink the graph
-            client.logger.debug(f"No uplink detail for device {device_id}: {exc}")
-            return
+        async with semaphore:
+            try:
+                response = await client.get(f"{devices_endpoint}/{device_id}")
+            except (AuthenticationError, RateLimitError):
+                # Systemic, not device-specific: every other lookup is failing
+                # the same way, so a degraded graph would misrepresent the site.
+                raise
+            except (APIError, NetworkError) as exc:
+                # One bad device must not sink the graph. Narrow on purpose:
+                # anything else is a bug and should fail loudly.
+                client.logger.debug(f"No uplink detail for device {device_id}: {exc}")
+                return
         detail = _extract_device_detail(response)
         if detail is not None and isinstance(detail.get("uplink"), dict):
             device["uplink"] = detail["uplink"]
@@ -91,6 +133,13 @@ def _resolve_depth(device_id: str, uplinks: dict[str, str], cache: dict[str, int
 
     depth = cache[current]
     for node in reversed(chain):
+        # A node already in the cache is the cycle root this walk just pinned to
+        # 0. Keep that value and continue counting from it, rather than
+        # overwriting the root and inflating everything downstream of it.
+        cached = cache.get(node)
+        if cached is not None:
+            depth = cached
+            continue
         depth += 1
         cache[node] = depth
     return cache[device_id]

--- a/src/tools/topology.py
+++ b/src/tools/topology.py
@@ -1,5 +1,6 @@
 """Network topology tools for UniFi MCP Server."""
 
+import asyncio
 import json
 from datetime import datetime, timezone
 from typing import Any, Literal, cast
@@ -8,6 +9,91 @@ from src.api.client import UniFiClient
 from src.config import Settings
 from src.models.topology import NetworkDiagram, TopologyConnection, TopologyNode
 from src.utils.exceptions import ValidationError
+
+# The Integration API reports "ONLINE"; older/legacy payloads use "CONNECTED".
+_ONLINE_DEVICE_STATES = frozenset({"ONLINE", "CONNECTED"})
+
+
+def _extract_device_detail(response: Any) -> dict[str, Any] | None:
+    """Unwrap a per-device detail response into the device object."""
+    if isinstance(response, dict):
+        data = response.get("data")
+        if isinstance(data, dict):
+            return data
+        if isinstance(data, list):
+            return data[0] if data and isinstance(data[0], dict) else None
+        return response
+    return None
+
+
+async def _merge_device_uplinks(
+    client: UniFiClient, devices_endpoint: str, devices: list[dict[str, Any]]
+) -> None:
+    """Populate each device's ``uplink`` from the per-device detail route.
+
+    The device *list* endpoint omits ``uplink`` entirely, so a topology built
+    from it alone contains no device-to-device edges. The detail route does
+    carry it, as ``{"deviceId": ...}``. Lookups run concurrently; a device whose
+    lookup fails keeps no uplink rather than failing the whole graph.
+
+    Args:
+        client: Authenticated API client
+        devices_endpoint: Base devices endpoint for the resolved site
+        devices: Device dicts to enrich in place
+    """
+
+    async def fetch(device: dict[str, Any]) -> None:
+        device_id = device.get("id")
+        if not device_id or isinstance(device.get("uplink"), dict):
+            return
+        try:
+            response = await client.get(f"{devices_endpoint}/{device_id}")
+        except Exception as exc:  # noqa: BLE001 - one bad device must not sink the graph
+            client.logger.debug(f"No uplink detail for device {device_id}: {exc}")
+            return
+        detail = _extract_device_detail(response)
+        if detail is not None and isinstance(detail.get("uplink"), dict):
+            device["uplink"] = detail["uplink"]
+
+    await asyncio.gather(*(fetch(device) for device in devices))
+
+
+def _resolve_depth(device_id: str, uplinks: dict[str, str], cache: dict[str, int]) -> int:
+    """Return a device's hop count from the gateway.
+
+    Walks the uplink chain rather than trusting device ordering, so depth is
+    correct regardless of the order the API returns devices in. A cycle in the
+    reported uplinks is broken by treating the repeated device as a root.
+
+    Args:
+        device_id: Device to resolve
+        uplinks: Device ID -> uplink device ID
+        cache: Memo of already-resolved depths, updated in place
+
+    Returns:
+        Hop count, 0 for a device with no uplink
+    """
+    chain: list[str] = []
+    seen: set[str] = set()
+    current = device_id
+
+    while current not in cache:
+        if current in seen:
+            cache[current] = 0
+            break
+        seen.add(current)
+        parent = uplinks.get(current)
+        if parent is None:
+            cache[current] = 0
+            break
+        chain.append(current)
+        current = parent
+
+    depth = cache[current]
+    for node in reversed(chain):
+        depth += 1
+        cache[node] = depth
+    return cache[device_id]
 
 
 async def get_network_topology(
@@ -70,23 +156,32 @@ async def get_network_topology(
             if len(data) < 100:
                 break
 
+        # The list endpoint above returns no `uplink` key; without this the
+        # graph would contain client edges only, with every device a root.
+        await _merge_device_uplinks(client, devices_endpoint, device_nodes)
+
         # Convert devices to topology nodes
         nodes = []
         connections = []
         depth_map: dict[str, int] = {}  # Track network depth for each device
 
+        # Uplink chain must be known up front: depth cannot be derived from a
+        # single pass unless parents happen to precede children.
+        uplinks: dict[str, str] = {}
+        for device in device_nodes:
+            device_id = device.get("id", "")
+            uplink_device_id = (device.get("uplink") or {}).get("deviceId")
+            if device_id and uplink_device_id:
+                uplinks[device_id] = uplink_device_id
+
         # First pass: Create all device nodes and calculate depth
         for device in device_nodes:
             device_id = device.get("id", "")
-            uplink_info = device.get("uplink", {})
+            uplink_info = device.get("uplink") or {}
             uplink_device_id = uplink_info.get("deviceId")
+            is_online = device.get("state") in _ONLINE_DEVICE_STATES
 
-            # Calculate depth (distance from gateway)
-            if uplink_device_id:
-                parent_depth = depth_map.get(uplink_device_id, 0)
-                depth_map[device_id] = parent_depth + 1
-            else:
-                depth_map[device_id] = 0  # Gateway device
+            _resolve_depth(device_id, uplinks, depth_map)
 
             node = TopologyNode(
                 node_id=device_id,
@@ -99,7 +194,7 @@ async def get_network_topology(
                 uplink_device_id=uplink_device_id,
                 uplink_port=uplink_info.get("portIndex"),
                 uplink_depth=depth_map.get(device_id, 0),
-                state=1 if device.get("state") == "CONNECTED" else 0,
+                state=1 if is_online else 0,
                 adopted=True,  # All returned devices are adopted
             )
             nodes.append(node)
@@ -114,7 +209,7 @@ async def get_network_topology(
                     source_port=uplink_info.get("portIndex"),
                     speed_mbps=uplink_info.get("speedMbps"),
                     is_uplink=True,
-                    status="up" if device.get("state") == "CONNECTED" else "down",
+                    status="up" if is_online else "down",
                 )
                 connections.append(conn)
 

--- a/tests/unit/tools/test_topology_tools.py
+++ b/tests/unit/tools/test_topology_tools.py
@@ -1,8 +1,11 @@
 """Tests for topology tools."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from src.utils.exceptions import AuthenticationError, RateLimitError, ResourceNotFoundError
 
 
 @pytest.fixture
@@ -471,6 +474,7 @@ class TestDeviceUplinkResolution:
     """The device list endpoint omits `uplink`; it comes from the detail route."""
 
     def test_depth_is_independent_of_device_order(self):
+        """Depth comes from the uplink chain, not from device ordering."""
         from src.tools.topology import _resolve_depth
 
         # Deliberately leaf-first: a single forward pass would score these 0.
@@ -482,16 +486,32 @@ class TestDeviceUplinkResolution:
         assert _resolve_depth("gateway", uplinks, cache) == 0
 
     def test_depth_survives_an_uplink_cycle(self):
+        """A cycle terminates, with the repeated device pinned as the root."""
         from src.tools.topology import _resolve_depth
 
         uplinks = {"a": "b", "b": "a"}
         cache: dict[str, int] = {}
 
-        # Must terminate rather than spin; the exact depth is unimportant.
-        assert _resolve_depth("a", uplinks, cache) >= 0
+        # The repeated device is the cycle root and must stay at 0; the unwind
+        # pass must not overwrite it and inflate the rest of the chain.
+        assert _resolve_depth("a", uplinks, cache) == 0
+        assert cache["a"] == 0
+        assert cache["b"] == 1
+
+    def test_depth_of_a_device_hanging_off_a_cycle(self):
+        """A device feeding into a cycle counts hops from the cycle root."""
+        from src.tools.topology import _resolve_depth
+
+        uplinks = {"leaf": "a", "a": "b", "b": "a"}
+        cache: dict[str, int] = {}
+
+        # "a" is pinned to 0 as the cycle root, so its child is one hop away.
+        assert _resolve_depth("leaf", uplinks, cache) == 1
+        assert cache["a"] == 0
 
     @pytest.mark.asyncio
     async def test_merge_device_uplinks_fills_from_detail_route(self):
+        """The detail route supplies the uplink the list route omits."""
         from src.tools.topology import _merge_device_uplinks
 
         devices = [{"id": "ap_001"}, {"id": "switch_001"}]
@@ -511,21 +531,79 @@ class TestDeviceUplinkResolution:
 
     @pytest.mark.asyncio
     async def test_merge_device_uplinks_tolerates_detail_failure(self):
+        """A per-device API failure degrades that device only."""
+        from src.tools.topology import _merge_device_uplinks
+
+        devices = [{"id": "ap_001"}, {"id": "switch_001"}]
+        detail = {"data": {"id": "switch_001", "uplink": {"deviceId": "gw_001"}}}
+
+        async def get(endpoint):
+            if endpoint.endswith("ap_001"):
+                raise ResourceNotFoundError("device", "ap_001")
+            return detail
+
+        client = MagicMock()
+        client.logger = MagicMock()
+        client.get = AsyncMock(side_effect=get)
+
+        await _merge_device_uplinks(client, "/integration/v1/sites/default/devices", devices)
+
+        # One unreachable device must not sink the whole graph.
+        assert "uplink" not in devices[0]
+        assert devices[1]["uplink"] == {"deviceId": "gw_001"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "systemic_error",
+        [AuthenticationError("401"), RateLimitError(retry_after=60)],
+    )
+    async def test_merge_device_uplinks_reraises_systemic_failures(self, systemic_error):
+        """Auth and rate-limit failures affect every lookup, so they surface.
+
+        Args:
+            systemic_error: Controller-wide failure raised by the detail route
+        """
         from src.tools.topology import _merge_device_uplinks
 
         devices = [{"id": "ap_001"}]
 
         client = MagicMock()
         client.logger = MagicMock()
-        client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        client.get = AsyncMock(side_effect=systemic_error)
+
+        with pytest.raises(type(systemic_error)):
+            await _merge_device_uplinks(client, "/integration/v1/sites/default/devices", devices)
+
+    @pytest.mark.asyncio
+    async def test_merge_device_uplinks_bounds_concurrency(self):
+        """Detail lookups are capped rather than fanned out one per device."""
+        from src.tools import topology
+        from src.tools.topology import _merge_device_uplinks
+
+        devices = [{"id": f"ap_{index:03d}"} for index in range(50)]
+        in_flight = 0
+        peak = 0
+
+        async def get(endpoint):
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0)
+            in_flight -= 1
+            return {"data": {"uplink": {"deviceId": "gw_001"}}}
+
+        client = MagicMock()
+        client.logger = MagicMock()
+        client.get = AsyncMock(side_effect=get)
 
         await _merge_device_uplinks(client, "/integration/v1/sites/default/devices", devices)
 
-        # One unreachable device must not sink the whole graph.
-        assert "uplink" not in devices[0]
+        assert peak <= topology._UPLINK_DETAIL_CONCURRENCY
+        assert all(device["uplink"] == {"deviceId": "gw_001"} for device in devices)
 
     @pytest.mark.asyncio
     async def test_merge_device_uplinks_skips_already_populated(self):
+        """A device that already carries an uplink is not re-fetched."""
         from src.tools.topology import _merge_device_uplinks
 
         devices = [{"id": "ap_001", "uplink": {"deviceId": "switch_001"}}]

--- a/tests/unit/tools/test_topology_tools.py
+++ b/tests/unit/tools/test_topology_tools.py
@@ -465,3 +465,95 @@ class TestGetTopologyStatistics:
             assert result["total_devices"] == 0
             assert result["total_clients"] == 0
             assert result["max_depth"] == 0
+
+
+class TestDeviceUplinkResolution:
+    """The device list endpoint omits `uplink`; it comes from the detail route."""
+
+    def test_depth_is_independent_of_device_order(self):
+        from src.tools.topology import _resolve_depth
+
+        # Deliberately leaf-first: a single forward pass would score these 0.
+        uplinks = {"ap": "switch", "switch": "gateway"}
+        cache: dict[str, int] = {}
+
+        assert _resolve_depth("ap", uplinks, cache) == 2
+        assert _resolve_depth("switch", uplinks, cache) == 1
+        assert _resolve_depth("gateway", uplinks, cache) == 0
+
+    def test_depth_survives_an_uplink_cycle(self):
+        from src.tools.topology import _resolve_depth
+
+        uplinks = {"a": "b", "b": "a"}
+        cache: dict[str, int] = {}
+
+        # Must terminate rather than spin; the exact depth is unimportant.
+        assert _resolve_depth("a", uplinks, cache) >= 0
+
+    @pytest.mark.asyncio
+    async def test_merge_device_uplinks_fills_from_detail_route(self):
+        from src.tools.topology import _merge_device_uplinks
+
+        devices = [{"id": "ap_001"}, {"id": "switch_001"}]
+        details = {
+            "ap_001": {"data": {"id": "ap_001", "uplink": {"deviceId": "switch_001"}}},
+            "switch_001": {"data": {"id": "switch_001", "uplink": {"deviceId": "gw_001"}}},
+        }
+
+        client = MagicMock()
+        client.logger = MagicMock()
+        client.get = AsyncMock(side_effect=lambda ep: details[ep.rsplit("/", 1)[1]])
+
+        await _merge_device_uplinks(client, "/integration/v1/sites/default/devices", devices)
+
+        assert devices[0]["uplink"] == {"deviceId": "switch_001"}
+        assert devices[1]["uplink"] == {"deviceId": "gw_001"}
+
+    @pytest.mark.asyncio
+    async def test_merge_device_uplinks_tolerates_detail_failure(self):
+        from src.tools.topology import _merge_device_uplinks
+
+        devices = [{"id": "ap_001"}]
+
+        client = MagicMock()
+        client.logger = MagicMock()
+        client.get = AsyncMock(side_effect=RuntimeError("boom"))
+
+        await _merge_device_uplinks(client, "/integration/v1/sites/default/devices", devices)
+
+        # One unreachable device must not sink the whole graph.
+        assert "uplink" not in devices[0]
+
+    @pytest.mark.asyncio
+    async def test_merge_device_uplinks_skips_already_populated(self):
+        from src.tools.topology import _merge_device_uplinks
+
+        devices = [{"id": "ap_001", "uplink": {"deviceId": "switch_001"}}]
+
+        client = MagicMock()
+        client.logger = MagicMock()
+        client.get = AsyncMock()
+
+        await _merge_device_uplinks(client, "/integration/v1/sites/default/devices", devices)
+
+        client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_online_state_is_recognised(self, mock_settings, sample_client_data):
+        """The Integration API reports ONLINE, not CONNECTED."""
+        from src.tools.topology import get_network_topology
+
+        devices = [{"id": "gw_001", "name": "UDM Pro", "state": "ONLINE"}]
+
+        with patch("src.tools.topology.UniFiClient") as mock_client:
+            mock_instance = mock_client.return_value.__aenter__.return_value
+            mock_instance.is_authenticated = True
+            mock_instance.resolve_site_id = AsyncMock(return_value="default")
+            mock_instance.settings = mock_settings
+            mock_instance.logger = MagicMock()
+            mock_instance.get = AsyncMock(side_effect=[devices, [], {"data": devices[0]}])
+
+            result = await get_network_topology("default", mock_settings)
+
+        device_nodes = [n for n in result["nodes"] if n["node_type"] == "device"]
+        assert device_nodes[0]["state"] == 1


### PR DESCRIPTION
Closes #102.

`get_network_topology` returned a graph with no device-to-device edges at all —
every device at depth 0, every device reported offline, and the only connections
present were client links. Three independent causes, all in the same pass.

## 1. Uplinks read from a field the list endpoint does not return

The code reads `device["uplink"]["deviceId"]`. That is exactly the shape of the
*detail* route:

```console
$ curl -sk -H "X-API-KEY: $KEY" ".../integration/v1/sites/<SITE>/devices/<ID>" | jq -c '{name,state,uplink}'
{"name":"<ap>","state":"ONLINE","uplink":{"deviceId":"610480c7-..."}}
```

The *list* route the topology is built from omits `uplink` entirely:

```console
$ curl -sk -H "X-API-KEY: $KEY" ".../integration/v1/sites/<SITE>/devices?limit=3" | jq -r '.data[] | {name, uplink, keys: (keys)}'
{"name":"<ap>","uplink":null,
 "keys":["features","firmwareUpdatable","firmwareVersion","id","interfaces",
         "ipAddress","macAddress","model","name","state","supported"]}
```

So `uplink_device_id` was always `None` and the `if uplink_device_id:` branch
that builds uplink connections never ran.

Details are now fetched concurrently via `asyncio.gather` and merged in.
Devices that already carry an `uplink` are not re-fetched — which keeps the
existing fixtures and any richer payload working — and a device whose detail
lookup fails keeps no uplink rather than sinking the whole graph.

This does add one request per device. Happy to switch to the legacy
`stat/device` endpoint (single request, also carries uplink) if you would rather
not fan out, but that mixes API modes, so I kept this PR inside Integration v1.

## 2. Online state compared against the wrong literal

The Integration API reports `"ONLINE"`. The comparison was against
`"CONNECTED"`, so `state` was `0` for every device and every uplink status was
`"down"` even on a fully healthy site. On the test controller all 17 devices
report `"ONLINE"`:

```console
$ ... | jq -r '[.data[].state] | group_by(.) | map({v: .[0], n: length})'
[{"v": "ONLINE", "n": 17}]
```

Both spellings are accepted now, so legacy payloads keep working.

## 3. Depth was order-dependent

Depth came from `depth_map.get(uplink_device_id, 0) + 1` in a single forward
pass, which is only correct when parents happen to precede children in the API
response. It is now resolved by walking the uplink chain, memoized, with cycle
protection.

## Verification

Against a UDM Pro SE (firmware 5.1.26.33914 — 17 devices: 1 gateway, 5 switches,
11 APs; 123 clients):

| | before | after |
|---|---|---|
| `max_depth` | 0 | 3 |
| uplink connections | 0 | 16 |
| devices with `state: 1` | 0 | 17 |

Depth distribution after the fix is `{0: 1, 1: 5, 2: 5, 3: 6}` — one gateway
root, then switches and APs — which matches the physical layout. 16 uplinks for
17 devices is correct: the gateway is the root and has none.

Six unit tests added covering depth resolution with leaf-first ordering, cycle
termination, uplink merging from the detail route, tolerance of a failed detail
lookup, skipping already-populated uplinks, and `ONLINE` mapping to state 1.

```console
$ uv run pytest tests/unit -q
1416 passed, 40 warnings in 5.63s

$ uvx ruff check src/tools/topology.py tests/unit/tools/test_topology_tools.py
All checks passed!

$ uvx ruff format --check src/tools/topology.py tests/unit/tools/test_topology_tools.py
2 files already formatted
```