### PR TITLE
chore(tests): use the RFC 7042 documentation MAC range in fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Tests
 
 - Corrected `test_update_ip` to assert the PUT body enables `use_fixedip`, and added `test_update_name_only_does_not_enable_fixedip` to ensure metadata-only updates don't flip the flag.
+- **Fixture MAC moved to the RFC 7042 documentation range**: `test_firewall_policy.py` used `bc:24:11:7d:bf:13`, whose OUI belongs to Proxmox/QEMU — a real VM's address from someone's network. Replaced with `00:00:5e:00:53:01` from the range RFC 7042 reserves for documentation; the value is opaque to every assertion that reads it.
 
 ## [0.4.0] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Tests
 
 - Corrected `test_update_ip` to assert the PUT body enables `use_fixedip`, and added `test_update_name_only_does_not_enable_fixedip` to ensure metadata-only updates don't flip the flag.
-- **Fixture MAC moved to the RFC 7042 documentation range**: `test_firewall_policy.py` used `bc:24:11:7d:bf:13`, whose OUI belongs to Proxmox/QEMU — a real VM's address from someone's network. Replaced with `00:00:5e:00:53:01` from the range RFC 7042 reserves for documentation; the value is opaque to every assertion that reads it.
+- **Fixture MAC moved to the RFC 7042 documentation range**: `test_firewall_policy.py` used a sample client MAC whose OUI belongs to Proxmox/QEMU — a real VM's address from someone's network rather than a synthetic value. Replaced with `00:00:5e:00:53:01` from the range RFC 7042 reserves for documentation; the value is opaque to every assertion that reads it.
 
 ## [0.4.0] - 2026-07-19
 

--- a/tests/unit/models/test_firewall_policy.py
+++ b/tests/unit/models/test_firewall_policy.py
@@ -177,10 +177,10 @@ class TestMatchTarget:
         target = MatchTarget(
             zone_id="zone-123",
             matching_target=MatchingTarget.CLIENT,
-            client_macs=["bc:24:11:7d:bf:13"],
+            client_macs=["00:00:5e:00:53:01"],
         )
         assert target.matching_target == MatchingTarget.CLIENT
-        assert target.client_macs == ["bc:24:11:7d:bf:13"]
+        assert target.client_macs == ["00:00:5e:00:53:01"]
 
     def test_port_matching(self):
         """Should support port matching."""


### PR DESCRIPTION
## Description

**Problem:** `test_firewall_policy.py` uses `bc:24:11:7d:bf:13` as a
sample client MAC. The `bc:24:11` OUI belongs to Proxmox/QEMU, so that is
a real VM's address from someone's network rather than a synthetic one.

**Fix:** replaced with `00:00:5e:00:53:01`, from the range RFC 7042
reserves for documentation. The value is opaque to every assertion that
reads it, so there is no behaviour change.

This is the same hygiene rule the repo's own fixtures follow elsewhere;
documentation-range values make it self-evident to reviewers that no real
network data has leaked into the test suite.

## Type of Change

- [x] Documentation update

(Test-fixture hygiene; no code or behavior change.)

## Testing

- `pytest tests/unit/` passes unchanged — the value is asserted
  opaquely.
- Pre-commit hooks pass for the file this PR touches.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (CHANGELOG.md)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (none — stands alone)

## AI Assistance

This PR was created with assistance from Claude Code.

**Human Review Status:** ✅ Reviewed and approved by @jpennin5
**Testing:** Full unit suite passing.
**Security Review:** Completed — this PR exists to remove a real-world
identifier from the public test suite.