### PR TITLE
fix(devices): parse Integration v1 device responses with IntegrationDevice

### DIFF
--- a/API.md
+++ b/API.md
@@ -537,17 +537,26 @@ Get detailed information for a specific device.
 **Parameters:**
 
 - `site_id` (string, required): Site identifier
-- `device_id` (string, required): Device ID
+- `device_id` (string, required): Device integration-API UUID (the IDs returned
+  by `get_network_topology`). A legacy `_id` ObjectId is also accepted.
 
 **Returns:**
-Object containing detailed device information.
+Object containing detailed device information, in the Integration v1 shape.
+
+This tool reads the Integration v1 device route, which reports a different
+shape from the legacy `/ea/` endpoints behind `search_devices` and
+`list_devices_by_type`: `mac_address` rather than `mac`, `ip_address` rather
+than `ip`, a string `state` (`"ONLINE"`) rather than the legacy integer, and no
+`type` field at all. Keys the controller does not report are omitted rather
+than returned as `null`, so look keys up defensively — an absent key means "not
+reported", never "empty" or "false".
 
 **Example:**
 
 ```python
 result = await mcp.call_tool("get_device_details", {
     "site_id": "default",
-    "device_id": "507f1f77bcf86cd799439011"
+    "device_id": "b12257d4-d910-3b09-bcf9-e842229ac697"
 })
 ```
 
