### PR TITLE
test(a2a): cover the A2A package and fix two bugs it surfaced

### DIFF
--- a/src/a2a/audit.py
+++ b/src/a2a/audit.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict, dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from threading import RLock
 from typing import Any
@@ -134,7 +134,7 @@ class AuditLogger:
         if value is None:
             return None
         if isinstance(value, datetime):
-            return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+            return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 

--- a/src/a2a/auth.py
+++ b/src/a2a/auth.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from ..config import APIType
@@ -27,7 +27,7 @@ class AuthContext:
 
     def is_expired(self) -> bool:
         """Return True when the authentication context has expired."""
-        return self.expiry is not None and datetime.now(tz=UTC) >= self.expiry
+        return self.expiry is not None and datetime.now(tz=timezone.utc) >= self.expiry
 
 
 class LocalAuthProvider:
@@ -70,7 +70,7 @@ class LocalAuthProvider:
 
     def _expiry_from_credentials(self, credentials: Mapping[str, Any]) -> datetime:
         expires_in = int(credentials.get("expires_in") or self.default_ttl_seconds)
-        return datetime.now(tz=UTC) + timedelta(seconds=max(1, expires_in))
+        return datetime.now(tz=timezone.utc) + timedelta(seconds=max(1, expires_in))
 
 
 class CloudAuthProvider:
@@ -118,7 +118,7 @@ class CloudAuthProvider:
 
     def _expiry_from_credentials(self, credentials: Mapping[str, Any]) -> datetime:
         expires_in = int(credentials.get("expires_in") or self.default_ttl_seconds)
-        return datetime.now(tz=UTC) + timedelta(seconds=max(1, expires_in))
+        return datetime.now(tz=timezone.utc) + timedelta(seconds=max(1, expires_in))
 
 
 class AuthManager:

--- a/src/a2a/delegation.py
+++ b/src/a2a/delegation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from fastmcp import FastMCP
@@ -17,7 +17,7 @@ from .types import AuthenticationMode, DelegationContract
 
 def _now_iso() -> str:
     """Return a UTC timestamp in ISO-8601 format."""
-    return datetime.now(UTC).isoformat()
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _run_sync(coro: Any) -> Any:

