### PR TITLE
fix(dpi): relax DPIApplication so Integration v1 responses validate

### DIFF
--- a/API.md
+++ b/API.md
@@ -2023,6 +2023,49 @@ result = await mcp.call_tool("list_top_applications", {
 ]
 ```
 
+#### `list_dpi_categories`
+
+List the DPI categories the controller recognises.
+
+**Parameters:** none.
+
+**Returns:**
+Array of category objects. Only `id` and `name` are guaranteed, and `id` is a
+number on the Integration v1 route (categories are numbered from zero) while
+the legacy endpoint sends a string. Fields the controller does not report are
+omitted rather than returned as `null`.
+
+**Example:**
+
+```python
+result = await mcp.call_tool("list_dpi_categories", {})
+# [{"id": 0, "name": "Instant messengers"}, {"id": 1, "name": "File transfer"}]
+```
+
+#### `list_dpi_applications`
+
+List the DPI applications the controller recognises.
+
+**Parameters:**
+
+- `limit` (integer, optional): Maximum number of results
+- `offset` (integer, optional): Starting position
+- `filter_expr` (string, optional): Filter expression
+
+**Returns:**
+Array of application objects. Only `id` and `name` are guaranteed — the
+Integration v1 route returns just those two, with a numeric `id` — so
+`category_id`, `category_name`, `enabled`, `protocols` and `ports` may all be
+missing. Absent keys are omitted rather than returned as `null`; an absent key
+means "not reported", never "empty" or "disabled".
+
+**Example:**
+
+```python
+result = await mcp.call_tool("list_dpi_applications", {"limit": 2})
+# [{"id": 3, "name": "ICQ"}, {"id": 7, "name": "Skype"}]
+```
+
 #### `get_client_dpi`
 
 Get DPI statistics for a specific client.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`list_dpi_applications` on Integration v1 (issue #108)**: `GET /integration/v1/dpi/applications` returns only `{"id": 3, "name": "ICQ"}`, but `DPIApplication` required `category_id` and typed `id` as a string, so every response raised `ValidationError` and the tool was unusable in local API mode. `category_id` is now optional, `id` accepts the numeric form the Integration v1 route sends, and `category_id`/`category_name` also accept the API's camelCase spellings.
+
+### Changed
+
+- **`list_dpi_applications` / `list_dpi_categories` output contract**: optional fields now default to `None` instead of `[]`/`True` (`protocols`, `ports`, `enabled`), and both tools dump with `exclude_none=True`, so fields the controller does not report are omitted rather than emitted as `null`. An absent key means "not reported", never "empty" or "disabled". Both tools are now documented in `API.md`.
+
 ## [0.4.0] - 2026-07-19
 
 ### Added

--- a/src/models/dpi.py
+++ b/src/models/dpi.py
@@ -21,19 +21,35 @@ class DPICategory(BaseModel):
 class DPIApplication(BaseModel):
     """DPI application model."""
 
-    id: str = Field(..., alias="_id", description="Application identifier")
+    # Only ``id`` and ``name`` are guaranteed: ``/integration/v1/dpi/applications``
+    # returns just those two, and ``id`` comes back as a number there while the
+    # legacy endpoint sends a string ``_id``. Everything below is optional so a
+    # sparse response validates instead of raising, and every optional field
+    # defaults to ``None`` rather than to a concrete value, so an omitted field
+    # is never reported as an empty list or an enabled flag nobody set.
+    id: int | str = Field(
+        ...,
+        validation_alias=AliasChoices("id", "_id"),
+        description="Application identifier",
+    )
     name: str = Field(..., description="Application name")
-    category_id: str = Field(..., description="Category identifier")
-    category_name: str | None = Field(None, description="Category name")
+    category_id: int | str | None = Field(
+        None,
+        validation_alias=AliasChoices("category_id", "categoryId"),
+        description="Category identifier",
+    )
+    category_name: str | None = Field(
+        None,
+        validation_alias=AliasChoices("category_name", "categoryName"),
+        description="Category name",
+    )
 
     # Application metadata
-    enabled: bool = Field(True, description="Whether application detection is enabled")
+    enabled: bool | None = Field(None, description="Whether application detection is enabled")
 
     # Traffic classification
-    protocols: list[str] = Field(
-        default_factory=list, description="Protocols used by this application"
-    )
-    ports: list[int] = Field(default_factory=list, description="Common ports used")
+    protocols: list[str] | None = Field(None, description="Protocols used by this application")
+    ports: list[int] | None = Field(None, description="Common ports used")
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 

--- a/src/tools/dpi_tools.py
+++ b/src/tools/dpi_tools.py
@@ -17,7 +17,9 @@ async def list_dpi_categories(settings: Settings) -> list[dict]:
         settings: Application settings
 
     Returns:
-        List of DPI categories
+        List of DPI categories. Fields the controller does not report are
+        omitted rather than returned as ``null`` — the Integration v1 route
+        supplies little more than ``id`` and ``name``.
     """
     async with UniFiClient(settings) as client:
         logger.info("Listing DPI categories")
@@ -28,7 +30,7 @@ async def list_dpi_categories(settings: Settings) -> list[dict]:
         response = await client.get("/integration/v1/dpi/categories")
         data = response if isinstance(response, list) else response.get("data", [])
 
-        return [DPICategory(**category).model_dump() for category in data]
+        return [DPICategory(**category).model_dump(exclude_none=True) for category in data]
 
 
 async def list_dpi_applications(
@@ -46,7 +48,10 @@ async def list_dpi_applications(
         filter_expr: Filter expression
 
     Returns:
-        List of DPI applications
+        List of DPI applications. Fields the controller does not report are
+        omitted rather than returned as ``null``: the Integration v1 route
+        supplies only ``id`` and ``name``, so keeping the nulls would bury
+        those two under five empty keys.
     """
     async with UniFiClient(settings) as client:
         logger.info("Listing DPI applications")
@@ -65,7 +70,7 @@ async def list_dpi_applications(
         response = await client.get("/integration/v1/dpi/applications", params=params)
         data = response if isinstance(response, list) else response.get("data", [])
 
-        return [DPIApplication(**app).model_dump() for app in data]
+        return [DPIApplication(**app).model_dump(exclude_none=True) for app in data]
 
 
 async def list_countries(settings: Settings) -> list[dict]:

--- a/tests/unit/tools/test_dpi_tools.py
+++ b/tests/unit/tools/test_dpi_tools.py
@@ -460,6 +460,105 @@ async def test_list_dpi_applications_empty(mock_settings):
     assert result == []
 
 
+@pytest.mark.asyncio
+async def test_list_dpi_applications_accepts_sparse_integration_response(mock_settings):
+    """Integration v1 returns only a numeric id and a name; that must not raise.
+
+    See issue #108: ``/integration/v1/dpi/applications`` sends exactly
+    ``{"id": 3, "name": "ICQ"}``, so requiring ``category_id`` and typing ``id``
+    as a string made the tool unusable on the local API.
+    """
+    mock_response = {"data": [{"id": 3, "name": "ICQ"}, {"id": 7, "name": "Skype"}]}
+
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.is_authenticated = True
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(dpi_tools_module, "UniFiClient", return_value=mock_client):
+        result = await list_dpi_applications(mock_settings)
+
+    # Absent fields are dropped rather than failing validation or padding the
+    # record with five nulls. Nothing carries a concrete default either, so an
+    # application the controller never described is not reported as enabled.
+    assert result == [{"id": 3, "name": "ICQ"}, {"id": 7, "name": "Skype"}]
+
+
+@pytest.mark.asyncio
+async def test_list_dpi_applications_preserves_populated_fields(mock_settings):
+    """Relaxing the model must not drop values when they are present."""
+    mock_response = {
+        "data": [
+            {
+                "_id": "app1",
+                "name": "YouTube",
+                "category_id": "cat1",
+                "category_name": "Streaming",
+                "enabled": False,
+                "protocols": ["tcp", "udp"],
+                "ports": [80, 443],
+            }
+        ]
+    }
+
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.is_authenticated = True
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(dpi_tools_module, "UniFiClient", return_value=mock_client):
+        result = await list_dpi_applications(mock_settings)
+
+    assert result[0]["id"] == "app1"
+    assert result[0]["category_id"] == "cat1"
+    assert result[0]["category_name"] == "Streaming"
+    assert result[0]["protocols"] == ["tcp", "udp"]
+    assert result[0]["ports"] == [80, 443]
+    # enabled=False survives the exclude_none filter; it is a reported value,
+    # not an absent one.
+    assert result[0]["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_dpi_applications_accepts_camel_case_category(mock_settings):
+    """The integration API spells the category key ``categoryId``."""
+    mock_response = {"data": [{"id": 3, "name": "ICQ", "categoryId": 1}]}
+
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.is_authenticated = True
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(dpi_tools_module, "UniFiClient", return_value=mock_client):
+        result = await list_dpi_applications(mock_settings)
+
+    assert result[0]["category_id"] == 1
+
+
+@pytest.mark.asyncio
+async def test_list_dpi_categories_accepts_numeric_id(mock_settings):
+    """``/integration/v1/dpi/categories`` numbers its categories from zero."""
+    mock_response = {"data": [{"id": 0, "name": "Instant messengers"}]}
+
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.is_authenticated = True
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(dpi_tools_module, "UniFiClient", return_value=mock_client):
+        result = await list_dpi_categories(mock_settings)
+
+    assert result == [{"id": 0, "name": "Instant messengers"}]
+
+
 # =============================================================================
 # list_countries Tests
 # =============================================================================


### PR DESCRIPTION
Part of #108.

## Problem

`GET /integration/v1/dpi/applications` returns exactly two fields per application — the same sparse shape as `/wans` in #100:

```json
{"id": 3, "name": "ICQ"}
```

`DPIApplication` required `category_id` and typed `id` as `str`, so every response raised:

```
2 validation errors for DPIApplication
id
  Input should be a valid string [type=string_type, input_value=3, input_type=int]
category_id
  Field required [type=missing, input_value={'id': 3, 'name': 'ICQ'}, input_type=dict]
```

The HTTP call succeeds with `200`; only parsing fails, so `list_dpi_applications` fetched the data and threw it away. Unusable in `UNIFI_API_TYPE=local` mode.

## Changes

- `id` is `int | str` with `AliasChoices("id", "_id")`, so the numeric Integration v1 form and the legacy string `_id` both work. This mirrors what `DPICategory` in the same file already does.
- `category_id` is optional and accepts `categoryId`; `category_name` accepts `categoryName`. The Integration v1 surface is camelCase, and neither key was reachable before.
- `enabled`, `protocols` and `ports` default to `None` rather than to `True`/`[]`. Reporting an application the controller never described as *enabled with no protocols and no ports* is a stronger claim than the controller made.
- `list_dpi_applications` and `list_dpi_categories` dump with `model_dump(exclude_none=True)`, so absent keys are omitted rather than emitted as `null`. Without it a sparse application record is two real keys buried under five nulls.

`id` and `name` stay required — both are always present. The model already sets `extra="allow"`, so richer payloads from other sources are unaffected.

`list_dpi_categories` gets the `exclude_none` treatment too, purely so the two DPI list tools agree on one output rule; its model was already fixed for the numeric `id` on `main`, and a regression test now pins that.

## Output contract

Absent keys are omitted rather than returned as `null`. An absent key means "not reported", never "empty" or "disabled". This is the rule #103 set for `list_wan_connections`, and it matches `src/tools/switching.py` and `src/tools/port_profiles.py`.

Neither DPI list tool was documented in `API.md` at all, so this PR adds entries for both, stating the guarantee.

## Tests

Four cases added:

- `test_list_dpi_applications_accepts_sparse_integration_response` — the real `{"id": 3, "name": "ICQ"}` shape validates and dumps to exactly those two keys
- `test_list_dpi_applications_preserves_populated_fields` — a fully populated payload round-trips every value, including `enabled=False`, which must survive the `exclude_none` filter because it is a reported value rather than an absent one
- `test_list_dpi_applications_accepts_camel_case_category` — `categoryId` populates `category_id`
- `test_list_dpi_categories_accepts_numeric_id` — pins the numeric-`id` behaviour that `main` already has

```console
$ uv run pytest tests/unit -q
1414 passed, 39 warnings in 5.56s

$ uvx ruff check src/models/dpi.py src/tools/dpi_tools.py tests/unit/tools/test_dpi_tools.py
All checks passed!

$ uvx ruff format --check src/models/dpi.py src/tools/dpi_tools.py tests/unit/tools/test_dpi_tools.py
3 files already formatted
```

Verified against a UDM Pro SE (firmware 5.1.26.33914, `UNIFI_API_TYPE=local`).