@@ -555,15 +564,20 @@ result = await mcp.call_tool("get_device_details", {
 
 ```json
 {
-  "id": "507f1f77bcf86cd799439011",
+  "id": "b12257d4-d910-3b09-bcf9-e842229ac697",
   "name": "Living Room AP",
-  "model": "U6-LR",
-  "type": "uap",
-  "mac": "aa:bb:cc:dd:ee:ff",
-  "ip": "192.168.2.100",
-  "state": 1,
-  "uptime": 86400,
-  "version": "6.5.55.14277"
+  "model": "U7-Pro-Wall",
+  "mac_address": "aa:bb:cc:dd:ee:ff",
+  "ip_address": "192.168.2.100",
+  "state": "ONLINE",
+  "supported": true,
+  "firmware_version": "8.6.11.18870",
+  "firmware_updatable": false,
+  "features": {"accessPoint": {}},
+  "interfaces": {
+    "ports": [],
+    "radios": [{"frequencyGHz": 5, "channelWidthMHz": 320, "channel": 53}]
+  }
 }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`get_device_details` on Integration v1 (issue #108)**: the tool reads the Integration v1 device route but parsed the response with the legacy `Device` model, which requires `type` and `mac` and types `state` as an integer. The Integration v1 API sends `macAddress`, no `type` at all, and a string `state` (`"ONLINE"`), so every call raised `ValidationError` for every device in local API mode. Now parsed with `IntegrationDevice`, the model that matches the endpoint.
+- **`IntegrationDevice.features` / `.interfaces`**: both were typed `list[str]` but the controller returns objects (`features.accessPoint`, `interfaces.ports[...]`, `interfaces.radios[...]`). This also broke `list_integration_devices` and `get_integration_device` against real hardware.
+
+### Changed
+
+- **`get_device_details` output shape**: now the Integration v1 shape — `mac_address`/`ip_address` rather than `mac`/`ip`, a string `state`, no `type` — and dumped with `exclude_none=True` so unreported keys are omitted rather than emitted as `null`. Documented in `API.md`. The legacy `/ea/` shape is unchanged for `search_devices` and `list_devices_by_type`.
+
 ## [0.4.0] - 2026-07-19
 
 ### Added

--- a/src/models/integration_api.py
+++ b/src/models/integration_api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 
 class PaginatedResponse(BaseModel):
@@ -33,7 +33,11 @@ class IntegrationDevice(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
-    id: str = Field(..., description="Device UUID")
+    id: str = Field(
+        ...,
+        validation_alias=AliasChoices("id", "_id"),
+        description="Device UUID (accepts the legacy ``_id`` key as well)",
+    )
     mac_address: str | None = Field(None, alias="macAddress", description="Device MAC address")
     ip_address: str | None = Field(None, alias="ipAddress", description="Device IP address")
     name: str | None = Field(None, description="Device name")
@@ -42,8 +46,11 @@ class IntegrationDevice(BaseModel):
     supported: bool | None = Field(None, description="Whether the device is supported")
     firmware_version: str | None = Field(None, alias="firmwareVersion", description="Current firmware version")
     firmware_updatable: bool | None = Field(None, alias="firmwareUpdatable", description="Whether firmware can be updated")
-    features: list[str] | None = Field(None, description="Supported feature tags")
-    interfaces: list[str] | None = Field(None, description="Available interface types")
+    # ``features`` and ``interfaces`` are objects, not lists: the controller
+    # sends ``features.switching`` / ``features.accessPoint`` and
+    # ``interfaces.ports[...]`` / ``interfaces.radios[...]``.
+    features: dict[str, Any] | None = Field(None, description="Per-capability feature details")
+    interfaces: dict[str, Any] | None = Field(None, description="Ports and radios reported by the device")
 
 
 class IntegrationClient(BaseModel):

--- a/src/tools/devices.py
+++ b/src/tools/devices.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from ..api import UniFiClient
 from ..config import Settings
-from ..models import Device
+from ..models import Device, IntegrationDevice
 from ..utils import (
     APIError,
     ResourceNotFoundError,
@@ -25,6 +25,12 @@ async def get_device_details(site_id: str, device_id: str, settings: Settings) -
     ``get_network_topology`` and other integration tools. Also accepts the
     legacy internal-stats MongoDB ObjectId (``_id``) as a fallback, so callers
     that already store the legacy ID continue to work.
+
+    The response is parsed with ``IntegrationDevice`` rather than the legacy
+    ``Device`` model, because the two endpoints report different shapes: the
+    integration API sends ``macAddress`` (not ``mac``), a string ``state``
+    (``"ONLINE"``, not ``1``) and no ``type`` field at all. Fields the
+    controller does not report are omitted rather than returned as ``null``.
 
     Args:
         site_id: Site identifier
@@ -58,7 +64,9 @@ async def get_device_details(site_id: str, device_id: str, settings: Settings) -
                 # through to the list scan below.
                 if isinstance(device_data, dict) and device_data:
                     logger.info(sanitize_log_message(f"Retrieved device details for {device_id}"))
-                    return Device(**device_data).model_dump()
+                    return IntegrationDevice.model_validate(device_data).model_dump(
+                        exclude_none=True
+                    )
         except (ResourceNotFoundError, APIError) as e:
             # Direct lookup is a best-effort fast path. A 404 / missing-resource
             # response just means we should fall through to the paginated list
@@ -84,7 +92,9 @@ async def get_device_details(site_id: str, device_id: str, settings: Settings) -
             for device_data in devices_data:
                 if device_data.get("id") == device_id or device_data.get("_id") == device_id:
                     logger.info(sanitize_log_message(f"Retrieved device details for {device_id}"))
-                    return Device(**device_data).model_dump()
+                    return IntegrationDevice.model_validate(device_data).model_dump(
+                        exclude_none=True
+                    )
             if len(devices_data) < 100:
                 break
             offset += len(devices_data)

--- a/tests/unit/tools/test_devices_tools.py
+++ b/tests/unit/tools/test_devices_tools.py
@@ -41,6 +41,43 @@ DEVICE_ID_1 = "507f1f77bcf86cd799439011"
 DEVICE_ID_2 = "507f1f77bcf86cd799439022"
 DEVICE_ID_3 = "507f1f77bcf86cd799439033"
 
+# The integration API keys devices by UUID, not by the legacy ObjectId above.
+DEVICE_UUID_1 = "b12257d4-d910-3b09-bcf9-e842229ac697"
+DEVICE_UUID_2 = "c33f1a92-7e41-4a0d-9a55-1de6f0b2c841"
+
+
+def make_integration_device(device_id=DEVICE_UUID_1, name="Test Device"):
+    """Build a device exactly as ``/integration/v1/sites/{site}/devices`` returns it.
+
+    Note the differences from the legacy ``/ea/`` shape in ``make_device``:
+    ``macAddress`` instead of ``mac``, a string ``state``, no ``type`` key, and
+    ``features`` / ``interfaces`` as objects rather than lists of strings.
+
+    Args:
+        device_id: Integration-API UUID to report as ``id``
+        name: Device display name
+
+    Returns:
+        A device record in the integration API's shape
+    """
+    return {
+        "id": device_id,
+        "name": name,
+        "model": "U7-Pro-Wall",
+        "macAddress": "1c:6a:1b:5b:c7:85",
+        "ipAddress": "192.168.1.185",
+        "state": "ONLINE",
+        "supported": True,
+        "firmwareVersion": "8.6.11.18870",
+        "firmwareUpdatable": False,
+        "adoptedAt": "2025-10-04T10:00:00Z",
+        "features": {"accessPoint": {}},
+        "interfaces": {
+            "ports": [],
+            "radios": [{"frequencyGHz": 5, "channelWidthMHz": 320, "channel": 53}],
+        },
+    }
+
 
 def make_device(
     device_id=DEVICE_ID_1, name="Test Device", device_type="uap", model="U7-Pro", state=1
@@ -66,31 +103,80 @@ def make_device(
 class TestGetDeviceDetails:
     @pytest.mark.asyncio
     async def test_get_device_details_success(self, mock_settings):
-        mock_response = {"data": [make_device(DEVICE_ID_1, "AP-Living")]}
+        mock_response = {"data": [make_integration_device(DEVICE_UUID_1, "AP-Living")]}
 
         with patch("src.tools.devices.UniFiClient") as mock_client_class:
             mock_client_class.return_value = create_mock_client(mock_response)
 
-            result = await get_device_details("site-1", DEVICE_ID_1, mock_settings)
+            result = await get_device_details("site-1", DEVICE_UUID_1, mock_settings)
 
-            assert result["id"] == DEVICE_ID_1
+            assert result["id"] == DEVICE_UUID_1
             assert result["name"] == "AP-Living"
 
     @pytest.mark.asyncio
     async def test_get_device_details_list_response(self, mock_settings):
-        mock_response = [make_device(DEVICE_ID_2, "Switch-Main")]
+        mock_response = [make_integration_device(DEVICE_UUID_2, "Switch-Main")]
 
         with patch("src.tools.devices.UniFiClient") as mock_client_class:
             mock_client_class.return_value = create_mock_client(mock_response)
 
-            result = await get_device_details("site-1", DEVICE_ID_2, mock_settings)
+            result = await get_device_details("site-1", DEVICE_UUID_2, mock_settings)
 
-            assert result["id"] == DEVICE_ID_2
+            assert result["id"] == DEVICE_UUID_2
             assert result["name"] == "Switch-Main"
 
     @pytest.mark.asyncio
+    async def test_get_device_details_parses_real_integration_payload(self, mock_settings):
+        """The integration API shape must validate — see issue #108.
+
+        It reports ``macAddress`` rather than ``mac``, a string ``state`` rather
+        than the legacy integer, no ``type`` at all, and ``features`` /
+        ``interfaces`` as objects rather than lists. Every one of those used to
+        raise because the response was parsed with the legacy ``Device`` model.
+        """
+        device = make_integration_device(DEVICE_UUID_1, "2p ap 2")
+
+        with patch("src.tools.devices.UniFiClient") as mock_client_class:
+            mock_client_class.return_value = create_mock_client(device)
+
+            result = await get_device_details("site-1", DEVICE_UUID_1, mock_settings)
+
+        assert result["mac_address"] == "1c:6a:1b:5b:c7:85"
+        assert result["state"] == "ONLINE"
+        assert result["firmware_version"] == "8.6.11.18870"
+        assert result["interfaces"]["radios"][0]["channel"] == 53
+        assert result["features"] == {"accessPoint": {}}
+        # Unmodelled keys survive via extra="allow" rather than being dropped
+        assert result["adoptedAt"] == "2025-10-04T10:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_get_device_details_omits_unreported_fields(self, mock_settings):
+        """Absent keys are omitted, not returned as null — same rule as #103."""
+        sparse = {"id": DEVICE_UUID_1, "name": "Sparse AP"}
+
+        with patch("src.tools.devices.UniFiClient") as mock_client_class:
+            mock_client_class.return_value = create_mock_client(sparse)
+
+            result = await get_device_details("site-1", DEVICE_UUID_1, mock_settings)
+
+        assert result == {"id": DEVICE_UUID_1, "name": "Sparse AP"}
+
+    @pytest.mark.asyncio
+    async def test_get_device_details_accepts_legacy_id_key(self, mock_settings):
+        """A legacy ``_id`` record still resolves, per the documented fallback."""
+        legacy = {"_id": DEVICE_ID_1, "name": "Legacy AP", "mac": "00:11:22:33:44:55"}
+
+        with patch("src.tools.devices.UniFiClient") as mock_client_class:
+            mock_client_class.return_value = create_mock_client({"data": [legacy]})
+
+            result = await get_device_details("site-1", DEVICE_ID_1, mock_settings)
+
+        assert result["id"] == DEVICE_ID_1
+        assert result["mac"] == "00:11:22:33:44:55"
+
+    @pytest.mark.asyncio
     async def test_get_device_details_not_found(self, mock_settings):
-        mock_response = {"data": [make_device(DEVICE_ID_1)]}
+        mock_response = {"data": [make_integration_device(DEVICE_UUID_1)]}
 
         with patch("src.tools.devices.UniFiClient") as mock_client_class:
             mock_client_class.return_value = create_mock_client(mock_response)

--- a/tests/unit/tools/test_integration_api_tools.py
+++ b/tests/unit/tools/test_integration_api_tools.py
@@ -95,8 +95,8 @@ async def test_list_integration_devices_success(mock_settings, mock_client):
                 "supported": True,
                 "firmwareVersion": "4.4.50",
                 "firmwareUpdatable": False,
-                "features": ["routing"],
-                "interfaces": ["ports"],
+                "features": {"switching": {}},
+                "interfaces": {"ports": [{"idx": 1, "state": "UP"}], "radios": []},
             }
         ],
     }


### PR DESCRIPTION
Part of #108.

## Problem

`get_device_details` reads the Integration v1 device route but parsed the response with the legacy `Device` model. Live against a UDM Pro SE:

```
3 validation errors for Device
type
  Field required [type=missing, ...]
mac
  Field required [type=missing, ...]
state
  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='ONLINE', input_type=str]
```

Integration v1 sends `macAddress` rather than `mac`, no `type` key at all, and a string `state` (`"ONLINE"`). This is not a sparse-response edge case — it fails for **every** device, so the tool is unusable in `UNIFI_API_TYPE=local` mode. `docs/UNIFI_API.md:566` documents the response fields as `id`, `macAddress`, `ipAddress`, `name`, `model`, `supported`, `state`.

The unit tests missed it because they fed legacy `/ea/`-shaped payloads (`_id`, `type`, `mac`, `state: 1`) through the integration endpoint — a shape the controller never returns from that route.

## Why not relax `Device`

`Device` is still correct for the legacy `/ea/` endpoints behind `search_devices`, `list_devices_by_type` and `get_device_statistics`, which really do send `mac`, `type` and an integer `state`. Relaxing it would weaken those paths to fix an unrelated one.

The repo already has the right model — `IntegrationDevice` in `src/models/integration_api.py`, used by `list_integration_devices`. `get_device_details` now uses it too.

## Second bug found on the way

`IntegrationDevice` itself was wrong: `features` and `interfaces` were typed `list[str]`, but the controller sends objects — `features.accessPoint`, `interfaces.ports[...]`, `interfaces.radios[...]` (`docs/UNIFI_API.md:570`). Against a real payload:

```
2 validation errors for IntegrationDevice
features    Input should be a valid list
interfaces  Input should be a valid list
```

So `list_integration_devices` and `get_integration_device` were broken against real hardware for the same underlying reason. Both are now `dict[str, Any] | None`. The existing test asserted `features: ["routing"]` / `interfaces: ["ports"]`, a shape that came from nowhere real; it now uses the documented one.

`id` also gained `_id` as a validation alias, so the legacy-ObjectId fallback documented in the `get_device_details` docstring keeps working and legacy keys survive through `extra="allow"`.

## Output contract

`get_device_details` now returns the Integration v1 shape: `mac_address`/`ip_address` rather than `mac`/`ip`, a string `state`, no `type`. It is dumped with `exclude_none=True`, so keys the controller does not report are omitted rather than emitted as `null` — the same rule #103 set for `list_wan_connections`, and consistent with `src/tools/switching.py` and `src/tools/port_profiles.py`. Documented in `API.md` and `CHANGELOG.md`.

The legacy tools' output is untouched.

## Not in scope

`list_pending_devices` and `adopt_device` also parse Integration v1 payloads with `Device`, but both call endpoints that do not exist (`/devices/pending` returns `400 'pending' is not a valid 'deviceId' value`). A model fix alone changes nothing there, so they stay with the endpoint-path half of #108.

## Tests

```console
$ uv run pytest tests/unit -q
1413 passed, 38 warnings in 5.62s

$ uvx ruff check src/models/integration_api.py src/tools/devices.py tests/unit/tools/test_devices_tools.py tests/unit/tools/test_integration_api_tools.py
All checks passed!
```

New `make_integration_device` fixture plus three cases: a full real-shape payload (asserts `mac_address`, string `state`, nested `interfaces.radios[0].channel`, and that unmodelled keys like `adoptedAt` survive), a sparse `{id, name}` payload (asserts absent keys are omitted, not nulled), and a legacy `_id` record (asserts the ObjectId fallback still resolves).

Note: `uvx ruff format --check src/models/integration_api.py` reports the file as unformatted, but it already was on `main` before this change — the long `Field(...)` lines throughout are pre-existing. I kept the file's existing style rather than reformatting lines this PR does not touch. `ruff check` passes (`E501` is ignored in `pyproject.toml`).

Verified against a UDM Pro SE (firmware 5.1.26.33914, `UNIFI_API_TYPE=local`).