--- a/src/a2a/http_handlers.py
+++ b/src/a2a/http_handlers.py
@@ -11,7 +11,7 @@ import importlib.metadata
 import json
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import asdict, dataclass, field
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from ..config import APIType, Settings
@@ -162,7 +162,7 @@ async def delegate_handler(
     params = dict(payload.get("params") or payload.get("arguments") or {})
     auth_payload = dict(payload.get("auth") or payload.get("credentials") or {})
     agent_id = _agent_id_from_payload(payload)
-    started = datetime.now(tz=UTC)
+    started = datetime.now(tz=timezone.utc)
 
     if not tool_name:
         return {"status": "error", "error": "tool_name is required"}
@@ -210,10 +210,10 @@ async def delegate_handler(
         if hasattr(result, "__await__"):
             result = await result  # type: ignore[func-returns-value]
 
-    duration_ms = (datetime.now(tz=UTC) - started).total_seconds() * 1000.0
+    duration_ms = (datetime.now(tz=timezone.utc) - started).total_seconds() * 1000.0
     active_state.audit_logger.log_invocation(
         AuditLog(
-            timestamp=datetime.now(tz=UTC),
+            timestamp=datetime.now(tz=timezone.utc),
             agent_id=agent_id,
             tool_name=tool_name,
             params=params,

--- a/src/a2a/prompt_playbook.py
+++ b/src/a2a/prompt_playbook.py
@@ -94,6 +94,19 @@ class PlaybookRegistry:
 DEFAULT_PLAYBOOK_REGISTRY = PlaybookRegistry.load_builtin()
 
 
+def _default_registry() -> PlaybookRegistry:
+    """Return the bundled registry, populating it on first use if it is empty.
+
+    ``src.a2a.playbooks`` imports this module, so importing that package first
+    builds the registry above while the package is still initializing and
+    ``PLAYBOOKS`` does not exist yet, leaving it empty.
+    """
+    if not DEFAULT_PLAYBOOK_REGISTRY.names():
+        for _, playbook in PlaybookRegistry.load_builtin().items():
+            DEFAULT_PLAYBOOK_REGISTRY.register(playbook)
+    return DEFAULT_PLAYBOOK_REGISTRY
+
+
 def _format_params(params: Mapping[str, Any] | None) -> str:
     if not params:
         return "{}"
@@ -115,7 +128,7 @@ def render_playbook(
     Returns:
         A prompt-ready string with steps, validation criteria, and fallbacks.
     """
-    active_registry = registry or DEFAULT_PLAYBOOK_REGISTRY
+    active_registry = registry or _default_registry()
     playbook = active_registry.get(playbook_name)
     context_data = dict(context or {})
 

--- a/src/a2a/route_policy.py
+++ b/src/a2a/route_policy.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections import defaultdict, deque
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from hashlib import sha256
 from secrets import compare_digest, token_urlsafe
 from threading import RLock
@@ -235,7 +235,7 @@ class SafetyController:
         policy = self._find_policy(tool_name)
         key = (agent_id, self._normalize_tool_name(tool_name))
         period_seconds = self.settings.rate_limit_period if self.settings else 60
-        now = datetime.now(tz=UTC).timestamp()
+        now = datetime.now(tz=timezone.utc).timestamp()
         window_start = now - period_seconds
 
         with self._lock:
@@ -328,7 +328,7 @@ class ConfirmationWorkflow:
         self, tool_name: str, params: Mapping[str, Any], reason: str
     ) -> ConfirmationToken:
         """Create a confirmation token for a pending action."""
-        now = datetime.now(tz=UTC)
+        now = datetime.now(tz=timezone.utc)
         token = ConfirmationToken(
             token=token_urlsafe(32),
             tool_name=tool_name,
@@ -348,7 +348,7 @@ class ConfirmationWorkflow:
             stored = self._tokens.get(token_value)
             if stored is None:
                 return False
-            if datetime.now(tz=UTC) >= stored.expires_at:
+            if datetime.now(tz=timezone.utc) >= stored.expires_at:
                 self._tokens.pop(token_value, None)
                 return False
 

--- a/tests/unit/a2a/__init__.py
+++ b/tests/unit/a2a/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the A2A package."""

--- a/tests/unit/a2a/conftest.py
+++ b/tests/unit/a2a/conftest.py
@@ -1,0 +1,63 @@
+"""Shared fixtures for A2A unit tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastmcp.resources.function_resource import FunctionResource
+from fastmcp.tools.function_tool import FunctionTool
+
+from src.config.config import Settings
+
+
+class FakeProvider:
+    """Stand-in for a FastMCP provider exposing a ``_components`` mapping."""
+
+    def __init__(self, components: dict[str, Any]) -> None:
+        self._components = components
+
+
+class FakeMCP:
+    """Minimal FastMCP stand-in exposing the attributes the A2A layer reads."""
+
+    def __init__(self, components: dict[str, Any] | None = None, name: str = "Fake UniFi") -> None:
+        self.providers = [FakeProvider(components or {})]
+        self._mcp_server = type("Server", (), {"name": name})()
+
+
+def make_tool(fn: Any, **kwargs: Any) -> FunctionTool:
+    """Build a real ``FunctionTool`` so ``isinstance`` checks in src/ still hold."""
+    return FunctionTool.from_function(fn, **kwargs)
+
+
+def make_resource(fn: Any, uri: str, **kwargs: Any) -> FunctionResource:
+    """Build a real ``FunctionResource`` for resource-discovery assertions."""
+    return FunctionResource.from_function(fn, uri=uri, **kwargs)
+
+
+def delete_site_device(site_id: str, confirm: bool = False) -> dict[str, Any]:
+    """Delete a device from the site."""
+    return {"ok": True}
+
+
+def list_site_clients(site_id: str) -> dict[str, Any]:
+    """List clients for a site."""
+    return {"clients": []}
+
+
+@pytest.fixture
+def local_settings(monkeypatch: pytest.MonkeyPatch) -> Settings:
+    """Return Settings configured for local controller access."""
+    monkeypatch.setenv("UNIFI_API_KEY", "test-key")
+    monkeypatch.setenv("UNIFI_API_TYPE", "local")
+    monkeypatch.setenv("UNIFI_LOCAL_HOST", "192.0.2.10")
+    return Settings()
+
+
+@pytest.fixture
+def cloud_settings(monkeypatch: pytest.MonkeyPatch) -> Settings:
+    """Return Settings configured for cloud access."""
+    monkeypatch.setenv("UNIFI_API_KEY", "test-key")
+    monkeypatch.setenv("UNIFI_API_TYPE", "cloud-ea")
+    return Settings()

--- a/tests/unit/a2a/test_agent_card.py
+++ b/tests/unit/a2a/test_agent_card.py
@@ -1,0 +1,374 @@
+"""Unit tests for src/a2a/agent_card.py."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.a2a.agent_card import (
+    _authentication_mode,
+    _example_call_payload,
+    _example_value_for_schema,
+    _is_destructive_tool,
+    _iter_registered_components,
+    _output_schema_for_tool,
+    _package_version,
+    _resource_uri,
+    _safety_requirement_for_tool,
+    _schema_for_tool,
+    _sensitive_fields,
+    _tool_description,
+    _tool_skill,
+    build_agent_card,
+)
+from src.a2a.types import AuthenticationMode
+from src.config.config import APIType, Settings
+
+from .conftest import FakeMCP, delete_site_device, list_site_clients, make_resource, make_tool
+
+
+class TestPackageVersion:
+    """Tests for _package_version."""
+
+    def test_returns_version_when_package_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(importlib.metadata, "version", lambda _name: "9.9.9")
+        assert _package_version() == "9.9.9"
+
+    def test_returns_unknown_when_package_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _raise(_name: str) -> str:
+            raise importlib.metadata.PackageNotFoundError(_name)
+
+        monkeypatch.setattr(importlib.metadata, "version", _raise)
+        assert _package_version() == "unknown"
+
+
+class TestIterRegisteredComponents:
+    """Tests for _iter_registered_components."""
+
+    def test_yields_components_from_each_provider(self) -> None:
+        tool = make_tool(list_site_clients)
+        mcp = FakeMCP({"list_site_clients": tool})
+
+        assert list(_iter_registered_components(mcp)) == [("list_site_clients", tool)]
+
+    def test_returns_nothing_when_mcp_has_no_providers(self) -> None:
+        assert list(_iter_registered_components(object())) == []
+
+    def test_skips_providers_whose_components_are_not_a_dict(self) -> None:
+        class BadProvider:
+            _components = ["not", "a", "dict"]
+
+        mcp = type("M", (), {"providers": [BadProvider()]})()
+
+        assert list(_iter_registered_components(mcp)) == []
+
+
+class TestToolDescription:
+    """Tests for _tool_description."""
+
+    def test_prefers_the_explicit_description(self) -> None:
+        tool = make_tool(list_site_clients, description="Explicit description")
+        assert _tool_description(tool) == "Explicit description"
+
+    def test_falls_back_to_the_first_docstring_line(self) -> None:
+        tool = make_tool(list_site_clients)
+        tool.description = None
+
+        assert _tool_description(tool) == "List clients for a site."
+
+    def test_falls_back_to_the_tool_name(self) -> None:
+        def undocumented(site_id: str) -> dict[str, Any]:
+            return {}
+
+        tool = make_tool(undocumented)
+        tool.description = None
+
+        assert _tool_description(tool) == "MCP tool: undocumented"
+
+
+class TestSchemaAccessors:
+    """Tests for _schema_for_tool and _output_schema_for_tool."""
+
+    def test_schema_for_tool_returns_the_parameter_schema(self) -> None:
+        tool = make_tool(list_site_clients)
+        assert _schema_for_tool(tool)["properties"]["site_id"]["type"] == "string"
+
+    def test_schema_for_tool_defaults_when_parameters_missing(self) -> None:
+        tool = make_tool(list_site_clients)
+        tool.parameters = None
+
+        assert _schema_for_tool(tool) == {"type": "object", "properties": {}}
+
+    def test_output_schema_defaults_if_missing(self) -> None:
+        tool = make_tool(list_site_clients)
+        tool.output_schema = None
+
+        assert _output_schema_for_tool(tool) == {"type": "object"}
+
+    def test_output_schema_returned_if_present(self) -> None:
+        tool = make_tool(list_site_clients)
+        tool.output_schema = {"type": "object", "properties": {"clients": {"type": "array"}}}
+
+        assert _output_schema_for_tool(tool)["properties"]["clients"]["type"] == "array"
+
+
+class TestExampleValueForSchema:
+    """Tests for _example_value_for_schema."""
+
+    def test_default_wins_over_type(self) -> None:
+        assert _example_value_for_schema({"type": "integer", "default": 42}, "count") == 42
+
+    @pytest.mark.parametrize(
+        ("schema_type", "expected"),
+        [("integer", 1), ("number", 1.0), ("boolean", True), ("object", {})],
+    )
+    def test_scalar_and_object_types(self, schema_type: str, expected: Any) -> None:
+        assert _example_value_for_schema({"type": schema_type}, "field") == expected
+
+    def test_array_type_wraps_the_item_example(self) -> None:
+        schema = {"type": "array", "items": {"type": "integer"}}
+        assert _example_value_for_schema(schema, "ports") == [1]
+
+    def test_array_with_non_dict_items_falls_back_to_a_string_example(self) -> None:
+        assert _example_value_for_schema({"type": "array", "items": "bogus"}, "tags") == [
+            "example-tags"
+        ]
+
+    def test_identifier_fields_get_example_ids(self) -> None:
+        assert _example_value_for_schema({}, "device_id") == "example-id"
+        assert _example_value_for_schema({}, "clientid") == "example-id"
+
+    def test_site_fields_default_to_the_default_site(self) -> None:
+        assert _example_value_for_schema({}, "site_name") == "default"
+
+    def test_name_like_fields_use_a_named_example(self) -> None:
+        assert _example_value_for_schema({}, "label") == "example-label"
+
+    def test_unrecognized_fields_use_a_generic_example(self) -> None:
+        assert _example_value_for_schema({}, "colour") == "example-colour"
+
+
+class TestExampleCallPayload:
+    """Tests for _example_call_payload."""
+
+    def test_uses_required_fields(self) -> None:
+        payload = _example_call_payload(make_tool(list_site_clients))
+
+        assert payload["tool"] == "list_site_clients"
+        assert payload["arguments"]["site_id"] == "example-id"
+
+    def test_adds_confirm_and_dry_run_when_offered(self) -> None:
+        def risky(site_id: str, confirm: bool = False, dry_run: bool = False) -> dict[str, Any]:
+            """Delete something."""
+            return {}
+
+        payload = _example_call_payload(make_tool(risky))
+
+        assert payload["arguments"]["confirm"] is True
+        assert payload["arguments"]["dry_run"] is True
+
+    def test_falls_back_to_the_first_optional_property(self) -> None:
+        def optional_only(limit: int = 10) -> dict[str, Any]:
+            """Do a thing."""
+            return {}
+
+        payload = _example_call_payload(make_tool(optional_only))
+
+        assert payload["arguments"] == {"limit": 10}
+
+    def test_returns_empty_arguments_for_a_tool_without_parameters(self) -> None:
+        tool = make_tool(list_site_clients)
+        tool.parameters = {"type": "object", "properties": {}}
+
+        assert _example_call_payload(tool)["arguments"] == {}
+
+
+class TestIsDestructiveTool:
+    """Tests for _is_destructive_tool."""
+
+    def test_destructive_name_is_detected(self) -> None:
+        assert _is_destructive_tool(make_tool(delete_site_device)) is True
+
+    def test_a_destructive_description_is_detected(self) -> None:
+        def touch_site(site_id: str) -> dict[str, Any]:
+            """Reboot the controller."""
+            return {}
+
+        assert _is_destructive_tool(make_tool(touch_site)) is True
+
+    def test_confirm_parameter_marks_a_tool_destructive(self) -> None:
+        def ambiguous(site_id: str, confirm: bool = False) -> dict[str, Any]:
+            """Do something unremarkable."""
+            return {}
+
+        assert _is_destructive_tool(make_tool(ambiguous)) is True
+
+    def test_read_only_tool_is_not_destructive(self) -> None:
+        assert _is_destructive_tool(make_tool(list_site_clients)) is False
+
+
+class TestSensitiveFields:
+    """Tests for _sensitive_fields."""
+
+    def test_detects_and_sorts_sensitive_parameter_names(self) -> None:
+        def login(username: str, password: str, api_key: str, site_id: str) -> dict[str, Any]:
+            """Authenticate."""
+            return {}
+
+        assert _sensitive_fields(make_tool(login)) == ["api_key", "password", "username"]
+
+    def test_returns_empty_list_when_nothing_is_sensitive(self) -> None:
+        assert _sensitive_fields(make_tool(list_site_clients)) == []
+
+    def test_returns_empty_list_when_properties_are_not_a_dict(self) -> None:
+        tool = make_tool(list_site_clients)
+        tool.parameters = {"type": "object", "properties": "bogus"}
+
+        assert _sensitive_fields(tool) == []
+
+
+class TestSafetyRequirementForTool:
+    """Tests for _safety_requirement_for_tool."""
+
+    def test_returns_none_for_a_safe_read_only_tool(self) -> None:
+        assert _safety_requirement_for_tool(make_tool(list_site_clients)) is None
+
+    def test_destructive_tool_requires_confirmation(self) -> None:
+        requirement = _safety_requirement_for_tool(make_tool(delete_site_device))
+
+        assert requirement is not None
+        assert requirement.confirmationLevel == "required"
+        assert requirement.destructive is True
+        assert requirement.toolName == "delete_site_device"
+        assert "confirmation" in (requirement.reason or "")
+
+    def test_sensitive_only_tool_is_recommended_not_required(self) -> None:
+        def authenticate(token: str) -> dict[str, Any]:
+            """Exchange a token."""
+            return {}
+
+        requirement = _safety_requirement_for_tool(make_tool(authenticate))
+
+        assert requirement is not None
+        assert requirement.confirmationLevel == "recommended"
+        assert requirement.destructive is False
+        assert requirement.sensitiveFields == ["token"]
+
+
+class TestAuthenticationMode:
+    """Tests for _authentication_mode."""
+
+    @pytest.mark.parametrize("api_type", [APIType.LOCAL, APIType.CLOUD_V1, APIType.CLOUD_EA])
+    def test_every_api_type_supports_both_modes(
+        self, local_settings: Settings, api_type: APIType
+    ) -> None:
+        local_settings.api_type = api_type
+
+        assert _authentication_mode(local_settings) is AuthenticationMode.BOTH
+
+    def test_defaults_to_both_for_an_unrecognized_api_type(self) -> None:
+        settings = SimpleNamespace(api_type="something-new")
+
+        assert _authentication_mode(settings) is AuthenticationMode.BOTH
+
+
+class TestComponentConversion:
+    """Tests for _tool_skill and _resource_uri."""
+
+    def test_tool_skill_carries_schemas_and_an_example(self) -> None:
+        skill = _tool_skill(make_tool(list_site_clients))
+
+        assert skill.name == "list_site_clients"
+        assert skill.description == "List clients for a site."
+        assert skill.inputSchema["properties"]["site_id"]["type"] == "string"
+        assert skill.examples[0]["tool"] == "list_site_clients"
+
+    def test_resource_uri_uses_the_declared_description(self) -> None:
+        resource = make_resource(
+            lambda: "payload", uri="unifi://sites", name="sites", description="All sites"
+        )
+
+        converted = _resource_uri(resource)
+
+        assert converted.uri == "unifi://sites"
+        assert converted.description == "All sites"
+
+    def test_resource_uri_falls_back_to_a_generated_description(self) -> None:
+        resource = make_resource(lambda: "payload", uri="unifi://devices", name="devices")
+
+        converted = _resource_uri(resource)
+
+        assert converted.description == "MCP resource: devices"
+        assert converted.mimeType == "text/plain"
+
+
+class TestBuildAgentCard:
+    """Tests for build_agent_card."""
+
+    def test_builds_skills_resources_and_safety_requirements(
+        self, local_settings: Settings
+    ) -> None:
+        mcp = FakeMCP(
+            {
+                "list_site_clients": make_tool(list_site_clients),
+                "delete_site_device": make_tool(delete_site_device),
+                "sites": make_resource(lambda: "payload", uri="unifi://sites", name="sites"),
+            }
+        )
+
+        card = build_agent_card(mcp, local_settings)
+
+        assert {skill.name for skill in card.skills} == {
+            "list_site_clients",
+            "delete_site_device",
+        }
+        assert [resource.uri for resource in card.resources] == ["unifi://sites"]
+        assert [req.toolName for req in card.safetyRequirements] == ["delete_site_device"]
+        assert card.protocol == "A2A"
+        assert card.integrationExamples
+
+    def test_ignores_components_that_are_neither_tools_nor_resources(
+        self, local_settings: Settings
+    ) -> None:
+        mcp = FakeMCP(
+            {
+                "list_site_clients": make_tool(list_site_clients),
+                "some_prompt": object(),
+            }
+        )
+
+        card = build_agent_card(mcp, local_settings)
+
+        assert [skill.name for skill in card.skills] == ["list_site_clients"]
+        assert card.resources == []
+
+    def test_local_settings_expose_the_local_host(self, local_settings: Settings) -> None:
+        card = build_agent_card(FakeMCP(), local_settings)
+
+        assert card.metadata is not None
+        assert card.metadata["localHost"] == "192.0.2.10"
+        assert "cloudApiUrl" not in card.metadata
+        assert card.metadata["skillCount"] == 0
+        assert card.metadata["apiType"] == APIType.LOCAL.value
+
+    def test_cloud_settings_expose_the_cloud_api_url(self, cloud_settings: Settings) -> None:
+        card = build_agent_card(FakeMCP(), cloud_settings)
+
+        assert card.metadata is not None
+        assert card.metadata["cloudApiUrl"] == cloud_settings.cloud_api_url
+        assert "localHost" not in card.metadata
+
+    def test_server_name_is_read_from_the_mcp_instance(self, local_settings: Settings) -> None:
+        card = build_agent_card(FakeMCP(name="Custom Server"), local_settings)
+
+        assert card.name == "Custom Server"
+
+    def test_falls_back_to_the_default_server_name(self, local_settings: Settings) -> None:
+        card = build_agent_card(object(), local_settings)
+
+        assert card.name == "UniFi MCP Server"
+        assert card.metadata is not None
+        assert card.metadata["toolModules"] == 0

--- a/tests/unit/a2a/test_audit.py
+++ b/tests/unit/a2a/test_audit.py
@@ -1,0 +1,269 @@
+"""Unit tests for src/a2a/audit.py."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.a2a import audit as audit_module
+from src.a2a.audit import AuditLog, AuditLogger, get_audit_logger
+
+
+def make_entry(
+    agent_id: str = "agent-a",
+    tool_name: str = "list_site_clients",
+    minutes: int = 0,
+    **overrides: Any,
+) -> AuditLog:
+    """Build an audit entry offset from a fixed base timestamp."""
+    defaults: dict[str, Any] = {
+        "timestamp": datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(minutes=minutes),
+        "agent_id": agent_id,
+        "tool_name": tool_name,
+        "params": {"site_id": "default"},
+        "result": {"ok": True},
+        "safety_level": "none",
+        "duration_ms": 12.5,
+    }
+    defaults.update(overrides)
+    return AuditLog(**defaults)
+
+
+@pytest.fixture
+def logger(tmp_path: Path) -> AuditLogger:
+    """Return an audit logger writing to an isolated temp file."""
+    return AuditLogger(log_file=tmp_path / "audit" / "trail.jsonl")
+
+
+class TestAuditLoggerInit:
+    """Tests for AuditLogger construction."""
+
+    def test_creates_the_parent_directory_for_the_log_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "nested" / "deeper" / "trail.jsonl"
+
+        AuditLogger(log_file=target)
+
+        assert target.parent.is_dir()
+
+    def test_defaults_to_a_logs_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        instance = AuditLogger()
+
+        assert instance.log_file == Path("logs") / "a2a-audit.jsonl"
+
+    def test_accepts_a_string_path(self, tmp_path: Path) -> None:
+        instance = AuditLogger(log_file=str(tmp_path / "trail.jsonl"))
+
+        assert instance.log_file == tmp_path / "trail.jsonl"
+
+    def test_starts_with_an_empty_trail(self, logger: AuditLogger) -> None:
+        assert logger.get_audit_trail() == []
+
+
+class TestSerialize:
+    """Tests for the AuditLogger._serialize JSON fallback."""
+
+    def test_datetimes_become_iso_strings(self) -> None:
+        moment = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        assert AuditLogger._serialize(moment) == moment.isoformat()
+
+    def test_paths_become_strings(self) -> None:
+        assert AuditLogger._serialize(Path("a") / "b") == str(Path("a") / "b")
+
+    def test_sets_become_sorted_lists(self) -> None:
+        assert AuditLogger._serialize({"b", "a"}) == ["a", "b"]
+
+    def test_objects_with_model_dump_are_unwrapped(self) -> None:
+        class Model:
+            def model_dump(self) -> dict[str, int]:
+                return {"value": 1}
+
+        assert AuditLogger._serialize(Model()) == {"value": 1}
+
+    def test_plain_objects_fall_back_to_their_dict(self) -> None:
+        class Plain:
+            def __init__(self) -> None:
+                self.value = 1
+
+        assert AuditLogger._serialize(Plain()) == {"value": 1}
+
+    def test_classes_are_returned_untouched(self) -> None:
+        class Plain:
+            pass
+
+        assert AuditLogger._serialize(Plain) is Plain
+
+    def test_primitives_are_returned_untouched(self) -> None:
+        assert AuditLogger._serialize(7) == 7
+
+
+class TestLogInvocation:
+    """Tests for AuditLogger.log_invocation."""
+
+    def test_appends_the_entry_to_the_in_memory_trail(self, logger: AuditLogger) -> None:
+        entry = make_entry()
+
+        logger.log_invocation(entry)
+
+        assert logger.get_audit_trail() == [entry]
+
+    def test_writes_one_json_line_per_call(self, logger: AuditLogger) -> None:
+        logger.log_invocation(make_entry())
+        logger.log_invocation(make_entry(agent_id="agent-b", minutes=1))
+
+        lines = logger.log_file.read_text(encoding="utf-8").strip().splitlines()
+
+        assert len(lines) == 2
+        first = json.loads(lines[0])
+        assert first["agent_id"] == "agent-a"
+        assert first["timestamp"] == "2026-01-01T00:00:00+00:00"
+        assert json.loads(lines[1])["agent_id"] == "agent-b"
+
+    def test_non_serializable_results_use_the_fallback_encoder(self, logger: AuditLogger) -> None:
+        class Model:
+            def model_dump(self) -> dict[str, str]:
+                return {"kind": "model"}
+
+        logger.log_invocation(make_entry(result=Model()))
+
+        row = json.loads(logger.log_file.read_text(encoding="utf-8").strip())
+        assert row["result"] == {"kind": "model"}
+
+    def test_write_failures_are_logged_and_do_not_propagate(
+        self, logger: AuditLogger, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        errors: list[str] = []
+
+        def explode(*_args: Any, **_kwargs: Any) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(Path, "open", explode)
+        monkeypatch.setattr(logger.logger, "error", lambda msg, **kw: errors.append(msg))
+
+        logger.log_invocation(make_entry())
+
+        assert errors == ["Failed to write A2A audit log"]
+        assert len(logger.get_audit_trail()) == 1
+
+
+class TestGetAuditTrail:
+    """Tests for AuditLogger.get_audit_trail filtering."""
+
+    @pytest.fixture
+    def populated(self, logger: AuditLogger) -> AuditLogger:
+        logger.log_invocation(make_entry(agent_id="agent-a", tool_name="list_sites", minutes=0))
+        logger.log_invocation(make_entry(agent_id="agent-b", tool_name="list_sites", minutes=10))
+        logger.log_invocation(make_entry(agent_id="agent-a", tool_name="delete_site", minutes=20))
+        return logger
+
+    def test_returns_every_entry_with_no_filter(self, populated: AuditLogger) -> None:
+        assert len(populated.get_audit_trail()) == 3
+
+    def test_filters_by_agent(self, populated: AuditLogger) -> None:
+        entries = populated.get_audit_trail(agent_id="agent-a")
+
+        assert [entry.tool_name for entry in entries] == ["list_sites", "delete_site"]
+
+    def test_filters_by_tool(self, populated: AuditLogger) -> None:
+        entries = populated.get_audit_trail(tool_name="list_sites")
+
+        assert [entry.agent_id for entry in entries] == ["agent-a", "agent-b"]
+
+    def test_filters_by_start_time(self, populated: AuditLogger) -> None:
+        entries = populated.get_audit_trail(start=datetime(2026, 1, 1, 0, 5, tzinfo=timezone.utc))
+
+        assert len(entries) == 2
+
+    def test_filters_by_end_time(self, populated: AuditLogger) -> None:
+        entries = populated.get_audit_trail(end=datetime(2026, 1, 1, 0, 5, tzinfo=timezone.utc))
+
+        assert len(entries) == 1
+
+    def test_accepts_iso_strings_for_the_time_range(self, populated: AuditLogger) -> None:
+        entries = populated.get_audit_trail(
+            start="2026-01-01T00:05:00Z", end="2026-01-01T00:15:00Z"
+        )
+
+        assert [entry.agent_id for entry in entries] == ["agent-b"]
+
+    def test_combines_filters(self, populated: AuditLogger) -> None:
+        entries = populated.get_audit_trail(agent_id="agent-a", tool_name="delete_site")
+
+        assert len(entries) == 1
+
+
+class TestCoerceDatetime:
+    """Tests for AuditLogger._coerce_datetime."""
+
+    def test_none_passes_through(self) -> None:
+        assert AuditLogger._coerce_datetime(None) is None
+
+    def test_aware_datetimes_are_unchanged(self) -> None:
+        moment = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        assert AuditLogger._coerce_datetime(moment) is moment
+
+    def test_naive_datetimes_are_assumed_utc(self) -> None:
+        assert AuditLogger._coerce_datetime(datetime(2026, 1, 1)).tzinfo is timezone.utc
+
+    def test_iso_strings_with_a_z_suffix_are_parsed(self) -> None:
+        parsed = AuditLogger._coerce_datetime("2026-01-01T00:00:00Z")
+
+        assert parsed == datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+class TestExportAuditLog:
+    """Tests for AuditLogger.export_audit_log."""
+
+    def test_json_export_is_a_parsable_array(self, logger: AuditLogger) -> None:
+        logger.log_invocation(make_entry())
+
+        payload = json.loads(logger.export_audit_log())
+
+        assert len(payload) == 1
+        assert payload[0]["timestamp"] == "2026-01-01T00:00:00+00:00"
+
+    def test_jsonl_export_has_one_row_per_entry(self, logger: AuditLogger) -> None:
+        logger.log_invocation(make_entry())
+        logger.log_invocation(make_entry(agent_id="agent-b", minutes=1))
+
+        lines = logger.export_audit_log("jsonl").splitlines()
+
+        assert [json.loads(line)["agent_id"] for line in lines] == ["agent-a", "agent-b"]
+
+    def test_format_is_case_insensitive(self, logger: AuditLogger) -> None:
+        logger.log_invocation(make_entry())
+
+        assert json.loads(logger.export_audit_log("JSON"))
+        assert logger.export_audit_log("JSONL")
+
+    def test_empty_trail_exports_cleanly(self, logger: AuditLogger) -> None:
+        assert logger.export_audit_log() == "[]"
+        assert logger.export_audit_log("jsonl") == ""
+
+    def test_unsupported_formats_raise(self, logger: AuditLogger) -> None:
+        with pytest.raises(ValueError, match="Unsupported export format"):
+            logger.export_audit_log("csv")
+
+
+class TestGetAuditLogger:
+    """Tests for the module-level get_audit_logger singleton."""
+
+    @pytest.fixture(autouse=True)
+    def reset_singleton(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(audit_module, "_audit_logger", None)
+
+    def test_returns_the_same_instance_on_repeat_calls(self, tmp_path: Path) -> None:
+        first = get_audit_logger(log_file=tmp_path / "trail.jsonl")
+        second = get_audit_logger(log_file=tmp_path / "other.jsonl")
+
+        assert first is second
+        assert second.log_file == tmp_path / "trail.jsonl"

--- a/tests/unit/a2a/test_auth.py
+++ b/tests/unit/a2a/test_auth.py
@@ -1,0 +1,264 @@
+"""Unit tests for src/a2a/auth.py."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.a2a.auth import AuthContext, AuthManager, CloudAuthProvider, LocalAuthProvider
+from src.config import APIType
+
+
+class TestAuthContext:
+    """Tests for AuthContext."""
+
+    def test_defaults_to_no_permissions_and_no_expiry(self) -> None:
+        context = AuthContext(mode="local", credentials={})
+
+        assert context.permissions == set()
+        assert context.expiry is None
+
+    def test_a_context_without_an_expiry_never_expires(self) -> None:
+        assert AuthContext(mode="local", credentials={}).is_expired() is False
+
+    def test_a_past_expiry_is_expired(self) -> None:
+        past = datetime.now(tz=timezone.utc) - timedelta(seconds=1)
+
+        assert AuthContext(mode="local", credentials={}, expiry=past).is_expired() is True
+
+    def test_a_future_expiry_is_not_expired(self) -> None:
+        future = datetime.now(tz=timezone.utc) + timedelta(hours=1)
+
+        assert AuthContext(mode="local", credentials={}, expiry=future).is_expired() is False
+
+
+class TestLocalAuthProvider:
+    """Tests for LocalAuthProvider."""
+
+    def test_authenticate_reports_local_mode(self) -> None:
+        context = LocalAuthProvider().authenticate({"api_key": "k"})
+
+        assert context.mode == APIType.LOCAL.value
+        assert context.credentials == {"api_key": "k"}
+
+    def test_explicit_permissions_are_normalized_and_win(self) -> None:
+        context = LocalAuthProvider().authenticate({"api_key": "k", "permissions": ["READ", None]})
+
+        assert context.permissions == {"read"}
+
+    @pytest.mark.parametrize("credential", ["api_key", "token", "username"])
+    def test_any_credential_grants_full_local_permissions(self, credential: str) -> None:
+        context = LocalAuthProvider().authenticate({credential: "value"})
+
+        assert context.permissions == {"read", "write", "destructive"}
+
+    def test_anonymous_access_is_read_only(self) -> None:
+        assert LocalAuthProvider().authenticate({}).permissions == {"read"}
+
+    def test_expiry_uses_the_default_ttl(self) -> None:
+        before = datetime.now(tz=timezone.utc)
+
+        context = LocalAuthProvider(default_ttl_seconds=60).authenticate({})
+
+        assert context.expiry is not None
+        assert timedelta(seconds=55) <= context.expiry - before <= timedelta(seconds=65)
+
+    def test_expires_in_overrides_the_default_ttl(self) -> None:
+        before = datetime.now(tz=timezone.utc)
+
+        context = LocalAuthProvider(default_ttl_seconds=3600).authenticate({"expires_in": 30})
+
+        assert context.expiry is not None
+        assert context.expiry - before <= timedelta(seconds=35)
+
+    def test_a_non_positive_ttl_is_clamped_to_one_second(self) -> None:
+        before = datetime.now(tz=timezone.utc)
+
+        context = LocalAuthProvider().authenticate({"expires_in": -100})
+
+        assert context.expiry is not None
+        assert timedelta(0) < context.expiry - before <= timedelta(seconds=5)
+
+    def test_refresh_extends_the_expiry_and_keeps_the_payload(self) -> None:
+        provider = LocalAuthProvider()
+        original = provider.authenticate({"api_key": "k", "expires_in": 1})
+
+        refreshed = provider.refresh(original)
+
+        assert refreshed.credentials == original.credentials
+        assert refreshed.permissions == original.permissions
+        assert refreshed.mode == original.mode
+        assert refreshed.expiry is not None
+
+
+class TestCloudAuthProvider:
+    """Tests for CloudAuthProvider."""
+
+    def test_defaults_to_the_cloud_ea_mode(self) -> None:
+        assert CloudAuthProvider().authenticate({}).mode == APIType.CLOUD_EA.value
+
+    def test_an_explicit_mode_is_lowercased(self) -> None:
+        assert CloudAuthProvider().authenticate({"mode": "CLOUD-V1"}).mode == "cloud-v1"
+
+    @pytest.mark.parametrize("scope", ["read", "viewer", "view"])
+    def test_read_scopes_grant_read(self, scope: str) -> None:
+        assert CloudAuthProvider().authenticate({"scopes": [scope]}).permissions == {"read"}
+
+    @pytest.mark.parametrize("scope", ["write", "editor", "manage"])
+    def test_write_scopes_grant_write(self, scope: str) -> None:
+        assert CloudAuthProvider().authenticate({"scopes": [scope]}).permissions == {"write"}
+
+    def test_destructive_scope_grants_write_and_destructive(self) -> None:
+        permissions = CloudAuthProvider().authenticate({"scopes": ["destructive"]}).permissions
+
+        assert permissions == {"write", "destructive"}
+
+    @pytest.mark.parametrize("scope", ["admin", "owner"])
+    def test_admin_scopes_grant_everything(self, scope: str) -> None:
+        permissions = CloudAuthProvider().authenticate({"scopes": [scope]}).permissions
+
+        assert permissions == {"write", "destructive", "admin"}
+
+    def test_permissions_key_is_accepted_instead_of_scopes(self) -> None:
+        assert CloudAuthProvider().authenticate({"permissions": ["write"]}).permissions == {"write"}
+
+    def test_none_scopes_are_ignored(self) -> None:
+        assert CloudAuthProvider().authenticate({"scopes": ["read", None]}).permissions == {"read"}
+
+    def test_unknown_scopes_fall_back_to_read_only(self) -> None:
+        assert CloudAuthProvider().authenticate({"scopes": ["bogus"]}).permissions == {"read"}
+
+    def test_missing_scopes_fall_back_to_read_only(self) -> None:
+        assert CloudAuthProvider().authenticate({}).permissions == {"read"}
+
+    def test_expires_in_overrides_the_default_ttl(self) -> None:
+        before = datetime.now(tz=timezone.utc)
+
+        context = CloudAuthProvider(default_ttl_seconds=1800).authenticate({"expires_in": 30})
+
+        assert context.expiry is not None
+        assert context.expiry - before <= timedelta(seconds=35)
+
+    def test_refresh_returns_a_context_with_a_new_expiry(self) -> None:
+        provider = CloudAuthProvider()
+        original = provider.authenticate({"scopes": ["admin"], "expires_in": 1})
+
+        refreshed = provider.refresh(original)
+
+        assert refreshed.permissions == original.permissions
+        assert refreshed.expiry is not None
+
+
+class TestAuthManagerNormalizeMode:
+    """Tests for AuthManager._normalize_mode."""
+
+    def test_accepts_an_api_type_enum(self) -> None:
+        assert AuthManager._normalize_mode(APIType.LOCAL) == "local"
+
+    def test_trims_and_lowercases_strings(self) -> None:
+        assert AuthManager._normalize_mode("  LOCAL  ") == "local"
+
+    def test_the_generic_cloud_mode_maps_to_cloud_ea(self) -> None:
+        assert AuthManager._normalize_mode(APIType.CLOUD.value) == APIType.CLOUD_EA.value
+
+
+class TestAuthManagerAuthenticate:
+    """Tests for AuthManager.authenticate."""
+
+    def test_local_mode_uses_the_local_provider(self) -> None:
+        context = AuthManager().authenticate(APIType.LOCAL, {"api_key": "k"})
+
+        assert context.mode == APIType.LOCAL.value
+        assert context.permissions == {"read", "write", "destructive"}
+
+    @pytest.mark.parametrize("mode", [APIType.CLOUD_EA, APIType.CLOUD_V1])
+    def test_cloud_modes_use_the_cloud_provider(self, mode: APIType) -> None:
+        context = AuthManager().authenticate(mode, {"scopes": ["admin"]})
+
+        assert context.mode == mode.value
+        assert "admin" in context.permissions
+
+    def test_unsupported_modes_raise(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported auth mode: carrier-pigeon"):
+            AuthManager().authenticate("carrier-pigeon", {})
+
+
+class TestAuthManagerRefresh:
+    """Tests for AuthManager.refresh."""
+
+    def test_local_contexts_are_refreshed_locally(self) -> None:
+        manager = AuthManager()
+        context = manager.authenticate(APIType.LOCAL, {"api_key": "k"})
+
+        assert manager.refresh(context).mode == APIType.LOCAL.value
+
+    def test_cloud_contexts_are_refreshed_in_the_cloud(self) -> None:
+        manager = AuthManager()
+        context = manager.authenticate(APIType.CLOUD_EA, {"scopes": ["write"]})
+
+        assert manager.refresh(context).permissions == {"write"}
+
+
+class TestRequiredPermission:
+    """Tests for AuthManager._required_permission."""
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        ["delete_site", "remove_client", "reset_device", "revoke_key", "purge_logs", "wipe_site"],
+    )
+    def test_destructive_prefixes(self, tool_name: str) -> None:
+        assert AuthManager._required_permission(tool_name) == "destructive"
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        ["create_wlan", "add_client", "update_site", "set_flag", "reboot_device", "adopt_device"],
+    )
+    def test_write_prefixes(self, tool_name: str) -> None:
+        assert AuthManager._required_permission(tool_name) == "write"
+
+    @pytest.mark.parametrize("tool_name", ["list_sites", "get_device", "  LIST_SITES  "])
+    def test_everything_else_is_read(self, tool_name: str) -> None:
+        assert AuthManager._required_permission(tool_name) == "read"
+
+
+class TestValidatePermissions:
+    """Tests for AuthManager.validate_permissions."""
+
+    @pytest.fixture
+    def manager(self) -> AuthManager:
+        return AuthManager()
+
+    def make_context(self, *permissions: str) -> AuthContext:
+        """Build a context granting exactly the given permissions."""
+        return AuthContext(mode="local", credentials={}, permissions=set(permissions))
+
+    def test_admin_may_do_anything(self, manager: AuthManager) -> None:
+        context = self.make_context("admin")
+
+        assert manager.validate_permissions(context, "delete_site") is True
+
+    @pytest.mark.parametrize("permission", ["read", "write", "destructive"])
+    def test_read_tools_accept_any_permission(self, manager: AuthManager, permission: str) -> None:
+        assert manager.validate_permissions(self.make_context(permission), "list_sites") is True
+
+    def test_read_tools_reject_an_empty_context(self, manager: AuthManager) -> None:
+        assert manager.validate_permissions(self.make_context(), "list_sites") is False
+
+    def test_write_tools_reject_read_only(self, manager: AuthManager) -> None:
+        assert manager.validate_permissions(self.make_context("read"), "create_wlan") is False
+
+    @pytest.mark.parametrize("permission", ["write", "destructive"])
+    def test_write_tools_accept_write_or_destructive(
+        self, manager: AuthManager, permission: str
+    ) -> None:
+        assert manager.validate_permissions(self.make_context(permission), "create_wlan") is True
+
+    def test_destructive_tools_require_the_destructive_permission(
+        self, manager: AuthManager
+    ) -> None:
+        assert manager.validate_permissions(self.make_context("write"), "delete_site") is False
+        assert manager.validate_permissions(self.make_context("destructive"), "delete_site") is True
+
+    def test_permissions_are_compared_case_insensitively(self, manager: AuthManager) -> None:
+        assert manager.validate_permissions(self.make_context("DESTRUCTIVE"), "delete_site") is True

--- a/tests/unit/a2a/test_delegation.py
+++ b/tests/unit/a2a/test_delegation.py
@@ -1,0 +1,330 @@
+"""Unit tests for src/a2a/delegation.py."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from src.a2a import delegation
+from src.a2a.delegation import (
+    _active_mcp,
+    _auth_mode_for_settings,
+    _is_destructive_tool_name,
+    _now_iso,
+    _run_sync,
+    create_delegation_contract,
+    execute_delegated_call,
+    validate_delegation,
+)
+from src.a2a.types import AuthenticationMode, DelegationContract, SafetyRequirement
+from src.config.config import Settings
+
+from .conftest import FakeMCP, delete_site_device, list_site_clients, make_tool
+
+
+def build_contract(**overrides: Any) -> DelegationContract:
+    """Create a valid contract, overriding individual fields as needed."""
+    defaults: dict[str, Any] = {
+        "contractId": "contract-1",
+        "toolName": "list_site_clients",
+        "params": {"site_id": "default"},
+        "requestingAgent": "agent-a",
+        "authenticationMode": AuthenticationMode.BOTH,
+        "createdAt": "2026-01-01T00:00:00+00:00",
+        "requiresConfirmation": False,
+    }
+    defaults.update(overrides)
+    return DelegationContract(**defaults)
+
+
+class TestNowIso:
+    """Tests for _now_iso."""
+
+    def test_returns_a_utc_iso_timestamp(self) -> None:
+        stamp = _now_iso()
+
+        assert stamp.endswith("+00:00")
+        assert "T" in stamp
+
+
+class TestRunSync:
+    """Tests for _run_sync."""
+
+    def test_runs_a_coroutine_outside_an_event_loop(self) -> None:
+        async def answer() -> int:
+            return 42
+
+        assert _run_sync(answer()) == 42
+
+    def test_rejects_being_called_inside_a_running_loop(self) -> None:
+        async def answer() -> int:
+            return 42
+
+        async def caller() -> None:
+            coro = answer()
+            try:
+                with pytest.raises(RuntimeError, match="inside a running event loop"):
+                    _run_sync(coro)
+            finally:
+                coro.close()
+
+        asyncio.run(caller())
+
+    def test_delegates_to_an_existing_idle_loop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def answer() -> int:
+            return 42
+
+        loop = asyncio.new_event_loop()
+        monkeypatch.setattr(asyncio, "get_running_loop", lambda: loop)
+        try:
+            assert _run_sync(answer()) == 42
+        finally:
+            loop.close()
+
+
+class Marker:
+    """Stands in for FastMCP so sys.modules scanning has exactly one match."""
+
+
+class TestActiveMcp:
+    """Tests for _active_mcp."""
+
+    @pytest.fixture(autouse=True)
+    def only_marker_counts_as_a_server(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Narrow the isinstance check so unrelated imports cannot match.
+
+        src/main.py holds a module-level FastMCP, so scanning the real
+        sys.modules would otherwise make these tests depend on import order.
+        """
+        monkeypatch.setattr(delegation, "FastMCP", Marker)
+
+    def test_returns_none_when_no_module_exposes_a_server(self) -> None:
+        assert _active_mcp() is None
+
+    def test_skips_none_entries_in_sys_modules(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setitem(sys.modules, "tests_a2a_stale_module", None)
+
+        assert _active_mcp() is None
+
+    def test_finds_a_module_level_server_instance(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        server = Marker()
+        holder = ModuleType("tests_a2a_holder")
+        holder.mcp = server
+        monkeypatch.setitem(sys.modules, "tests_a2a_holder", holder)
+
+        assert _active_mcp() is server
+
+    def test_ignores_attributes_named_mcp_that_are_not_servers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        decoy = ModuleType("tests_a2a_decoy")
+        decoy.mcp = "not-a-server"
+        monkeypatch.setitem(sys.modules, "tests_a2a_decoy", decoy)
+
+        assert _active_mcp() is None
+
+
+class TestAuthModeForSettings:
+    """Tests for _auth_mode_for_settings."""
+
+    def test_always_reports_both(self, local_settings: Settings) -> None:
+        assert _auth_mode_for_settings(local_settings) is AuthenticationMode.BOTH
+
+
+class TestIsDestructiveToolName:
+    """Tests for _is_destructive_tool_name."""
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "delete_site_device",
+            "remove_client",
+            "reset_controller",
+            "restore_backup",
+            "reboot_device",
+            "restart_service",
+            "disable_wlan",
+            "flush_dns",
+            "purge_logs",
+            "provision_device",
+            "deprovision_device",
+            "DELETE_SITE_DEVICE",
+        ],
+    )
+    def test_detects_destructive_names(self, tool_name: str) -> None:
+        assert _is_destructive_tool_name(tool_name) is True
+
+    @pytest.mark.parametrize("tool_name", ["list_site_clients", "get_device", "search_events"])
+    def test_treats_read_only_names_as_safe(self, tool_name: str) -> None:
+        assert _is_destructive_tool_name(tool_name) is False
+
+
+class TestCreateDelegationContract:
+    """Tests for create_delegation_contract."""
+
+    def test_rejects_params_that_are_not_json_serializable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(delegation, "_active_mcp", lambda: None)
+
+        with pytest.raises(TypeError):
+            create_delegation_contract("list_site_clients", {"when": object()}, "agent-a")
+
+    def test_falls_back_to_the_name_heuristic_without_an_active_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(delegation, "_active_mcp", lambda: None)
+
+        contract = create_delegation_contract("delete_site_device", {"site_id": "s"}, "agent-a")
+
+        assert contract.requiresConfirmation is True
+        assert contract.safetyRequirement is None
+        assert contract.toolName == "delete_site_device"
+        assert contract.requestingAgent == "agent-a"
+        assert contract.dryRun is False
+        assert contract.metadata == {"source": "a2a.delegation"}
+        assert contract.authenticationMode is AuthenticationMode.BOTH
+        assert contract.contractId
+
+    def test_generates_a_unique_id_per_contract(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(delegation, "_active_mcp", lambda: None)
+
+        first = create_delegation_contract("list_site_clients", {}, "agent-a")
+        second = create_delegation_contract("list_site_clients", {}, "agent-a")
+
+        assert first.contractId != second.contractId
+
+    def test_reads_safety_metadata_from_the_registered_tool(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = FakeMCP({"delete_site_device": make_tool(delete_site_device)})
+        monkeypatch.setattr(delegation, "_active_mcp", lambda: mcp)
+
+        contract = create_delegation_contract("delete_site_device", {"site_id": "s"}, "agent-a")
+
+        assert contract.safetyRequirement is not None
+        assert contract.safetyRequirement.destructive is True
+        assert contract.requiresConfirmation is True
+
+    def test_read_only_registered_tools_do_not_require_confirmation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = FakeMCP({"list_site_clients": make_tool(list_site_clients)})
+        monkeypatch.setattr(delegation, "_active_mcp", lambda: mcp)
+
+        contract = create_delegation_contract("list_site_clients", {"site_id": "s"}, "agent-a")
+
+        assert contract.requiresConfirmation is False
+
+    def test_ignores_providers_without_a_component_mapping(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = FakeMCP({"delete_site_device": make_tool(delete_site_device)})
+        mcp.providers.insert(0, type("Bare", (), {"_components": "not-a-dict"})())
+        monkeypatch.setattr(delegation, "_active_mcp", lambda: mcp)
+
+        contract = create_delegation_contract("delete_site_device", {"site_id": "s"}, "agent-a")
+
+        assert contract.safetyRequirement is not None
+
+    def test_unregistered_tool_names_fall_back_to_the_heuristic(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = FakeMCP({"list_site_clients": make_tool(list_site_clients)})
+        monkeypatch.setattr(delegation, "_active_mcp", lambda: mcp)
+
+        contract = create_delegation_contract("purge_logs", {}, "agent-a")
+
+        assert contract.safetyRequirement is None
+        assert contract.requiresConfirmation is True
+
+
+class TestValidateDelegation:
+    """Tests for validate_delegation."""
+
+    def test_accepts_a_well_formed_read_only_contract(self) -> None:
+        assert validate_delegation(build_contract()) is True
+
+    @pytest.mark.parametrize("field", ["contractId", "toolName", "requestingAgent"])
+    def test_rejects_missing_identity_fields(self, field: str) -> None:
+        assert validate_delegation(build_contract(**{field: ""})) is False
+
+    def test_rejects_params_that_are_not_a_mapping(self) -> None:
+        assert validate_delegation(build_contract(params=["site_id"])) is False
+
+    def test_rejects_confirmation_contracts_without_safety_metadata(self) -> None:
+        contract = build_contract(requiresConfirmation=True, params={"confirm": True})
+
+        assert validate_delegation(contract) is False
+
+    def test_rejects_confirmation_contracts_without_an_explicit_confirm_flag(self) -> None:
+        contract = build_contract(
+            requiresConfirmation=True,
+            safetyRequirement=SafetyRequirement("required", True, []),
+            params={},
+        )
+
+        assert validate_delegation(contract) is False
+
+    def test_accepts_a_confirmed_destructive_contract(self) -> None:
+        contract = build_contract(
+            requiresConfirmation=True,
+            safetyRequirement=SafetyRequirement("required", True, []),
+            params={"confirm": True},
+        )
+
+        assert validate_delegation(contract) is True
+
+
+class TestExecuteDelegatedCall:
+    """Tests for execute_delegated_call."""
+
+    def test_rejects_an_invalid_contract(self, local_settings: Settings) -> None:
+        with pytest.raises(ValueError, match="Invalid delegation contract"):
+            execute_delegated_call(build_contract(contractId=""), local_settings)
+
+    def test_requires_an_active_server(
+        self, monkeypatch: pytest.MonkeyPatch, local_settings: Settings
+    ) -> None:
+        monkeypatch.setattr(delegation, "_active_mcp", lambda: None)
+
+        with pytest.raises(RuntimeError, match="No active FastMCP instance"):
+            execute_delegated_call(build_contract(), local_settings)
+
+    def test_invokes_the_named_tool_with_the_contract_params(
+        self, monkeypatch: pytest.MonkeyPatch, local_settings: Settings
+    ) -> None:
+        calls: list[tuple[str, dict[str, Any]]] = []
+
+        class RecordingMCP:
+            async def call_tool(self, name: str, params: dict[str, Any]) -> str:
+                calls.append((name, params))
+                return "tool-result"
+
+        monkeypatch.setattr(delegation, "_active_mcp", lambda: RecordingMCP())
+
+        result = execute_delegated_call(build_contract(), local_settings)
+
+        assert result == "tool-result"
+        assert calls == [("list_site_clients", {"site_id": "default"})]
+
+    def test_confirmed_destructive_contracts_are_executed(
+        self, monkeypatch: pytest.MonkeyPatch, local_settings: Settings
+    ) -> None:
+        class RecordingMCP:
+            async def call_tool(self, name: str, params: dict[str, Any]) -> str:
+                return "deleted"
+
+        monkeypatch.setattr(delegation, "_active_mcp", lambda: RecordingMCP())
+        contract = build_contract(
+            toolName="delete_site_device",
+            requiresConfirmation=True,
+            safetyRequirement=SafetyRequirement("required", True, []),
+            params={"confirm": True},
+        )
+
+        assert execute_delegated_call(contract, local_settings) == "deleted"

--- a/tests/unit/a2a/test_discovery.py
+++ b/tests/unit/a2a/test_discovery.py
@@ -1,0 +1,149 @@
+"""Unit tests for src/a2a/discovery.py."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from src.a2a import discovery
+from src.a2a.discovery import (
+    _iter_components,
+    _resolve_active_mcp,
+    build_agent_card,
+    get_resource_endpoints,
+    get_skills_manifest,
+)
+from src.config.config import Settings
+
+from .conftest import FakeMCP, delete_site_device, list_site_clients, make_resource, make_tool
+
+
+class Marker:
+    """Stands in for FastMCP so sys.modules scanning has exactly one match."""
+
+
+def build_populated_mcp() -> FakeMCP:
+    """Return a fake server exposing one tool, one resource, and one other component."""
+    return FakeMCP(
+        {
+            "list_site_clients": make_tool(list_site_clients),
+            "delete_site_device": make_tool(delete_site_device),
+            "sites": make_resource(lambda: "payload", uri="unifi://sites", name="sites"),
+            "some_prompt": object(),
+        }
+    )
+
+
+class TestIterComponents:
+    """Tests for _iter_components."""
+
+    def test_yields_nothing_for_a_server_without_providers(self) -> None:
+        assert list(_iter_components(object())) == []
+
+    def test_yields_every_registered_component(self) -> None:
+        mcp = FakeMCP({"a": "first", "b": "second"})
+
+        assert list(_iter_components(mcp)) == ["first", "second"]
+
+    def test_skips_providers_without_a_component_mapping(self) -> None:
+        mcp = FakeMCP({"a": "first"})
+        mcp.providers.insert(0, type("Bare", (), {"_components": None})())
+
+        assert list(_iter_components(mcp)) == ["first"]
+
+    def test_spans_multiple_providers(self) -> None:
+        mcp = FakeMCP({"a": "first"})
+        mcp.providers.append(type("Extra", (), {"_components": {"b": "second"}})())
+
+        assert list(_iter_components(mcp)) == ["first", "second"]
+
+
+class TestResolveActiveMcp:
+    """Tests for _resolve_active_mcp."""
+
+    @pytest.fixture(autouse=True)
+    def only_marker_counts_as_a_server(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Narrow the isinstance check so unrelated imports cannot match.
+
+        src/main.py holds a module-level FastMCP, so scanning the real
+        sys.modules would otherwise make these tests depend on import order.
+        """
+        monkeypatch.setattr(discovery, "FastMCP", Marker)
+
+    def test_returns_none_when_no_module_exposes_a_server(self) -> None:
+        assert _resolve_active_mcp() is None
+
+    def test_skips_none_entries_in_sys_modules(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setitem(sys.modules, "tests_a2a_discovery_stale", None)
+
+        assert _resolve_active_mcp() is None
+
+    def test_finds_a_module_level_server_instance(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        server = Marker()
+        holder = ModuleType("tests_a2a_discovery_holder")
+        holder.mcp = server
+        monkeypatch.setitem(sys.modules, "tests_a2a_discovery_holder", holder)
+
+        assert _resolve_active_mcp() is server
+
+    def test_ignores_attributes_named_mcp_that_are_not_servers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        decoy = ModuleType("tests_a2a_discovery_decoy")
+        decoy.mcp = "not-a-server"
+        monkeypatch.setitem(sys.modules, "tests_a2a_discovery_decoy", decoy)
+
+        assert _resolve_active_mcp() is None
+
+
+class TestBuildAgentCard:
+    """Tests for the discovery build_agent_card wrapper."""
+
+    def test_delegates_to_the_card_builder(self, local_settings: Settings) -> None:
+        card = build_agent_card(build_populated_mcp(), local_settings)
+
+        assert {skill.name for skill in card.skills} == {
+            "list_site_clients",
+            "delete_site_device",
+        }
+        assert [resource.uri for resource in card.resources] == ["unifi://sites"]
+
+
+class TestGetSkillsManifest:
+    """Tests for get_skills_manifest."""
+
+    def test_returns_an_empty_list_without_an_active_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(discovery, "_resolve_active_mcp", lambda: None)
+
+        assert get_skills_manifest() == []
+
+    def test_returns_only_tool_components(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(discovery, "_resolve_active_mcp", build_populated_mcp)
+
+        skills = get_skills_manifest()
+
+        assert {skill.name for skill in skills} == {"list_site_clients", "delete_site_device"}
+        assert all(skill.description for skill in skills)
+
+
+class TestGetResourceEndpoints:
+    """Tests for get_resource_endpoints."""
+
+    def test_returns_an_empty_list_without_an_active_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(discovery, "_resolve_active_mcp", lambda: None)
+
+        assert get_resource_endpoints() == []
+
+    def test_returns_only_resource_components(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(discovery, "_resolve_active_mcp", build_populated_mcp)
+
+        resources = get_resource_endpoints()
+
+        assert [resource.uri for resource in resources] == ["unifi://sites"]
+        assert resources[0].name == "sites"

--- a/tests/unit/a2a/test_prompt_playbook.py
+++ b/tests/unit/a2a/test_prompt_playbook.py
@@ -1,0 +1,252 @@
+"""Unit tests for src/a2a/prompt_playbook.py and the bundled playbooks."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.a2a.playbooks import PLAYBOOKS
+from src.a2a.prompt_playbook import (
+    DEFAULT_PLAYBOOK_REGISTRY,
+    PlaybookRegistry,
+    PlaybookStep,
+    PromptPlaybook,
+    _default_registry,
+    _format_params,
+    render_playbook,
+)
+
+EXPECTED_BUILTIN_NAMES = [
+    "device_provisioning",
+    "guest_wifi_setup",
+    "incident_response",
+    "network_diagnostics",
+    "security_audit",
+    "site_migration",
+]
+
+
+def make_playbook(name: str = "demo", **overrides: object) -> PromptPlaybook:
+    """Build a small playbook for registry and rendering tests."""
+    defaults: dict[str, object] = {
+        "name": name,
+        "description": "Demo workflow.",
+        "steps": [
+            PlaybookStep(
+                order=2,
+                action="Second action.",
+                tool="list_site_clients",
+                params={"site_id": "default"},
+                validation="Confirm clients are listed.",
+                fallback="Retry with a narrower scope.",
+            ),
+            PlaybookStep(order=1, action="First action."),
+        ],
+        "requiredSkills": ["list_site_clients"],
+        "safetyLevel": "confirm",
+    }
+    defaults.update(overrides)
+    return PromptPlaybook(**defaults)  # type: ignore[arg-type]
+
+
+class TestPlaybookStep:
+    """Tests for PlaybookStep."""
+
+    def test_defaults_are_empty(self) -> None:
+        step = PlaybookStep(order=1, action="Do the thing.")
+
+        assert step.tool is None
+        assert step.params == {}
+        assert step.validation == ""
+        assert step.fallback == ""
+
+    def test_to_dict_round_trips_every_field(self) -> None:
+        step = PlaybookStep(order=3, action="Act.", tool="t", params={"a": 1})
+
+        assert step.to_dict() == {
+            "order": 3,
+            "action": "Act.",
+            "tool": "t",
+            "params": {"a": 1},
+            "validation": "",
+            "fallback": "",
+        }
+
+    def test_params_are_not_shared_between_instances(self) -> None:
+        first = PlaybookStep(order=1, action="One.")
+        second = PlaybookStep(order=2, action="Two.")
+        first.params["site_id"] = "default"
+
+        assert second.params == {}
+
+
+class TestPromptPlaybook:
+    """Tests for PromptPlaybook."""
+
+    def test_defaults_are_empty(self) -> None:
+        playbook = PromptPlaybook(name="p", description="d")
+
+        assert playbook.steps == []
+        assert playbook.requiredSkills == []
+        assert playbook.safetyLevel == "none"
+
+    def test_to_dict_serializes_nested_steps(self) -> None:
+        payload = make_playbook().to_dict()
+
+        assert payload["name"] == "demo"
+        assert payload["safetyLevel"] == "confirm"
+        assert [step["order"] for step in payload["steps"]] == [2, 1]
+        assert json.dumps(payload)
+
+
+class TestPlaybookRegistry:
+    """Tests for PlaybookRegistry."""
+
+    def test_starts_empty(self) -> None:
+        assert PlaybookRegistry().names() == []
+
+    def test_registers_playbooks_supplied_to_the_constructor(self) -> None:
+        registry = PlaybookRegistry([make_playbook("b"), make_playbook("a")])
+
+        assert registry.names() == ["a", "b"]
+
+    def test_register_replaces_an_existing_name(self) -> None:
+        registry = PlaybookRegistry([make_playbook("a", description="first")])
+        registry.register(make_playbook("a", description="second"))
+
+        assert registry.get("a").description == "second"
+        assert registry.names() == ["a"]
+
+    def test_get_raises_a_descriptive_error_for_unknown_names(self) -> None:
+        with pytest.raises(KeyError, match="Unknown playbook: missing"):
+            PlaybookRegistry().get("missing")
+
+    def test_items_are_sorted_by_name(self) -> None:
+        registry = PlaybookRegistry([make_playbook("z"), make_playbook("a")])
+
+        assert [name for name, _ in registry.items()] == ["a", "z"]
+        assert all(name == playbook.name for name, playbook in registry.items())
+
+    def test_to_dict_is_json_serializable(self) -> None:
+        payload = PlaybookRegistry([make_playbook("a")]).to_dict()
+
+        assert list(payload) == ["a"]
+        assert json.dumps(payload)
+
+    def test_load_builtin_registers_every_bundled_playbook(self) -> None:
+        registry = PlaybookRegistry.load_builtin()
+
+        assert registry.names() == EXPECTED_BUILTIN_NAMES
+
+
+class TestDefaultRegistry:
+    """Tests for the module-level DEFAULT_PLAYBOOK_REGISTRY."""
+
+    def test_exposes_the_bundled_playbooks(self) -> None:
+        assert _default_registry().names() == EXPECTED_BUILTIN_NAMES
+
+    def test_recovers_when_the_registry_was_built_before_the_playbooks_package(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Importing src.a2a.playbooks first used to leave the registry empty."""
+        monkeypatch.setattr(DEFAULT_PLAYBOOK_REGISTRY, "_playbooks", {})
+
+        assert _default_registry().names() == EXPECTED_BUILTIN_NAMES
+        assert "# A2A Prompt Playbook: security_audit" in render_playbook("security_audit")
+
+
+class TestFormatParams:
+    """Tests for _format_params."""
+
+    @pytest.mark.parametrize("params", [None, {}])
+    def test_empty_params_render_as_an_empty_object(self, params: dict[str, object] | None) -> None:
+        assert _format_params(params) == "{}"
+
+    def test_keys_are_sorted(self) -> None:
+        assert _format_params({"b": 1, "a": 2}) == '{\n  "a": 2,\n  "b": 1\n}'
+
+    def test_non_serializable_values_fall_back_to_their_string_form(self) -> None:
+        rendered = _format_params({"when": object()})
+
+        assert "object object" in rendered
+
+
+class TestRenderPlaybook:
+    """Tests for render_playbook."""
+
+    def test_renders_steps_in_order(self) -> None:
+        registry = PlaybookRegistry([make_playbook()])
+
+        rendered = render_playbook("demo", {"site_id": "default"}, registry)
+
+        assert rendered.index("### Step 1:") < rendered.index("### Step 2:")
+
+    def test_includes_the_header_metadata_and_context(self) -> None:
+        registry = PlaybookRegistry([make_playbook()])
+
+        rendered = render_playbook("demo", {"site_id": "default"}, registry)
+
+        assert "# A2A Prompt Playbook: demo" in rendered
+        assert "Description: Demo workflow." in rendered
+        assert "Safety level: confirm" in rendered
+        assert "Required skills: list_site_clients" in rendered
+        assert '"site_id": "default"' in rendered
+        assert "## Operating Notes" in rendered
+
+    def test_missing_context_renders_an_empty_object(self) -> None:
+        registry = PlaybookRegistry([make_playbook()])
+
+        rendered = render_playbook("demo", None, registry)
+
+        assert "## Context\n```json\n{}\n```" in rendered
+
+    def test_playbooks_without_required_skills_say_none(self) -> None:
+        registry = PlaybookRegistry([make_playbook(requiredSkills=[])])
+
+        assert "Required skills: none" in render_playbook("demo", {}, registry)
+
+    def test_steps_without_a_tool_or_guidance_use_defaults(self) -> None:
+        registry = PlaybookRegistry(
+            [make_playbook(steps=[PlaybookStep(order=1, action="Summarize.")])]
+        )
+
+        rendered = render_playbook("demo", {}, registry)
+
+        assert "Tool: none" in rendered
+        assert "Validation: confirm the action completed successfully." in rendered
+        assert "Fallback: pause and request human guidance." in rendered
+
+    def test_defaults_to_the_bundled_registry(self) -> None:
+        rendered = render_playbook("network_diagnostics", {"site_id": "default"})
+
+        assert "# A2A Prompt Playbook: network_diagnostics" in rendered
+
+    def test_unknown_playbooks_raise_key_error(self) -> None:
+        with pytest.raises(KeyError, match="Unknown playbook: nope"):
+            render_playbook("nope")
+
+
+class TestBundledPlaybooks:
+    """Contract tests covering every playbook in src/a2a/playbooks."""
+
+    def test_names_are_unique_and_complete(self) -> None:
+        assert sorted(playbook.name for playbook in PLAYBOOKS) == EXPECTED_BUILTIN_NAMES
+
+    @pytest.mark.parametrize("playbook", PLAYBOOKS, ids=lambda item: item.name)
+    def test_each_playbook_is_well_formed(self, playbook: PromptPlaybook) -> None:
+        assert playbook.description
+        assert playbook.steps
+        assert [step.order for step in playbook.steps] == list(range(1, len(playbook.steps) + 1))
+        for step in playbook.steps:
+            assert step.action
+            assert step.validation
+            assert step.fallback
+
+    @pytest.mark.parametrize("playbook", PLAYBOOKS, ids=lambda item: item.name)
+    def test_each_playbook_renders(self, playbook: PromptPlaybook) -> None:
+        rendered = render_playbook(playbook.name, {"site_id": "default"})
+
+        assert f"# A2A Prompt Playbook: {playbook.name}" in rendered
+        for step in playbook.steps:
+            assert f"### Step {step.order}: {step.action}" in rendered

--- a/tests/unit/a2a/test_route_policy.py
+++ b/tests/unit/a2a/test_route_policy.py
@@ -1,0 +1,500 @@
+"""Unit tests for src/a2a/route_policy.py."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.a2a.route_policy import (
+    ConfirmationToken,
+    ConfirmationWorkflow,
+    RoutePolicy,
+    SafetyController,
+    SafetyResult,
+)
+from src.config.config import Settings
+
+
+def auth(permissions: set[str] | None = None, **credentials: Any) -> SimpleNamespace:
+    """Build a stand-in auth context with the given permissions and credentials."""
+    return SimpleNamespace(permissions=permissions or {"admin"}, credentials=credentials)
+
+
+@pytest.fixture
+def controller() -> SafetyController:
+    """Return a controller using the built-in default policies."""
+    return SafetyController()
+
+
+class TestDataclasses:
+    """Tests for the module's dataclass defaults."""
+
+    def test_safety_result_defaults(self) -> None:
+        result = SafetyResult(True, "read", "allowed")
+
+        assert result.requires_confirmation is False
+        assert result.rate_limited is False
+        assert result.policy is None
+
+    def test_confirmation_token_starts_unconfirmed(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        token = ConfirmationToken("t", "delete_site", "hash", "why", now, now)
+
+        assert token.confirmed is False
+
+
+class TestDefaultPolicies:
+    """Tests for SafetyController._build_default_policies."""
+
+    def test_without_settings_uses_baseline_rates(self, controller: SafetyController) -> None:
+        by_path = {policy.path: policy for policy in controller._policies}
+
+        assert by_path["/a2a/agent-card"].rateLimit == 120
+        assert by_path["/a2a/delegate"].rateLimit == 30
+        assert by_path["tool://destructive"].rateLimit == 5
+        assert by_path["/a2a/audit"].requiredAuth == "admin"
+
+    def test_rates_are_derived_from_settings(self, local_settings: Settings) -> None:
+        local_settings.rate_limit_requests = 200
+
+        by_path = {p.path: p for p in SafetyController(local_settings)._policies}
+
+        assert by_path["/a2a/agent-card"].rateLimit == 200
+        assert by_path["/a2a/delegate"].rateLimit == 50
+        assert by_path["tool://destructive"].rateLimit == 10
+
+    def test_derived_rates_never_drop_below_one(self, local_settings: Settings) -> None:
+        local_settings.rate_limit_requests = 1
+
+        by_path = {p.path: p for p in SafetyController(local_settings)._policies}
+
+        assert by_path["/a2a/delegate"].rateLimit == 1
+        assert by_path["tool://destructive"].rateLimit == 1
+
+    def test_explicit_policies_replace_the_defaults(self) -> None:
+        policy = RoutePolicy("tool://custom", ("POST",), "read", "none", 7)
+
+        assert SafetyController(policies=[policy])._policies == [policy]
+
+
+class TestNormalizeAndHash:
+    """Tests for the small static helpers."""
+
+    def test_tool_names_are_trimmed_and_lowercased(self) -> None:
+        assert SafetyController._normalize_tool_name("  Delete_Site  ") == "delete_site"
+
+    def test_params_hash_is_stable_regardless_of_key_order(self) -> None:
+        first = SafetyController._params_hash({"a": 1, "b": 2})
+        second = SafetyController._params_hash({"b": 2, "a": 1})
+
+        assert first == second
+
+    def test_params_hash_changes_with_values(self) -> None:
+        assert SafetyController._params_hash({"a": 1}) != SafetyController._params_hash({"a": 2})
+
+
+class TestClassifyTool:
+    """Tests for SafetyController._classify_tool."""
+
+    @pytest.mark.parametrize(
+        "tool_name", ["delete_site", "revoke_key", "block_client", "factory_reset_device"]
+    )
+    def test_destructive_prefixes(self, controller: SafetyController, tool_name: str) -> None:
+        level, policy = controller._classify_tool(tool_name, {})
+
+        assert level == "destructive"
+        assert policy.requiredAuth == "destructive"
+        assert policy.confirmationLevel == "critical"
+
+    def test_destructive_keywords_anywhere_in_the_name(self, controller: SafetyController) -> None:
+        level, _ = controller._classify_tool("site_purge_all", {})
+
+        assert level == "destructive"
+
+    @pytest.mark.parametrize("tool_name", ["create_wlan", "update_site", "adopt_device"])
+    def test_write_prefixes(self, controller: SafetyController, tool_name: str) -> None:
+        level, policy = controller._classify_tool(tool_name, {})
+
+        assert level == "write"
+        assert policy.requiredAuth == "write"
+        assert policy.confirmationLevel == "standard"
+
+    def test_write_keywords_anywhere_in_name(self, controller: SafetyController) -> None:
+        level, _ = controller._classify_tool("site_sync_now", {})
+
+        assert level == "write"
+
+    @pytest.mark.parametrize("tool_name", ["list_sites", "get_device", "search_events"])
+    def test_read_tools(self, controller: SafetyController, tool_name: str) -> None:
+        level, policy = controller._classify_tool(tool_name, {})
+
+        assert level == "read"
+        assert policy.requiredAuth == "read"
+        assert policy.rateLimit == 120
+
+    def test_rates_follow_settings(self, local_settings: Settings) -> None:
+        local_settings.rate_limit_requests = 400
+        controller = SafetyController(local_settings)
+
+        assert controller._classify_tool("delete_site", {})[1].rateLimit == 20
+        assert controller._classify_tool("create_wlan", {})[1].rateLimit == 100
+        assert controller._classify_tool("list_sites", {})[1].rateLimit == 400
+
+
+class TestFindPolicy:
+    """Tests for SafetyController._find_policy."""
+
+    def test_an_exact_policy_path_wins(self) -> None:
+        policy = RoutePolicy("tool://list_sites", ("POST",), "read", "none", 9)
+        controller = SafetyController(policies=[policy])
+
+        assert controller._find_policy("List_Sites") is policy
+
+    def test_the_wildcard_policy_matches_any_tool(self) -> None:
+        policy = RoutePolicy("tool://*", ("POST",), "read", "standard", 11)
+        controller = SafetyController(policies=[policy])
+
+        assert controller._find_policy("anything") is policy
+
+    @pytest.mark.parametrize(
+        ("tool_name", "expected"),
+        [("delete_site", "destructive"), ("create_wlan", "write"), ("list_sites", "read")],
+    )
+    def test_falls_back_to_classification(self, tool_name: str, expected: str) -> None:
+        route_only = RoutePolicy("/a2a/audit", ("GET",), "admin", "none", 7)
+        controller = SafetyController(policies=[route_only])
+
+        assert controller._find_policy(tool_name).requiredAuth == expected
+
+    def test_an_empty_policy_list_falls_back_to_the_defaults(self) -> None:
+        controller = SafetyController(policies=[])
+
+        assert controller._find_policy("delete_site").path == "tool://*"
+
+
+class TestRequiresConfirmation:
+    """Tests for SafetyController.requires_confirmation."""
+
+    @pytest.mark.parametrize("key", ["confirm", "confirmed", "confirmation", "approve"])
+    def test_an_explicit_confirmation_flag_short_circuits(
+        self, controller: SafetyController, key: str
+    ) -> None:
+        assert controller.requires_confirmation("delete_site", {key: True}) is False
+
+    def test_destructive_tools_require_confirmation(self, controller: SafetyController) -> None:
+        assert controller.requires_confirmation("delete_site", {}) is True
+
+    def test_write_tools_with_a_mutating_marker_require_confirmation(
+        self, controller: SafetyController
+    ) -> None:
+        assert controller.requires_confirmation("update_site", {}) is True
+
+    def test_plain_write_tools_do_not_require_confirmation(
+        self, controller: SafetyController
+    ) -> None:
+        assert controller.requires_confirmation("adopt_device", {}) is False
+
+    def test_write_tools_honour_an_explicit_request(self, controller: SafetyController) -> None:
+        result = controller.requires_confirmation("adopt_device", {"requires_confirmation": True})
+
+        assert result is True
+
+    def test_read_tools_do_not_require_confirmation(self, controller: SafetyController) -> None:
+        assert controller.requires_confirmation("list_sites", {}) is False
+
+    def test_read_tools_honour_an_explicit_request(self, controller: SafetyController) -> None:
+        result = controller.requires_confirmation("list_sites", {"requires_confirmation": True})
+
+        assert result is True
+
+
+class TestCheckRateLimit:
+    """Tests for SafetyController.check_rate_limit."""
+
+    def test_allows_calls_up_to_the_limit_then_blocks(self) -> None:
+        policy = RoutePolicy("tool://*", ("POST",), "read", "none", 2)
+        controller = SafetyController(policies=[policy])
+
+        assert controller.check_rate_limit("agent-a", "list_sites") is True
+        assert controller.check_rate_limit("agent-a", "list_sites") is True
+        assert controller.check_rate_limit("agent-a", "list_sites") is False
+
+    def test_limits_are_tracked_per_agent(self) -> None:
+        policy = RoutePolicy("tool://*", ("POST",), "read", "none", 1)
+        controller = SafetyController(policies=[policy])
+
+        assert controller.check_rate_limit("agent-a", "list_sites") is True
+        assert controller.check_rate_limit("agent-b", "list_sites") is True
+
+    def test_limits_are_tracked_per_tool(self) -> None:
+        controller = SafetyController(policies=[])
+
+        assert controller.check_rate_limit("agent-a", "delete_site") is True
+        assert controller.check_rate_limit("agent-a", "remove_site") is True
+
+    def test_entries_older_than_the_window_are_evicted(self, local_settings: Settings) -> None:
+        local_settings.rate_limit_period = 60
+        policy = RoutePolicy("tool://*", ("POST",), "read", "none", 1)
+        controller = SafetyController(local_settings, policies=[policy])
+        stale = datetime.now(tz=timezone.utc).timestamp() - 3600
+        controller._request_windows[("agent-a", "list_sites")].append(stale)
+
+        assert controller.check_rate_limit("agent-a", "list_sites") is True
+
+
+class TestPermissionsAllow:
+    """Tests for SafetyController._permissions_allow."""
+
+    def test_admin_allows_everything(self, controller: SafetyController) -> None:
+        assert controller._permissions_allow({"admin"}, "destructive") is True
+
+    @pytest.mark.parametrize("permission", ["read", "write", "destructive"])
+    def test_read_accepts_any_permission(
+        self, controller: SafetyController, permission: str
+    ) -> None:
+        assert controller._permissions_allow({permission}, "read") is True
+
+    def test_write_rejects_read_only(self, controller: SafetyController) -> None:
+        assert controller._permissions_allow({"read"}, "write") is False
+
+    def test_destructive_requires_the_destructive_permission(
+        self, controller: SafetyController
+    ) -> None:
+        assert controller._permissions_allow({"write"}, "destructive") is False
+        assert controller._permissions_allow({"destructive"}, "destructive") is True
+
+    def test_unknown_requirements_are_matched_literally(self, controller: SafetyController) -> None:
+        assert controller._permissions_allow({"custom"}, "custom") is True
+        assert controller._permissions_allow({"read"}, "custom") is False
+
+    def test_comparison_is_case_insensitive(self, controller: SafetyController) -> None:
+        assert controller._permissions_allow({"ADMIN"}, "destructive") is True
+
+
+class TestValidateSafetyConstraints:
+    """Tests for SafetyController.validate_safety_constraints."""
+
+    def test_missing_auth_is_rejected(self, controller: SafetyController) -> None:
+        result = controller.validate_safety_constraints("list_sites", {}, None)
+
+        assert result.allowed is False
+        assert result.reason == "authentication required"
+        assert result.risk_level == "read"
+
+    def test_insufficient_permissions_are_rejected(self, controller: SafetyController) -> None:
+        result = controller.validate_safety_constraints(
+            "delete_site", {"confirm": True}, auth({"read"})
+        )
+
+        assert result.allowed is False
+        assert "missing required permission" in result.reason
+
+    def test_a_confirmed_destructive_call_is_allowed(self, controller: SafetyController) -> None:
+        result = controller.validate_safety_constraints(
+            "delete_site", {"confirm": True}, auth({"destructive"})
+        )
+
+        assert result.allowed is True
+        assert result.reason == "allowed"
+        assert result.risk_level == "destructive"
+
+    def test_an_unconfirmed_destructive_call_requests_confirmation(
+        self, controller: SafetyController
+    ) -> None:
+        result = controller.validate_safety_constraints("delete_site", {}, auth({"destructive"}))
+
+        assert result.allowed is False
+        assert result.requires_confirmation is True
+        assert result.reason == "confirmation required"
+
+    def test_rate_limited_calls_are_reported(self) -> None:
+        policy = RoutePolicy("tool://*", ("POST",), "read", "none", 1)
+        controller = SafetyController(policies=[policy])
+        controller.validate_safety_constraints("list_sites", {}, auth())
+
+        result = controller.validate_safety_constraints("list_sites", {}, auth())
+
+        assert result.allowed is False
+        assert result.rate_limited is True
+        assert result.reason == "rate limit exceeded"
+
+    @pytest.mark.parametrize("key", ["agent_id", "client_id", "subject", "sub"])
+    def test_the_agent_identity_is_read_from_any_known_claim(self, key: str) -> None:
+        policy = RoutePolicy("tool://*", ("POST",), "read", "none", 1)
+        controller = SafetyController(policies=[policy])
+
+        controller.validate_safety_constraints("list_sites", {}, auth(**{key: "agent-a"}))
+
+        assert ("agent-a", "list_sites") in controller._request_windows
+
+    def test_an_unidentified_caller_is_tracked_as_anonymous(self) -> None:
+        controller = SafetyController(policies=[])
+
+        controller.validate_safety_constraints("list_sites", {}, auth())
+
+        assert ("anonymous", "list_sites") in controller._request_windows
+
+    def test_a_wildcard_policy_is_replaced_by_the_inferred_policy(self) -> None:
+        policy = RoutePolicy("tool://*", ("POST",), "read", "standard", 100)
+        controller = SafetyController(policies=[policy])
+
+        result = controller.validate_safety_constraints(
+            "delete_site", {"confirm": True}, auth({"read"})
+        )
+
+        assert result.allowed is False
+        assert result.policy is not None
+        assert result.policy.requiredAuth == "destructive"
+
+    def test_a_context_without_permissions_is_rejected(self, controller: SafetyController) -> None:
+        result = controller.validate_safety_constraints(
+            "list_sites", {}, SimpleNamespace(permissions=None, credentials={})
+        )
+
+        assert result.allowed is False
+
+
+class TestConfirmationWorkflow:
+    """Tests for ConfirmationWorkflow."""
+
+    @pytest.fixture
+    def workflow(self) -> ConfirmationWorkflow:
+        return ConfirmationWorkflow()
+
+    def test_request_confirmation_issues_a_unique_token(
+        self, workflow: ConfirmationWorkflow
+    ) -> None:
+        first = workflow.request_confirmation("delete_site", {"site_id": "s"}, "destructive")
+        second = workflow.request_confirmation("delete_site", {"site_id": "s"}, "destructive")
+
+        assert first.token != second.token
+        assert first.tool_name == "delete_site"
+        assert first.reason == "destructive"
+        assert first.expires_at > first.created_at
+
+    def test_the_ttl_controls_the_expiry(self) -> None:
+        token = ConfirmationWorkflow(ttl_seconds=30).request_confirmation("delete_site", {}, "why")
+
+        assert token.expires_at - token.created_at == timedelta(seconds=30)
+
+    def test_a_boolean_response_approves_or_denies(self, workflow: ConfirmationWorkflow) -> None:
+        token = workflow.request_confirmation("delete_site", {}, "why")
+
+        assert workflow.verify_confirmation(token, True) is True
+        assert workflow.verify_confirmation(token, False) is False
+
+    @pytest.mark.parametrize("response", ["true", "YES", "approved", "confirm"])
+    def test_an_affirmative_word_is_not_enough_on_its_own(
+        self, workflow: ConfirmationWorkflow, response: str
+    ) -> None:
+        """A string response doubles as the token, so a bare 'yes' is rejected."""
+        token = workflow.request_confirmation("delete_site", {}, "why")
+
+        assert workflow.verify_confirmation(token, response) is False
+
+    def test_a_string_response_that_looks_like_a_token_must_match(
+        self, workflow: ConfirmationWorkflow
+    ) -> None:
+        token = workflow.request_confirmation("delete_site", {}, "why")
+
+        assert workflow.verify_confirmation(token, "not-the-token") is False
+
+    def test_the_issued_token_string_is_accepted_as_the_response(
+        self, workflow: ConfirmationWorkflow
+    ) -> None:
+        token = workflow.request_confirmation("delete_site", {}, "why")
+
+        assert workflow.verify_confirmation(token.token, token.token) is False
+
+    @pytest.mark.parametrize("key", ["approved", "confirmed", "ok", "allow"])
+    def test_mapping_responses_approve_on_any_known_key(
+        self, workflow: ConfirmationWorkflow, key: str
+    ) -> None:
+        token = workflow.request_confirmation("delete_site", {}, "why")
+
+        assert workflow.verify_confirmation(token, {key: True}) is True
+
+    def test_a_mapping_response_may_echo_the_token(self, workflow: ConfirmationWorkflow) -> None:
+        token = workflow.request_confirmation("delete_site", {}, "why")
+
+        assert workflow.verify_confirmation(token, {"approved": True, "token": token.token}) is True
+
+    def test_a_mapping_response_with_the_wrong_token_is_rejected(
+        self, workflow: ConfirmationWorkflow
+    ) -> None:
+        token = workflow.request_confirmation("delete_site", {}, "why")
+
+        result = workflow.verify_confirmation(token, {"approved": True, "token": "wrong"})
+
+        assert result is False
+
+    def test_a_confirmation_token_key_is_also_accepted(
+        self, workflow: ConfirmationWorkflow
+    ) -> None:
+        token = workflow.request_confirmation("delete_site", {}, "why")
+        response = {"approved": True, "confirmation_token": token.token}
+
+        assert workflow.verify_confirmation(token, response) is True
+
+    def test_a_mismatched_params_hash_is_rejected(self, workflow: ConfirmationWorkflow) -> None:
+        token = workflow.request_confirmation("delete_site", {"site_id": "s"}, "why")
+
+        result = workflow.verify_confirmation(token, {"approved": True, "params_hash": "wrong"})
+
+        assert result is False
+
+    def test_a_matching_params_hash_is_accepted(self, workflow: ConfirmationWorkflow) -> None:
+        params = {"site_id": "s"}
+        token = workflow.request_confirmation("delete_site", params, "why")
+        response = {"approved": True, "params_hash": SafetyController._params_hash(params)}
+
+        assert workflow.verify_confirmation(token, response) is True
+
+    def test_other_response_types_are_coerced_to_a_boolean(
+        self, workflow: ConfirmationWorkflow
+    ) -> None:
+        token = workflow.request_confirmation("delete_site", {}, "why")
+
+        assert workflow.verify_confirmation(token, [1]) is True
+        assert workflow.verify_confirmation(token, []) is False
+
+    def test_approval_marks_the_stored_token_confirmed(
+        self, workflow: ConfirmationWorkflow
+    ) -> None:
+        token = workflow.request_confirmation("delete_site", {}, "why")
+
+        workflow.verify_confirmation(token, True)
+
+        assert workflow._tokens[token.token].confirmed is True
+
+    def test_an_unknown_token_is_rejected(self, workflow: ConfirmationWorkflow) -> None:
+        assert workflow.verify_confirmation("never-issued", True) is False
+
+    def test_an_expired_token_is_rejected_and_discarded(self) -> None:
+        workflow = ConfirmationWorkflow(ttl_seconds=-1)
+        token = workflow.request_confirmation("delete_site", {}, "why")
+
+        assert workflow.verify_confirmation(token, True) is False
+        assert token.token not in workflow._tokens
+
+    def test_expire_confirmation_removes_the_token(self, workflow: ConfirmationWorkflow) -> None:
+        token = workflow.request_confirmation("delete_site", {}, "why")
+
+        workflow.expire_confirmation(token)
+
+        assert workflow.verify_confirmation(token, True) is False
+
+    def test_expire_confirmation_accepts_a_raw_token_string(
+        self, workflow: ConfirmationWorkflow
+    ) -> None:
+        token = workflow.request_confirmation("delete_site", {}, "why")
+
+        workflow.expire_confirmation(token.token)
+
+        assert token.token not in workflow._tokens
+
+    def test_expiring_an_unknown_token_is_a_no_op(self, workflow: ConfirmationWorkflow) -> None:
+        workflow.expire_confirmation("never-issued")

--- a/tests/unit/a2a/test_types.py
+++ b/tests/unit/a2a/test_types.py
@@ -1,0 +1,206 @@
+"""Unit tests for src/a2a/types.py."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+from enum import Enum
+from pathlib import Path
+
+import pytest
+
+from src.a2a.types import (
+    A2AJSONEncoder,
+    AgentCard,
+    AuthenticationMode,
+    DelegationContract,
+    ResourceURI,
+    SafetyRequirement,
+    Skill,
+)
+
+
+def make_skill() -> Skill:
+    """Build a representative skill."""
+    return Skill(
+        name="list_site_clients",
+        description="List clients for a site.",
+        inputSchema={"type": "object"},
+        outputSchema={"type": "object"},
+        examples=[{"tool": "list_site_clients", "arguments": {}}],
+    )
+
+
+class TestAuthenticationMode:
+    """Tests for the AuthenticationMode enum."""
+
+    def test_values(self) -> None:
+        assert AuthenticationMode.LOCAL.value == "local"
+        assert AuthenticationMode.CLOUD.value == "cloud"
+        assert AuthenticationMode.BOTH.value == "both"
+
+    def test_behaves_as_a_string(self) -> None:
+        assert AuthenticationMode.LOCAL == "local"
+
+
+class TestA2AJSONEncoder:
+    """Tests for A2AJSONEncoder."""
+
+    def test_encodes_dataclasses(self) -> None:
+        payload = json.loads(json.dumps(make_skill(), cls=A2AJSONEncoder))
+
+        assert payload["name"] == "list_site_clients"
+
+    def test_encodes_enums_by_value(self) -> None:
+        class Colour(Enum):
+            RED = "red"
+
+        assert json.dumps(Colour.RED, cls=A2AJSONEncoder) == '"red"'
+
+    def test_string_enums_serialize_as_their_value(self) -> None:
+        assert json.dumps(AuthenticationMode.BOTH, cls=A2AJSONEncoder) == '"both"'
+
+    def test_encodes_datetimes_and_dates_as_iso_strings(self) -> None:
+        moment = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        assert json.dumps(moment, cls=A2AJSONEncoder) == f'"{moment.isoformat()}"'
+        assert json.dumps(date(2026, 1, 1), cls=A2AJSONEncoder) == '"2026-01-01"'
+
+    def test_encodes_paths_as_strings(self) -> None:
+        target = Path("logs") / "audit.jsonl"
+
+        assert json.dumps(target, cls=A2AJSONEncoder) == json.dumps(str(target))
+
+    def test_encodes_sets_as_sorted_lists(self) -> None:
+        assert json.dumps({"b", "a"}, cls=A2AJSONEncoder) == '["a", "b"]'
+
+    def test_unsupported_types_still_raise(self) -> None:
+        with pytest.raises(TypeError):
+            json.dumps(object(), cls=A2AJSONEncoder)
+
+
+class TestSkill:
+    """Tests for Skill."""
+
+    def test_to_dict_round_trips(self) -> None:
+        payload = make_skill().to_dict()
+
+        assert payload["name"] == "list_site_clients"
+        assert payload["examples"][0]["tool"] == "list_site_clients"
+
+
+class TestResourceURI:
+    """Tests for ResourceURI."""
+
+    def test_to_dict_round_trips(self) -> None:
+        resource = ResourceURI(
+            uri="unifi://sites",
+            name="sites",
+            description="All sites.",
+            mimeType="application/json",
+        )
+
+        assert resource.to_dict() == {
+            "uri": "unifi://sites",
+            "name": "sites",
+            "description": "All sites.",
+            "mimeType": "application/json",
+        }
+
+
+class TestSafetyRequirement:
+    """Tests for SafetyRequirement."""
+
+    def test_optional_fields_default_to_none(self) -> None:
+        requirement = SafetyRequirement(
+            confirmationLevel="required", destructive=True, sensitiveFields=["confirm"]
+        )
+
+        assert requirement.toolName is None
+        assert requirement.reason is None
+
+    def test_to_dict_round_trips(self) -> None:
+        requirement = SafetyRequirement("required", True, ["confirm"], "delete_site", "Deletes.")
+
+        assert requirement.to_dict() == {
+            "confirmationLevel": "required",
+            "destructive": True,
+            "sensitiveFields": ["confirm"],
+            "toolName": "delete_site",
+            "reason": "Deletes.",
+        }
+
+
+class TestDelegationContract:
+    """Tests for DelegationContract."""
+
+    def test_optional_fields_default_sensibly(self) -> None:
+        contract = DelegationContract(
+            contractId="c1",
+            toolName="list_site_clients",
+            params={},
+            requestingAgent="agent-a",
+            authenticationMode=AuthenticationMode.BOTH,
+            createdAt="2026-01-01T00:00:00+00:00",
+            requiresConfirmation=False,
+        )
+
+        assert contract.safetyRequirement is None
+        assert contract.metadata is None
+        assert contract.dryRun is False
+
+    def test_to_dict_nests_the_safety_requirement(self) -> None:
+        contract = DelegationContract(
+            contractId="c1",
+            toolName="delete_site",
+            params={"confirm": True},
+            requestingAgent="agent-a",
+            authenticationMode=AuthenticationMode.LOCAL,
+            createdAt="2026-01-01T00:00:00+00:00",
+            requiresConfirmation=True,
+            safetyRequirement=SafetyRequirement("required", True, ["confirm"]),
+        )
+
+        payload = contract.to_dict()
+
+        assert payload["safetyRequirement"]["destructive"] is True
+        assert json.dumps(payload, cls=A2AJSONEncoder)
+
+
+class TestAgentCard:
+    """Tests for AgentCard."""
+
+    def test_defaults_to_the_a2a_protocol(self) -> None:
+        card = AgentCard(
+            name="UniFi",
+            version="1.0.0",
+            description="UniFi MCP server.",
+            authenticationMode=AuthenticationMode.BOTH,
+            skills=[],
+            resources=[],
+            safetyRequirements=[],
+            integrationExamples=[],
+        )
+
+        assert card.protocol == "A2A"
+        assert card.metadata is None
+
+    def test_to_dict_serializes_nested_members(self) -> None:
+        card = AgentCard(
+            name="UniFi",
+            version="1.0.0",
+            description="UniFi MCP server.",
+            authenticationMode=AuthenticationMode.BOTH,
+            skills=[make_skill()],
+            resources=[ResourceURI("unifi://sites", "sites", "All sites.", "application/json")],
+            safetyRequirements=[SafetyRequirement("required", True, ["confirm"])],
+            integrationExamples=["Ask the agent to list clients."],
+            metadata={"skillCount": 1},
+        )
+
+        payload = card.to_dict()
+
+        assert payload["skills"][0]["name"] == "list_site_clients"
+        assert payload["resources"][0]["uri"] == "unifi://sites"
+        assert payload["safetyRequirements"][0]["confirmationLevel"] == "required"
+        assert json.dumps(payload, cls=A2AJSONEncoder)


### PR DESCRIPTION
## Summary

Every module under `src/a2a/` was at 0% coverage. Writing tests for them surfaced two real bugs, both of which are fixed here — neither could have been noticed while nothing imported these modules.

This also lifts the project total from 73.97% to **80.60%**, crossing the `--cov-fail-under=80` gate that `.github/workflows/ci.yml` already enforces.

Three commits, reviewable independently:

### 1. `fix(a2a): restore Python 3.10 compatibility`

`datetime.UTC` was added in Python 3.11, but `pyproject.toml` declares `requires-python = ">=3.10"` and the CI matrix includes a 3.10 job. Since `src/a2a/__init__.py` imports `audit`, `auth`, `delegation` and `http_handlers`, `import src.a2a` fails outright on 3.10:

```
ImportError: cannot import name 'UTC' from 'datetime'
```

That is the current failure in the `Test (Python 3.10)` job on `main`. Swapped all 17 call sites to `timezone.utc`, which is equivalent and available on every supported version.

### 2. `fix(a2a): populate the default playbook registry lazily`

`src.a2a.playbooks` imports `prompt_playbook`, so importing the playbooks package first evaluates `DEFAULT_PLAYBOOK_REGISTRY = PlaybookRegistry.load_builtin()` while that package is still initializing. `PLAYBOOKS` does not exist yet, the lookup falls back to an empty default, and the registry stays permanently empty.

Reproducer against current `main`:

```python
import src.a2a.playbooks
from src.a2a.prompt_playbook import render_playbook

render_playbook("network_diagnostics")
# KeyError: Unknown playbook: network_diagnostics
```

Import order alone decided whether the documented entry point worked. The registry is now resolved through a helper that refills it on first use. A regression test covers the failing import order.

### 3. `test(a2a): add unit tests for the A2A package`

345 new tests across `agent_card`, `audit`, `auth`, `delegation`, `discovery`, `prompt_playbook`, `route_policy`, `types` and the six bundled playbooks.

| Module | Before | After |
|---|---|---|
| `agent_card.py` | 0% | 99.03% |
| `audit.py` | 0% | 100% |
| `auth.py` | 0% | 98.65% |
| `delegation.py` | 0% | 100% |
| `discovery.py` | 0% | 100% |
| `prompt_playbook.py` | 0% | 100% |
| `route_policy.py` | 0% | 100% |
| `types.py` | 0% | 100% |
| `playbooks/*` (6) | 0% | 100% |

The two modules short of 100% have only unreachable defensive branches left (`isinstance` guards and a `return` after an exhaustive chain).

Tests assert current behaviour rather than intended behaviour where the two differ, so a few read as documentation of sharp edges — for example `ConfirmationWorkflow.verify_confirmation` treats any string response as a candidate token, so a bare `"yes"` is rejected. Happy to split those out if you would rather they were filed as issues.

## Test plan

- [x] `pytest` — 1811 passed, 14 skipped, 0 failures
- [x] `pytest --cov=src --cov-fail-under=80` — 80.60%, gate passes
- [x] `black --check src/ tests/`, `isort --check-only src/ tests/`, `ruff check src/ tests/` — all clean
- [x] Bug 2 reproducer confirmed failing before the fix and passing after
- [x] No source behaviour changed beyond the two fixes above

## Notes

`src/a2a/http_handlers.py` is deliberately left for a follow-up — it needs request-level fixtures and would have made this change hard to review.
