### PR TITLE
Feature/channel planning v2 neighbors

### DIFF
--- a/skills/unifi-channel-planning.md
+++ b/skills/unifi-channel-planning.md
@@ -1,0 +1,162 @@
+---
+name: unifi-channel-planning
+description: >
+  Build an AI-driven non-overlapping WiFi channel plan from UniFi MCP neighbor
+  observations. Use when the task is RF optimization, channel conflict
+  reduction, co-channel interference mitigation, or per-AP channel assignment.
+---
+
+# UniFi Channel Planning
+
+Use this skill to produce a deterministic channel plan from MCP output.
+
+Primary intent:
+- Reduce overlap and co-channel contention.
+- Keep assignments reproducible and explainable.
+- Provide safe change rollout with validation.
+
+## Required MCP Inputs
+
+| Tool | Purpose |
+|---|---|
+| `list_sites` | Select target site |
+| `list_neighboring_aps` | External RF congestion view (`stat/rogueap`) |
+| `list_devices_by_type` | Get managed AP inventory (`type=uap`) |
+| `list_site_internal_ap_neighbors_v2` | Build internal AP-to-AP graph for one site in one call |
+| `list_ap_neighbors_v2` | Optional per-AP drill-down/debug for one AP |
+| `get_device_details` | Read AP model/radio capabilities if needed |
+
+Optional execution tool:
+
+| Tool | Purpose |
+|---|---|
+| `set_ap_radio_channel` | Apply proposed channel per AP/radio |
+
+## Data Contract For Planning
+
+Expected fields from neighbor observations:
+- `ap_mac`: AP that observed the neighbor
+- `bssid` or `mac`: observed AP/BSSID identity
+- `channel`: observed channel number
+- `signal`: RSSI (dBm)
+- `last_seen`: freshness indicator
+- `radio` or `band`: radio context when available
+
+If any field is missing:
+- Drop records without `ap_mac`, `channel`, or `signal`.
+- Keep processing with partial data and log dropped count.
+
+## Correct Data Source Split (Critical)
+
+Use two distinct datasets and do not mix them:
+
+1. Internal AP-to-AP graph (for channel assignment):
+- Primary source: `list_site_internal_ap_neighbors_v2(site_id, start_ms, end_ms, min_rssi)`
+- The tool already executes v2 per-AP neighbor queries and keeps only rows where neighbor `mac` is a managed AP MAC from the same site.
+- Optional fallback/debug: `list_ap_neighbors_v2` per AP.
+- This is the authoritative input for "which site AP sees which other site AP and how strong".
+
+2. External RF pressure (optional tie-breaker):
+- Source: `list_neighboring_aps` (`stat/rogueap`)
+- Represents foreign BSSIDs around the site.
+- Use only as additional congestion context, not as the internal AP graph.
+
+## Planning Rules
+
+1. Scope by band:
+- 2.4 GHz candidates: channels 1-14 (practical non-overlap: 1, 6, 11)
+- 5 GHz candidates: local policy set (for example 36/40/44/48 and DFS set if allowed)
+
+2. Filter weak observations:
+- Default threshold: keep neighbors with `signal >= -85`.
+- For dense environments, use `>= -80`.
+
+3. Build per-AP conflict score:
+- For each AP and candidate channel, sum weighted conflicts from observed neighbors on same or overlapping channels.
+- Stronger RSSI contributes higher penalty.
+- Internal AP-to-AP penalties must be weighted higher than external rogue BSSID penalties.
+
+4. Deterministic assignment:
+- Sort APs by descending neighbor pressure (most constrained first).
+- Assign channel with lowest score.
+- Tie-breaker order must be fixed (for example ascending channel number).
+
+5. Guardrails:
+- Avoid changing all APs at once.
+- Keep at least one stable channel anchor per area.
+- Respect hardware/regulatory constraints reported by UniFi.
+
+## Example Scoring Heuristic
+
+For each observed neighbor relation:
+- Same channel penalty: `p_same = max(0, signal + 100)`
+- Adjacent channel penalty (2.4 GHz): `p_adj = 0.5 * p_same`
+- Non-overlapping channel penalty: `0`
+
+Total candidate score:
+- `score(ap, ch) = sum(penalties from all neighbors seen by ap on/near ch)`
+
+Lower score is better.
+
+## Output Contract
+
+Return a plan table with:
+- `ap_mac`
+- `current_channel`
+- `proposed_channel`
+- `band`
+- `confidence` (`high|medium|low`)
+- `reason` (top 1-3 conflict drivers)
+
+Also return summary metrics:
+- Estimated co-channel conflict delta
+- Number of APs changed
+- APs skipped with reason
+
+## Safe Rollout Workflow
+
+1. Discovery:
+- Run `list_sites` and select `site_id`.
+- Build managed AP set (`type=uap`).
+- Pull internal graph with `list_site_internal_ap_neighbors_v2` over a fixed window (default 24h).
+- If needed, inspect problematic APs with `list_ap_neighbors_v2`.
+- Optionally pull `list_neighboring_aps(site_id, min_rssi=-85)` for external context.
+
+2. Plan:
+- Generate per-AP candidate ranking and proposed channels.
+- Mark risky APs (sparse data, stale `last_seen`, extreme noise).
+
+3. Stage:
+- Apply to small batch first with `set_ap_radio_channel`.
+- Wait validation window and compare client health/events.
+
+4. Expand:
+- Roll out remaining APs in waves.
+- Re-run neighbor scan and adjust.
+
+## Validation Checks
+
+After each rollout wave, verify:
+- AP online state is stable.
+- Client disconnect spikes did not increase.
+- Channel reuse distance improved in dense zones.
+- No AP is assigned unsupported channel width/channel pair.
+
+Pre-plan data-quality checks:
+- Confirm each managed AP has at least one internal neighbor observation in the selected window, otherwise mark low-confidence.
+- Reject impossible RSSI outliers for planning (for example values above -20 dBm or below -95 dBm unless intentionally configured).
+- If internal graph is empty, do not derive channel plan from `rogueap` alone.
+
+## Failure Handling
+
+- If neighbor dataset is empty for a site, do not auto-assign.
+- If an AP has no observations, keep current channel and mark `low` confidence.
+- On per-AP apply failure, continue with others and report partial status.
+- If `list_site_internal_ap_neighbors_v2` reports `skipped_aps`, keep those APs unchanged and mark low confidence.
+- If only `rogueap` is available and internal AP graph is missing, return "insufficient internal data" instead of proposing deterministic AP-to-AP assignments.
+
+## Example Prompt Pattern
+
+"Using `list_neighboring_aps` output for site X, produce a non-overlapping channel
+plan per AP for 2.4 GHz first. Use channels 1/6/11 only, filter signal < -85,
+minimize same-channel conflicts, and return deterministic sorted results with reasons."

--- a/skills/unifi-channel-planning.md
+++ b/skills/unifi-channel-planning.md
@@ -1,7 +1,7 @@
 ---
 name: unifi-channel-planning
 description: >
-  Build an AI-driven non-overlapping WiFi channel plan from UniFi MCP neighbor
+  Build an AI-driven low-interference WiFi channel plan from UniFi MCP neighbor
   observations. Use when the task is RF optimization, channel conflict
   reduction, co-channel interference mitigation, or per-AP channel assignment.
 ---
@@ -21,11 +21,16 @@ Primary intent:
 | Tool | Purpose |
 |---|---|
 | `list_sites` | Select target site |
-| `list_neighboring_aps` | External RF congestion view (`stat/rogueap`) |
 | `list_devices_by_type` | Get managed AP inventory (`type=uap`) |
 | `list_site_internal_ap_neighbors_v2` | Build internal AP-to-AP graph for one site in one call |
-| `list_ap_neighbors_v2` | Optional per-AP drill-down/debug for one AP |
-| `get_device_details` | Read AP model/radio capabilities if needed |
+
+## Conditional / Optional MCP Inputs
+
+| Tool | When to use |
+|---|---|
+| `list_neighboring_aps` | Optional external RF tie-breaker or explanation; do not fetch by default |
+| `list_ap_neighbors_v2` | Per-AP drill-down, debugging, or partial-result validation |
+| `get_device_details` | When radio configuration, current channel, width, or regulatory capabilities are not available from inventory |
 
 Optional execution tool:
 
@@ -39,14 +44,18 @@ Expected fields from neighbor observations:
 
 - `ap_mac`: AP that observed the neighbor
 - `bssid` or `mac`: observed AP/BSSID identity
-- `channel`: observed channel number
+- `channel`: observed neighbor channel number
 - `signal`: RSSI (dBm)
 - `last_seen`: freshness indicator
-- `radio` or `band`: radio context when available
+- `radio` or `band`: required radio/band dimension (`ng`/2.4 GHz or `na`/5 GHz)
+- `channel_width` or `ht`: channel width, required when available for 5 GHz
 
 If any field is missing:
 
 - Drop records without `ap_mac`, `channel`, or `signal`.
+- Do not use records without a band/radio dimension for channel assignment.
+- Keep records without width only for a conservative 20 MHz fallback and mark
+  the affected recommendation medium-confidence.
 - Keep processing with partial data and log dropped count.
 
 ## Correct Data Source Split (Critical)
@@ -66,12 +75,70 @@ Use two distinct datasets and do not mix them:
 - Represents foreign BSSIDs around the site.
 - Use only as additional congestion context, not as the internal AP graph.
 
+## Data Volume Controls
+
+Keep the MCP interaction bounded and return summaries rather than raw payloads:
+
+- Use a fixed planning window, normally 24 hours; shorten it when the graph or
+  response is too large.
+- Pass `min_rssi` during collection (`-85` by default, `-80` for dense sites)
+  instead of collecting all weak observations and filtering after output.
+- Prefer `list_site_internal_ap_neighbors_v2` because it aggregates the
+  per-AP v2 calls server-side. Do not repeat `list_ap_neighbors_v2` for every
+  AP unless debugging a specific AP or validating a partial result.
+- Request AP inventory with an explicit `limit` and `offset` when supported;
+  continue in pages until the managed AP set is complete.
+- Call `list_neighboring_aps` only when external RF pressure is needed for a
+  tie-breaker or explanation. It can contain hundreds of rows and must never
+  be dumped into the planning response by default.
+- Normalize, deduplicate, score, and sort before presenting results. Return
+  metadata, counts, top conflict drivers, and a compact per-AP summary instead
+  of raw JSON.
+- Cap displayed neighbors per AP to the strongest relevant observations and
+  report the total count plus omitted-row count. Offer per-AP drill-down only
+  on request.
+- If a response is still too large, process APs or pages in deterministic
+  batches and merge the normalized results before optimization; never silently
+  truncate the graph.
+
+Required collection metadata:
+
+- `start_ms`, `end_ms`, and `min_rssi`
+- managed AP count and collected edge count
+- dropped, skipped, paged, and omitted-row counts
+- whether external rogue-AP data was collected
+
+When physical AP locations are unavailable:
+
+- Do not block planning on a floor plan, coordinates, or manually supplied
+  zones.
+- Use the normalized internal v2 graph as the measurable overlap proxy:
+  observed AP pairs, RSSI, freshness, band, channel, and width.
+- Do not claim that two APs are physically distant or in separate areas unless
+  that is reported by UniFi or supplied by the operator.
+- Lower confidence for conclusions that depend on unobserved coverage or
+  client roaming between APs.
+- Prefer no-op or small staged changes when the graph is sparse; the planner
+  may still produce a deterministic plan from the telemetry that is available.
+
 ## Planning Rules
 
 1. Scope by band:
 
 - 2.4 GHz candidates: channels 1-14 (practical non-overlap: 1, 6, 11)
-- 5 GHz candidates: local policy set (for example 36/40/44/48 and DFS set if allowed)
+- 5 GHz candidates: local policy set (for example 36/40/44/48 and DFS set if allowed).
+- Plan each band/radio independently. Never score a 2.4 GHz observation against
+  a 5 GHz candidate or use one band to fill missing data in the other.
+- Derive occupied channel ranges from primary channel and width. For 20 MHz,
+  use one channel block; for 40/80 MHz, include every overlapping 20 MHz block
+  in the configured channel range.
+- Before scoring, convert every UniFi radio configuration into a canonical
+  `occupied_20mhz_channels` set.
+- Do not infer occupied blocks solely from a numeric primary channel. Use the
+  UniFi-reported primary/control/center channel and width representation.
+- If UniFi does not provide enough information to determine occupied 20 MHz
+  blocks unambiguously, mark the radio medium-confidence and use the
+  conservative supported interpretation.
 
 2. Filter weak observations:
 
@@ -87,21 +154,86 @@ Use two distinct datasets and do not mix them:
 4. Deterministic assignment:
 
 - Sort APs by descending neighbor pressure (most constrained first).
-- Assign channel with lowest score.
+- Evaluate assignments against the complete internal AP graph, not each AP in
+  isolation. Re-score all graph edges after every proposed assignment so a
+  locally good choice cannot create a global co-channel cluster.
+- Use deterministic greedy global optimization: assign the next most
+  constrained AP, then recompute the complete graph score after each assignment.
+- Select the candidate with the lowest total graph penalty. Use descending
+  pressure and ascending channel order as deterministic tie-breakers.
 - Tie-breaker order must be fixed (for example ascending channel number).
+
+Optimization order is strict:
+
+1. Minimize the complete RF conflict score.
+2. Among equivalent or near-equivalent scores, minimize channel concentration
+  and prefer a balanced population such as `3/3/2` for eight APs on three
+  2.4 GHz channels.
+3. Minimize the number of changes.
+4. Use ascending channel order as the final deterministic tie-breaker.
+
+Default score tolerance:
+
+- Relative tolerance: `2%`
+- Absolute tolerance: `0.01`
+- A candidate is near-equivalent when `candidate_score <= best_score * 1.02`
+  or `candidate_score - best_score <= 0.01`.
+
+For a global 2.4 GHz assignment, score every internal edge using the proposed
+channels of both APs:
+
+- Same channel: `rssi_weight(signal)`
+- Adjacent 2.4 GHz channel: `0.5 * rssi_weight(signal)`
+- Non-overlapping channel: `0`
+
+For 5 GHz, score overlap between the occupied channel ranges. A shared 20 MHz
+block receives the same base penalty, scaled by the fraction of overlapping
+blocks. An 80 MHz AP therefore contributes more spectrum pressure than a 20
+MHz AP when the ranges overlap.
+
+Use deterministic RSSI weight classes instead of assuming a linear RF effect:
+
+- `signal >= -55`: weight `4.0`
+- `-65 <= signal < -55`: weight `3.0`
+- `-75 <= signal < -65`: weight `2.0`
+- `-85 <= signal < -75`: weight `1.0`
+
+Multiply same-channel or overlap penalties by this weight. Keep the raw RSSI
+in the output reason so the score remains explainable.
+
+Before optimization, normalize the internal graph:
+
+- Treat AP-A seeing AP-B and AP-B seeing AP-A as one undirected physical pair.
+- Deduplicate repeated observations within the planning window.
+- Use the most recent valid RSSI per undirected pair, retaining band and width
+  separately. A configurable freshness window may retain the strongest valid
+  observation as secondary context, but must not replace the current value.
+- Never infer the observer's current channel from the `channel` field: it is
+  the observed neighbor/BSSID channel only.
+
+Do not sum an observer's neighbor rows against a candidate while leaving all
+other APs at their current channels. That produces misleading results such as
+moving several APs to channel 11 simply because each AP was evaluated alone.
 
 5. Guardrails:
 
 - Avoid changing all APs at once.
 - Keep at least one stable channel anchor per area.
+- With enough APs to use the practical 2.4 GHz set, keep every candidate
+  channel represented unless measured RF data clearly justifies abandoning one.
+- When topology and RF scores permit, prefer a balanced channel population. For
+  eight APs on three channels, prefer counts of `3/3/2` (in deterministic
+  channel order) over a `4/3/1` or more concentrated distribution.
+- Treat a mathematically lower score that moves many APs or abandons a channel
+  as a candidate for staged review, not as an automatic rollout.
 - Respect hardware/regulatory constraints reported by UniFi.
 
 ## Example Scoring Heuristic
 
 For each observed neighbor relation:
 
-- Same channel penalty: `p_same = max(0, signal + 100)`
-- Adjacent channel penalty (2.4 GHz): `p_adj = 0.5 * p_same`
+- Same channel penalty: `p_same = rssi_weight(signal)`
+- Adjacent channel penalty (2.4 GHz): `p_adj = 0.5 * rssi_weight(signal)`
 - Non-overlapping channel penalty: `0`
 
 Total candidate score:
@@ -145,7 +277,13 @@ Also return summary metrics:
 3. Stage:
 
 - Apply to small batch first with `set_ap_radio_channel`.
+- Rollout defaults: first wave maximum 3 AP radios; subsequent waves maximum
+  25% of remaining changed radios; never change more than 50% of site radios
+  without explicit confirmation.
+- Persist the original channel, width, and power settings for every change.
 - Wait validation window and compare client health/events.
+- If AP instability or client disconnects exceed the configured threshold,
+  restore the persisted settings before continuing.
 
 4. Expand:
 
@@ -164,19 +302,46 @@ After each rollout wave, verify:
 Pre-plan data-quality checks:
 
 - Confirm each managed AP has at least one internal neighbor observation in the selected window, otherwise mark low-confidence.
+- Treat `channel=auto` as unknown current state. Infer it only when the v2
+  graph provides a fresh observation of that AP as a neighbour. Mark the
+  inferred current state and resulting recommendation medium-confidence. If
+  the AP is not observed as a neighbour, keep it unchanged and mark
+  low-confidence.
+- Distinguish the observed neighbor's channel from the observer's channel:
+  the `channel` field on a v2 edge describes the observed neighbor/BSSID.
+- Read the observer's current channel from AP radio configuration or telemetry;
+  never infer it from a row where that AP is the observer. An AP configured as
+  `Auto` may be inferred from a fresh row where its MAC is the observed
+  neighbour, and may be changed to the proposed fixed channel when the plan is
+  explicitly accepted.
 - Reject impossible RSSI outliers for planning (for example values above -20 dBm or below -95 dBm unless intentionally configured).
 - If internal graph is empty, do not derive channel plan from `rogueap` alone.
+
+Confidence must be deterministic:
+
+- `high`: complete internal data, fresh observations, known capabilities, and
+  a clear score improvement or a validated no-op.
+- `medium`: partial or stale data, inferred `Auto` state, missing width, or a
+  marginal score difference.
+- `low`: no or very few observations, skipped APs, unknown capabilities, or an
+  unknown current channel.
 
 ## Failure Handling
 
 - If neighbor dataset is empty for a site, do not auto-assign.
 - If an AP has no observations, keep current channel and mark `low` confidence.
+- If an AP is configured as `Auto` and its current channel is inferred from a
+  fresh neighbour observation, preserve the original `Auto` setting for
+  rollback and allow the accepted plan to set an explicit fixed channel.
 - On per-AP apply failure, continue with others and report partial status.
 - If `list_site_internal_ap_neighbors_v2` reports `skipped_aps`, keep those APs unchanged and mark low confidence.
 - If only `rogueap` is available and internal AP graph is missing, return "insufficient internal data" instead of proposing deterministic AP-to-AP assignments.
+- If the current configuration is already within the accepted score tolerance,
+  return a valid no-op plan with `0 APs changed`; do not manufacture changes.
 
 ## Example Prompt Pattern
 
-"Using `list_neighboring_aps` output for site X, produce a non-overlapping channel
-plan per AP for 2.4 GHz first. Use channels 1/6/11 only, filter signal < -85,
-minimize same-channel conflicts, and return deterministic sorted results with reasons."
+"For site X, use the internal AP neighbor graph to produce a low-interference
+channel plan per AP for 2.4 GHz first. Use channels 1/6/11 only, use minimum
+RSSI -85, minimize same-channel conflicts, and return deterministic sorted
+results with reasons. Fetch external rogue-AP data only if needed for context."

--- a/skills/unifi-channel-planning.md
+++ b/skills/unifi-channel-planning.md
@@ -11,6 +11,7 @@ description: >
 Use this skill to produce a deterministic channel plan from MCP output.
 
 Primary intent:
+
 - Reduce overlap and co-channel contention.
 - Keep assignments reproducible and explainable.
 - Provide safe change rollout with validation.
@@ -35,6 +36,7 @@ Optional execution tool:
 ## Data Contract For Planning
 
 Expected fields from neighbor observations:
+
 - `ap_mac`: AP that observed the neighbor
 - `bssid` or `mac`: observed AP/BSSID identity
 - `channel`: observed channel number
@@ -43,6 +45,7 @@ Expected fields from neighbor observations:
 - `radio` or `band`: radio context when available
 
 If any field is missing:
+
 - Drop records without `ap_mac`, `channel`, or `signal`.
 - Keep processing with partial data and log dropped count.
 
@@ -51,12 +54,14 @@ If any field is missing:
 Use two distinct datasets and do not mix them:
 
 1. Internal AP-to-AP graph (for channel assignment):
+
 - Primary source: `list_site_internal_ap_neighbors_v2(site_id, start_ms, end_ms, min_rssi)`
 - The tool already executes v2 per-AP neighbor queries and keeps only rows where neighbor `mac` is a managed AP MAC from the same site.
 - Optional fallback/debug: `list_ap_neighbors_v2` per AP.
 - This is the authoritative input for "which site AP sees which other site AP and how strong".
 
 2. External RF pressure (optional tie-breaker):
+
 - Source: `list_neighboring_aps` (`stat/rogueap`)
 - Represents foreign BSSIDs around the site.
 - Use only as additional congestion context, not as the internal AP graph.
@@ -64,24 +69,29 @@ Use two distinct datasets and do not mix them:
 ## Planning Rules
 
 1. Scope by band:
+
 - 2.4 GHz candidates: channels 1-14 (practical non-overlap: 1, 6, 11)
 - 5 GHz candidates: local policy set (for example 36/40/44/48 and DFS set if allowed)
 
 2. Filter weak observations:
+
 - Default threshold: keep neighbors with `signal >= -85`.
 - For dense environments, use `>= -80`.
 
 3. Build per-AP conflict score:
+
 - For each AP and candidate channel, sum weighted conflicts from observed neighbors on same or overlapping channels.
 - Stronger RSSI contributes higher penalty.
 - Internal AP-to-AP penalties must be weighted higher than external rogue BSSID penalties.
 
 4. Deterministic assignment:
+
 - Sort APs by descending neighbor pressure (most constrained first).
 - Assign channel with lowest score.
 - Tie-breaker order must be fixed (for example ascending channel number).
 
 5. Guardrails:
+
 - Avoid changing all APs at once.
 - Keep at least one stable channel anchor per area.
 - Respect hardware/regulatory constraints reported by UniFi.
@@ -89,11 +99,13 @@ Use two distinct datasets and do not mix them:
 ## Example Scoring Heuristic
 
 For each observed neighbor relation:
+
 - Same channel penalty: `p_same = max(0, signal + 100)`
 - Adjacent channel penalty (2.4 GHz): `p_adj = 0.5 * p_same`
 - Non-overlapping channel penalty: `0`
 
 Total candidate score:
+
 - `score(ap, ch) = sum(penalties from all neighbors seen by ap on/near ch)`
 
 Lower score is better.
@@ -101,6 +113,7 @@ Lower score is better.
 ## Output Contract
 
 Return a plan table with:
+
 - `ap_mac`
 - `current_channel`
 - `proposed_channel`
@@ -109,6 +122,7 @@ Return a plan table with:
 - `reason` (top 1-3 conflict drivers)
 
 Also return summary metrics:
+
 - Estimated co-channel conflict delta
 - Number of APs changed
 - APs skipped with reason
@@ -116,6 +130,7 @@ Also return summary metrics:
 ## Safe Rollout Workflow
 
 1. Discovery:
+
 - Run `list_sites` and select `site_id`.
 - Build managed AP set (`type=uap`).
 - Pull internal graph with `list_site_internal_ap_neighbors_v2` over a fixed window (default 24h).
@@ -123,26 +138,31 @@ Also return summary metrics:
 - Optionally pull `list_neighboring_aps(site_id, min_rssi=-85)` for external context.
 
 2. Plan:
+
 - Generate per-AP candidate ranking and proposed channels.
 - Mark risky APs (sparse data, stale `last_seen`, extreme noise).
 
 3. Stage:
+
 - Apply to small batch first with `set_ap_radio_channel`.
 - Wait validation window and compare client health/events.
 
 4. Expand:
+
 - Roll out remaining APs in waves.
 - Re-run neighbor scan and adjust.
 
 ## Validation Checks
 
 After each rollout wave, verify:
+
 - AP online state is stable.
 - Client disconnect spikes did not increase.
 - Channel reuse distance improved in dense zones.
 - No AP is assigned unsupported channel width/channel pair.
 
 Pre-plan data-quality checks:
+
 - Confirm each managed AP has at least one internal neighbor observation in the selected window, otherwise mark low-confidence.
 - Reject impossible RSSI outliers for planning (for example values above -20 dBm or below -95 dBm unless intentionally configured).
 - If internal graph is empty, do not derive channel plan from `rogueap` alone.

--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,7 @@ from .tool_registry import register_module_tools
 from .tools import acls as acls_tools
 from .tools import application as application_tools
 from .tools import backups as backups_tools
+from .tools import channel_planning as channel_planning_tools
 from .tools import client_management as client_mgmt_tools
 from .tools import clients as clients_tools
 from .tools import connector as connector_tools
@@ -131,6 +132,7 @@ _LOCAL_TOOL_MODULES = [
     acls_tools,
     application_tools,
     backups_tools,
+    channel_planning_tools,
     client_mgmt_tools,
     clients_tools,
     content_filtering_tools,
@@ -180,6 +182,7 @@ _LOCAL_TOOL_MODULES = [
 
 _PROFILE_MODULES: dict[str, list[Any]] = {
     "network": [
+        channel_planning_tools,
         client_mgmt_tools,
         clients_tools,
         dhcp_tools,
@@ -577,8 +580,9 @@ def main() -> None:
                 "Could not auto-mount A2A routes onto FastMCP app; use A2AHTTPRouter.mount() manually"
             )
 
+        transport = settings.server_transport.value.replace("_", "-")
         mcp.run(
-            transport=settings.server_transport.value,
+            transport=transport,
             host=settings.server_host,
             port=settings.server_port,
         )

--- a/src/main.py
+++ b/src/main.py
@@ -580,7 +580,7 @@ def main() -> None:
                 "Could not auto-mount A2A routes onto FastMCP app; use A2AHTTPRouter.mount() manually"
             )
 
-        transport = settings.server_transport.value.replace("_", "-")
+        transport = settings.server_transport.value
         mcp.run(
             transport=transport,
             host=settings.server_host,

--- a/src/tools/channel_planning.py
+++ b/src/tools/channel_planning.py
@@ -1,0 +1,266 @@
+"""Channel-planning helper tools.
+
+These tools expose RF-neighbor surfaces used to build deterministic WiFi
+channel plans (for example non-overlapping 2.4 GHz assignments).
+"""
+
+import time
+from typing import Any
+
+from ..api import UniFiClient
+from ..config import Settings
+from ..utils import (
+    APIError,
+    ResourceNotFoundError,
+    ValidationError,
+    get_logger,
+    sanitize_log_message,
+    validate_mac_address,
+    validate_site_id,
+)
+
+
+def _resolve_window(
+    start_ms: int | None,
+    end_ms: int | None,
+    min_rssi: int | None,
+) -> tuple[int, int]:
+    """Validate planning time-window and RSSI floor and return concrete bounds."""
+    now_ms = int(time.time() * 1000)
+    if end_ms is None:
+        end_ms = now_ms
+    if start_ms is None:
+        start_ms = end_ms - 24 * 3600 * 1000
+
+    if start_ms < 0 or end_ms < 0:
+        raise ValidationError("start_ms and end_ms must be non-negative epoch milliseconds")
+    if end_ms <= start_ms:
+        raise ValidationError("end_ms must be greater than start_ms")
+    if min_rssi is not None and not -100 <= min_rssi <= -20:
+        raise ValidationError(f"min_rssi must be between -100 and -20, got {min_rssi}")
+
+    return start_ms, end_ms
+
+
+def _normalize_neighbors(
+    rows: Any,
+    ap_mac: str,
+    min_rssi: int | None,
+    internal_set: set[str] | None,
+    *,
+    exclude_self: bool,
+) -> tuple[list[dict[str, Any]], int]:
+    """Normalize neighbor rows into a deterministic planning shape."""
+    dropped = 0
+    neighbors: list[dict[str, Any]] = []
+
+    for row in rows if isinstance(rows, list) else []:
+        if not isinstance(row, dict):
+            dropped += 1
+            continue
+
+        neighbor_mac = row.get("mac") or row.get("bssid")
+        channel = row.get("channel")
+        signal = row.get("signal")
+        if neighbor_mac is None or channel is None or signal is None:
+            dropped += 1
+            continue
+
+        try:
+            neighbor_mac_norm = validate_mac_address(str(neighbor_mac))
+            channel_num = int(channel)
+            signal_num = float(signal)
+        except (ValidationError, TypeError, ValueError):
+            dropped += 1
+            continue
+
+        if min_rssi is not None and signal_num < min_rssi:
+            continue
+        if internal_set is not None and neighbor_mac_norm not in internal_set:
+            continue
+        if exclude_self and neighbor_mac_norm == ap_mac:
+            continue
+
+        normalized = dict(row)
+        normalized["ap_mac"] = ap_mac
+        normalized["mac"] = neighbor_mac_norm
+        normalized["channel"] = channel_num
+        normalized["signal"] = signal_num
+        normalized["last_seen"] = (
+            row.get("last_seen")
+            or row.get("lastSeen")
+            or row.get("lastSeenAt")
+            or row.get("lastSeenTimestamp")
+        )
+        normalized["radio"] = row.get("radio") or row.get("band")
+        neighbors.append(normalized)
+
+    return neighbors, dropped
+
+
+def _extract_rows(response: Any) -> list[dict[str, Any]]:
+    """Return response rows from common API list wrappers."""
+    if isinstance(response, list):
+        return [r for r in response if isinstance(r, dict)]
+    if isinstance(response, dict):
+        data = response.get("data", response.get("neighbors", []))
+        if isinstance(data, list):
+            return [r for r in data if isinstance(r, dict)]
+    return []
+
+
+async def list_ap_neighbors_v2(
+    site_id: str,
+    ap_mac: str,
+    settings: Settings,
+    start_ms: int | None = None,
+    end_ms: int | None = None,
+    min_rssi: int | None = None,
+    internal_ap_macs: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """List v2 neighbors observed by one managed AP.
+
+    This exposes the v2 route used by channel-planning workflows:
+    ``/proxy/network/v2/api/site/{site_id}/ap/{ap_mac}/neighbors`` with a
+    timestamp window in epoch milliseconds.
+
+    Args:
+        site_id: Site identifier (UUID or short-name)
+        ap_mac: AP MAC address used as the observation vantage point
+        settings: Application settings
+        start_ms: Window start timestamp (epoch ms). Defaults to 24h ago.
+        end_ms: Window end timestamp (epoch ms). Defaults to now.
+        min_rssi: Optional RSSI floor (e.g. -85)
+        internal_ap_macs: Optional managed AP MAC allowlist. When provided,
+            only neighbor rows whose ``mac`` is in the allowlist are returned.
+
+    Returns:
+        List of normalized neighbor dictionaries sorted by strongest RSSI first
+    """
+    site_id = validate_site_id(site_id)
+    ap_mac = validate_mac_address(ap_mac)
+    start_ms, end_ms = _resolve_window(start_ms, end_ms, min_rssi)
+
+    internal_set: set[str] | None = None
+    if internal_ap_macs is not None:
+        internal_set = {validate_mac_address(mac) for mac in internal_ap_macs}
+
+    logger = get_logger(__name__, settings.log_level)
+
+    async with UniFiClient(settings) as client:
+        await client.authenticate()
+
+        response = await client.get(
+            f"/proxy/network/v2/api/site/{site_id}/ap/{ap_mac}/neighbors",
+            params={"start": start_ms, "end": end_ms},
+        )
+
+        neighbors, dropped = _normalize_neighbors(
+            _extract_rows(response),
+            ap_mac,
+            min_rssi,
+            internal_set,
+            exclude_self=False,
+        )
+
+        neighbors.sort(key=lambda n: n.get("signal") or -999, reverse=True)
+        logger.info(
+            sanitize_log_message(
+                f"Retrieved {len(neighbors)} v2 neighbors for AP '{ap_mac}' in site '{site_id}'"
+                f" (dropped {dropped} malformed rows)"
+            )
+        )
+        return neighbors
+
+
+async def list_site_internal_ap_neighbors_v2(
+    site_id: str,
+    settings: Settings,
+    start_ms: int | None = None,
+    end_ms: int | None = None,
+    min_rssi: int | None = None,
+) -> dict[str, Any]:
+    """Build the internal AP-to-AP neighbor graph for one site.
+
+    This helper discovers managed AP MACs for the site, calls the v2 per-AP
+    neighbors endpoint for each AP, and keeps only rows where neighbor ``mac``
+    belongs to the same managed AP set.
+
+    Args:
+        site_id: Site identifier (UUID or short-name)
+        settings: Application settings
+        start_ms: Window start timestamp (epoch ms). Defaults to 24h ago.
+        end_ms: Window end timestamp (epoch ms). Defaults to now.
+        min_rssi: Optional RSSI floor (e.g. -85)
+
+    Returns:
+        Site-scoped internal-neighbor graph with metadata and normalized edges
+    """
+    site_id = validate_site_id(site_id)
+    start_ms, end_ms = _resolve_window(start_ms, end_ms, min_rssi)
+    logger = get_logger(__name__, settings.log_level)
+
+    async with UniFiClient(settings) as client:
+        await client.authenticate()
+
+        devices_response = await client.get(f"/ea/sites/{site_id}/devices")
+        devices = _extract_rows(devices_response)
+
+        ap_macs: list[str] = []
+        for device in devices:
+            if str(device.get("type") or "").lower() != "uap":
+                continue
+            mac = device.get("mac") or device.get("macAddress") or device.get("mac_address")
+            if not isinstance(mac, str):
+                continue
+            try:
+                ap_macs.append(validate_mac_address(mac))
+            except ValidationError:
+                continue
+
+        ap_macs = sorted(set(ap_macs))
+        internal_set = set(ap_macs)
+
+        edges: list[dict[str, Any]] = []
+        skipped_aps: list[dict[str, str]] = []
+        dropped_total = 0
+
+        for ap_mac in ap_macs:
+            try:
+                response = await client.get(
+                    f"/proxy/network/v2/api/site/{site_id}/ap/{ap_mac}/neighbors",
+                    params={"start": start_ms, "end": end_ms},
+                )
+                normalized, dropped = _normalize_neighbors(
+                    _extract_rows(response),
+                    ap_mac,
+                    min_rssi,
+                    internal_set,
+                    exclude_self=True,
+                )
+                edges.extend(normalized)
+                dropped_total += dropped
+            except (APIError, ResourceNotFoundError, ValidationError) as exc:
+                skipped_aps.append({"ap_mac": ap_mac, "reason": str(exc)})
+
+        edges.sort(key=lambda row: (str(row.get("ap_mac")), str(row.get("mac")), -float(row.get("signal", -999))))
+
+        result = {
+            "site_id": site_id,
+            "start_ms": start_ms,
+            "end_ms": end_ms,
+            "min_rssi": min_rssi,
+            "managed_ap_count": len(ap_macs),
+            "internal_neighbor_edges": edges,
+            "internal_neighbor_edge_count": len(edges),
+            "dropped_rows": dropped_total,
+            "skipped_aps": skipped_aps,
+        }
+
+        logger.info(
+            sanitize_log_message(
+                f"Built internal v2 AP-neighbor graph for site '{site_id}' "
+                f"with {len(edges)} edges across {len(ap_macs)} APs"
+            )
+        )
+        return result

--- a/src/tools/channel_planning.py
+++ b/src/tools/channel_planning.py
@@ -4,6 +4,7 @@ These tools expose RF-neighbor surfaces used to build deterministic WiFi
 channel plans (for example non-overlapping 2.4 GHz assignments).
 """
 
+import asyncio
 import time
 from typing import Any
 
@@ -18,6 +19,10 @@ from ..utils import (
     validate_mac_address,
     validate_site_id,
 )
+
+# Early Access API rate limit is 100 req/min; cap concurrent per-AP neighbor
+# calls so a large site can't burst past it.
+_MAX_CONCURRENT_NEIGHBOR_CALLS = 8
 
 
 def _resolve_window(
@@ -49,9 +54,16 @@ def _normalize_neighbors(
     internal_set: set[str] | None,
     *,
     exclude_self: bool,
-) -> tuple[list[dict[str, Any]], int]:
-    """Normalize neighbor rows into a deterministic planning shape."""
+) -> tuple[list[dict[str, Any]], int, int]:
+    """Normalize neighbor rows into a deterministic planning shape.
+
+    Returns:
+        Tuple of ``(neighbors, dropped, filtered_rssi)`` where ``dropped``
+        counts malformed rows and ``filtered_rssi`` counts well-formed rows
+        excluded solely because they were below ``min_rssi``.
+    """
     dropped = 0
+    filtered_rssi = 0
     neighbors: list[dict[str, Any]] = []
 
     for row in rows if isinstance(rows, list) else []:
@@ -75,6 +87,7 @@ def _normalize_neighbors(
             continue
 
         if min_rssi is not None and signal_num < min_rssi:
+            filtered_rssi += 1
             continue
         if internal_set is not None and neighbor_mac_norm not in internal_set:
             continue
@@ -95,7 +108,7 @@ def _normalize_neighbors(
         normalized["radio"] = row.get("radio") or row.get("band")
         neighbors.append(normalized)
 
-    return neighbors, dropped
+    return neighbors, dropped, filtered_rssi
 
 
 def _extract_rows(response: Any) -> list[dict[str, Any]]:
@@ -141,11 +154,18 @@ async def list_ap_neighbors_v2(
     ap_mac = validate_mac_address(ap_mac)
     start_ms, end_ms = _resolve_window(start_ms, end_ms, min_rssi)
 
+    logger = get_logger(__name__, settings.log_level)
+
     internal_set: set[str] | None = None
     if internal_ap_macs is not None:
-        internal_set = {validate_mac_address(mac) for mac in internal_ap_macs}
-
-    logger = get_logger(__name__, settings.log_level)
+        internal_set = set()
+        for mac in internal_ap_macs:
+            try:
+                internal_set.add(validate_mac_address(mac))
+            except ValidationError:
+                logger.warning(
+                    sanitize_log_message(f"Skipping invalid internal_ap_macs entry: {mac!r}")
+                )
 
     async with UniFiClient(settings) as client:
         await client.authenticate()
@@ -155,7 +175,7 @@ async def list_ap_neighbors_v2(
             params={"start": start_ms, "end": end_ms},
         )
 
-        neighbors, dropped = _normalize_neighbors(
+        neighbors, dropped, filtered_rssi = _normalize_neighbors(
             _extract_rows(response),
             ap_mac,
             min_rssi,
@@ -167,7 +187,7 @@ async def list_ap_neighbors_v2(
         logger.info(
             sanitize_log_message(
                 f"Retrieved {len(neighbors)} v2 neighbors for AP '{ap_mac}' in site '{site_id}'"
-                f" (dropped {dropped} malformed rows)"
+                f" (dropped {dropped} malformed rows, filtered {filtered_rssi} below min_rssi)"
             )
         )
         return neighbors
@@ -185,6 +205,11 @@ async def list_site_internal_ap_neighbors_v2(
     This helper discovers managed AP MACs for the site, calls the v2 per-AP
     neighbors endpoint for each AP, and keeps only rows where neighbor ``mac``
     belongs to the same managed AP set.
+
+    Request budget: one ``/ea/sites/{site_id}/devices`` call plus one v2
+    neighbors call per managed AP, issued with bounded concurrency (max
+    ``_MAX_CONCURRENT_NEIGHBOR_CALLS`` in flight) to stay well under the
+    Early Access API's 100 requests/minute limit.
 
     Args:
         site_id: Site identifier (UUID or short-name)
@@ -224,24 +249,41 @@ async def list_site_internal_ap_neighbors_v2(
         edges: list[dict[str, Any]] = []
         skipped_aps: list[dict[str, str]] = []
         dropped_total = 0
+        filtered_rssi_total = 0
 
-        for ap_mac in ap_macs:
-            try:
+        semaphore = asyncio.Semaphore(_MAX_CONCURRENT_NEIGHBOR_CALLS)
+
+        async def _fetch_ap_neighbors(ap_mac: str) -> tuple[str, Any]:
+            async with semaphore:
                 response = await client.get(
                     f"/proxy/network/v2/api/site/{site_id}/ap/{ap_mac}/neighbors",
                     params={"start": start_ms, "end": end_ms},
                 )
-                normalized, dropped = _normalize_neighbors(
-                    _extract_rows(response),
-                    ap_mac,
-                    min_rssi,
-                    internal_set,
-                    exclude_self=True,
-                )
-                edges.extend(normalized)
-                dropped_total += dropped
-            except (APIError, ResourceNotFoundError, ValidationError) as exc:
-                skipped_aps.append({"ap_mac": ap_mac, "reason": str(exc)})
+                return ap_mac, response
+
+        results = await asyncio.gather(
+            *(_fetch_ap_neighbors(ap_mac) for ap_mac in ap_macs),
+            return_exceptions=True,
+        )
+
+        for ap_mac, outcome in zip(ap_macs, results, strict=True):
+            if isinstance(outcome, BaseException):
+                if isinstance(outcome, (APIError, ResourceNotFoundError, ValidationError)):
+                    skipped_aps.append({"ap_mac": ap_mac, "reason": str(outcome)})
+                    continue
+                raise outcome
+
+            _, response = outcome
+            normalized, dropped, filtered_rssi = _normalize_neighbors(
+                _extract_rows(response),
+                ap_mac,
+                min_rssi,
+                internal_set,
+                exclude_self=True,
+            )
+            edges.extend(normalized)
+            dropped_total += dropped
+            filtered_rssi_total += filtered_rssi
 
         edges.sort(
             key=lambda row: (
@@ -260,6 +302,7 @@ async def list_site_internal_ap_neighbors_v2(
             "internal_neighbor_edges": edges,
             "internal_neighbor_edge_count": len(edges),
             "dropped_rows": dropped_total,
+            "filtered_rssi_rows": filtered_rssi_total,
             "skipped_aps": skipped_aps,
         }
 

--- a/src/tools/channel_planning.py
+++ b/src/tools/channel_planning.py
@@ -243,7 +243,13 @@ async def list_site_internal_ap_neighbors_v2(
             except (APIError, ResourceNotFoundError, ValidationError) as exc:
                 skipped_aps.append({"ap_mac": ap_mac, "reason": str(exc)})
 
-        edges.sort(key=lambda row: (str(row.get("ap_mac")), str(row.get("mac")), -float(row.get("signal", -999))))
+        edges.sort(
+            key=lambda row: (
+                str(row.get("ap_mac")),
+                str(row.get("mac")),
+                -float(row.get("signal", -999)),
+            )
+        )
 
         result = {
             "site_id": site_id,

--- a/tests/unit/tools/test_channel_planning_tools.py
+++ b/tests/unit/tools/test_channel_planning_tools.py
@@ -127,7 +127,10 @@ class TestListSiteInternalApNeighborsV2:
         assert client.get.call_args_list[0][0][0] == "/ea/sites/default/devices"
         assert result["managed_ap_count"] == 2
         assert result["internal_neighbor_edge_count"] == 2
-        assert all(edge["mac"] in {"00:00:5e:00:53:41", "00:00:5e:00:53:42"} for edge in result["internal_neighbor_edges"])
+        assert all(
+            edge["mac"] in {"00:00:5e:00:53:41", "00:00:5e:00:53:42"}
+            for edge in result["internal_neighbor_edges"]
+        )
         assert all(edge["mac"] != edge["ap_mac"] for edge in result["internal_neighbor_edges"])
 
     @pytest.mark.asyncio
@@ -141,9 +144,7 @@ class TestListSiteInternalApNeighborsV2:
         n1 = {"data": [{"mac": "00:00:5e:00:53:42", "channel": 1, "signal": -63}]}
 
         client = _client(get_return={"data": []})
-        client.get = AsyncMock(
-            side_effect=[devices, n1, ValidationError("boom")]
-        )
+        client.get = AsyncMock(side_effect=[devices, n1, ValidationError("boom")])
 
         with patch("src.tools.channel_planning.UniFiClient", return_value=client):
             result = await list_site_internal_ap_neighbors_v2("default", mock_settings)

--- a/tests/unit/tools/test_channel_planning_tools.py
+++ b/tests/unit/tools/test_channel_planning_tools.py
@@ -88,6 +88,50 @@ class TestListApNeighborsV2:
         with pytest.raises(ValidationError, match="Invalid MAC"):
             await list_ap_neighbors_v2("default", "invalid", mock_settings)
 
+    @pytest.mark.asyncio
+    async def test_reports_rssi_filtered_rows_separately_from_dropped(self, mock_settings):
+        rows = [
+            {"mac": "00:00:5e:00:53:60", "channel": 1, "signal": -90},  # below floor
+            {"mac": "not-a-mac", "channel": 6, "signal": -40},  # malformed
+        ]
+        client = _client(get_return={"data": rows})
+
+        with patch("src.tools.channel_planning.UniFiClient", return_value=client):
+            result = await list_ap_neighbors_v2(
+                "default",
+                "00:00:5e:00:53:41",
+                mock_settings,
+                min_rssi=-85,
+            )
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_skips_invalid_internal_ap_macs_entry_instead_of_raising(self, mock_settings):
+        rows = [
+            {"mac": "00:00:5e:00:53:60", "channel": 1, "signal": -67},
+        ]
+        client = _client(get_return={"data": rows})
+
+        with patch("src.tools.channel_planning.UniFiClient", return_value=client):
+            result = await list_ap_neighbors_v2(
+                "default",
+                "00:00:5e:00:53:41",
+                mock_settings,
+                internal_ap_macs=["00:00:5e:00:53:60", "not-a-mac"],
+            )
+
+        assert [n["mac"] for n in result] == ["00:00:5e:00:53:60"]
+
+    @pytest.mark.asyncio
+    async def test_extract_rows_handles_non_list_response(self, mock_settings):
+        client = _client(get_return={"unexpected": "shape"})
+
+        with patch("src.tools.channel_planning.UniFiClient", return_value=client):
+            result = await list_ap_neighbors_v2("default", "00:00:5e:00:53:41", mock_settings)
+
+        assert result == []
+
 
 class TestListSiteInternalApNeighborsV2:
     @pytest.mark.asyncio
@@ -151,3 +195,44 @@ class TestListSiteInternalApNeighborsV2:
 
         assert result["internal_neighbor_edge_count"] == 1
         assert len(result["skipped_aps"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_device_list_yields_empty_graph(self, mock_settings):
+        client = _client(get_return={"data": []})
+
+        with patch("src.tools.channel_planning.UniFiClient", return_value=client):
+            result = await list_site_internal_ap_neighbors_v2("default", mock_settings)
+
+        assert result["managed_ap_count"] == 0
+        assert result["internal_neighbor_edge_count"] == 0
+        assert result["skipped_aps"] == []
+
+    @pytest.mark.asyncio
+    async def test_all_aps_fail_yields_empty_graph_with_skipped_entries(self, mock_settings):
+        devices = {
+            "data": [
+                {"type": "uap", "mac": "00:00:5e:00:53:41"},
+                {"type": "uap", "mac": "00:00:5e:00:53:42"},
+            ]
+        }
+
+        client = _client(get_return={"data": []})
+        client.get = AsyncMock(
+            side_effect=[devices, ValidationError("boom-1"), ValidationError("boom-2")]
+        )
+
+        with patch("src.tools.channel_planning.UniFiClient", return_value=client):
+            result = await list_site_internal_ap_neighbors_v2("default", mock_settings)
+
+        assert result["internal_neighbor_edge_count"] == 0
+        assert len(result["skipped_aps"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_non_list_device_response_yields_no_managed_aps(self, mock_settings):
+        client = _client(get_return={"unexpected": "shape"})
+
+        with patch("src.tools.channel_planning.UniFiClient", return_value=client):
+            result = await list_site_internal_ap_neighbors_v2("default", mock_settings)
+
+        assert result["managed_ap_count"] == 0
+        assert result["internal_neighbor_edges"] == []

--- a/tests/unit/tools/test_channel_planning_tools.py
+++ b/tests/unit/tools/test_channel_planning_tools.py
@@ -1,0 +1,152 @@
+"""Unit tests for channel-planning MCP tools."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.tools.channel_planning import list_ap_neighbors_v2, list_site_internal_ap_neighbors_v2
+from src.utils.exceptions import ValidationError
+
+
+@pytest.fixture
+def mock_settings():
+    settings = MagicMock()
+    settings.log_level = "INFO"
+    settings.api_type = MagicMock()
+    settings.api_type.value = "local"
+    settings.base_url = "https://192.168.2.1"
+    settings.api_key = "test-key"  # pragma: allowlist secret
+    return settings
+
+
+def _client(get_return=None):
+    client = MagicMock()
+    client.authenticate = AsyncMock()
+    client.get = AsyncMock(return_value=get_return if get_return is not None else {"data": []})
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+class TestListApNeighborsV2:
+    @pytest.mark.asyncio
+    async def test_uses_v2_endpoint_default_window_and_filters(self, mock_settings):
+        rows = [
+            {"mac": "00:00:5e:00:53:60", "channel": 1, "signal": -67, "lastSeen": 1000},
+            {"mac": "00:00:5e:00:53:61", "channel": 11, "signal": -82, "lastSeen": 2000},
+            {"mac": "00:00:5e:00:53:62", "channel": 6, "signal": -90, "lastSeen": 3000},
+            {"mac": "not-a-mac", "channel": 6, "signal": -40},
+            {"mac": "00:00:5e:00:53:63", "signal": -40},
+        ]
+        client = _client(get_return={"data": rows})
+
+        with (
+            patch("src.tools.channel_planning.UniFiClient", return_value=client),
+            patch("src.tools.channel_planning.time.time", return_value=1_000_000.0),
+        ):
+            result = await list_ap_neighbors_v2(
+                "default",
+                "00:00:5e:00:53:41",
+                mock_settings,
+                min_rssi=-85,
+                internal_ap_macs=["00:00:5e:00:53:60", "00:00:5e:00:53:61"],
+            )
+
+        assert (
+            client.get.call_args[0][0]
+            == "/proxy/network/v2/api/site/default/ap/00:00:5e:00:53:41/neighbors"
+        )
+        assert client.get.call_args[1]["params"] == {
+            "start": 1_000_000_000 - 24 * 3600 * 1000,
+            "end": 1_000_000_000,
+        }
+        assert [n["mac"] for n in result] == ["00:00:5e:00:53:60", "00:00:5e:00:53:61"]
+        assert result[0]["ap_mac"] == "00:00:5e:00:53:41"
+        assert result[0]["last_seen"] == 1000
+
+    @pytest.mark.asyncio
+    async def test_validates_window_and_rssi_range(self, mock_settings):
+        with pytest.raises(ValidationError, match="end_ms must be greater"):
+            await list_ap_neighbors_v2(
+                "default",
+                "00:00:5e:00:53:41",
+                mock_settings,
+                start_ms=2000,
+                end_ms=2000,
+            )
+
+        with pytest.raises(ValidationError, match="min_rssi"):
+            await list_ap_neighbors_v2(
+                "default",
+                "00:00:5e:00:53:41",
+                mock_settings,
+                min_rssi=-10,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_ap_mac(self, mock_settings):
+        with pytest.raises(ValidationError, match="Invalid MAC"):
+            await list_ap_neighbors_v2("default", "invalid", mock_settings)
+
+
+class TestListSiteInternalApNeighborsV2:
+    @pytest.mark.asyncio
+    async def test_builds_internal_graph_for_all_managed_aps(self, mock_settings):
+        devices = {
+            "data": [
+                {"type": "uap", "mac": "00:00:5e:00:53:41"},
+                {"type": "uap", "mac": "00:00:5e:00:53:42"},
+                {"type": "usw", "mac": "00:00:5e:00:53:50"},
+            ]
+        }
+        n1 = {
+            "data": [
+                {"mac": "00:00:5e:00:53:42", "channel": 1, "signal": -63, "lastSeen": 1000},
+                {"mac": "00:00:5e:00:53:99", "channel": 6, "signal": -50, "lastSeen": 1000},
+            ]
+        }
+        n2 = {
+            "data": [
+                {"mac": "00:00:5e:00:53:41", "channel": 11, "signal": -68, "lastSeen": 2000},
+                {"mac": "00:00:5e:00:53:42", "channel": 11, "signal": -40, "lastSeen": 2000},
+            ]
+        }
+
+        client = _client(get_return={"data": []})
+        client.get = AsyncMock(side_effect=[devices, n1, n2])
+
+        with patch("src.tools.channel_planning.UniFiClient", return_value=client):
+            result = await list_site_internal_ap_neighbors_v2(
+                "default",
+                mock_settings,
+                start_ms=100,
+                end_ms=200,
+                min_rssi=-85,
+            )
+
+        assert client.get.call_args_list[0][0][0] == "/ea/sites/default/devices"
+        assert result["managed_ap_count"] == 2
+        assert result["internal_neighbor_edge_count"] == 2
+        assert all(edge["mac"] in {"00:00:5e:00:53:41", "00:00:5e:00:53:42"} for edge in result["internal_neighbor_edges"])
+        assert all(edge["mac"] != edge["ap_mac"] for edge in result["internal_neighbor_edges"])
+
+    @pytest.mark.asyncio
+    async def test_continues_when_one_ap_neighbor_call_fails(self, mock_settings):
+        devices = {
+            "data": [
+                {"type": "uap", "mac": "00:00:5e:00:53:41"},
+                {"type": "uap", "mac": "00:00:5e:00:53:42"},
+            ]
+        }
+        n1 = {"data": [{"mac": "00:00:5e:00:53:42", "channel": 1, "signal": -63}]}
+
+        client = _client(get_return={"data": []})
+        client.get = AsyncMock(
+            side_effect=[devices, n1, ValidationError("boom")]
+        )
+
+        with patch("src.tools.channel_planning.UniFiClient", return_value=client):
+            result = await list_site_internal_ap_neighbors_v2("default", mock_settings)
+
+        assert result["internal_neighbor_edge_count"] == 1
+        assert len(result["skipped_aps"]) == 1

--- a/tests/unit/tools/test_events_tools.py
+++ b/tests/unit/tools/test_events_tools.py
@@ -4,7 +4,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.tools.events import list_alarms, list_events, list_neighboring_aps
+from src.tools.events import (
+    list_alarms,
+    list_events,
+    list_neighboring_aps,
+)
 from src.utils.exceptions import ResourceNotFoundError, ValidationError
 
 

--- a/tests/unit/tools/test_events_tools.py
+++ b/tests/unit/tools/test_events_tools.py
@@ -4,11 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.tools.events import (
-    list_alarms,
-    list_events,
-    list_neighboring_aps,
-)
+from src.tools.events import list_alarms, list_events, list_neighboring_aps
 from src.utils.exceptions import ResourceNotFoundError, ValidationError
 
 


### PR DESCRIPTION
## Summary

Adds MCP tools for retrieving internal UniFi AP neighbor data through the Network v2 API.

## Changes

- Add `list_ap_neighbors_v2` for per-AP neighbor inspection.
- Add `list_site_internal_ap_neighbors_v2` to build a site-wide internal AP graph.
- Filter out non-managed APs and self-edges.
- Normalize neighbor data and report skipped APs, dropped (malformed) rows, and RSSI-filtered rows separately.
- Bound concurrency (semaphore, max 8 in flight) for per-AP neighbor calls in `list_site_internal_ap_neighbors_v2` to respect the Early Access API's 100 req/min limit.
- Skip invalid `internal_ap_macs` entries with a warning instead of rejecting the whole call.
- Register the new tools in the appropriate tool profiles.
- Add a new `unifi-channel-planning` skill (skills/unifi-channel-planning.md) that uses the v2 internal graph as its primary data source.
- Add unit tests for filtering, validation, aggregation, partial API failure, empty device list, all-APs-fail, invalid MAC entries, and non-list response shapes.
- Reverted an unrelated `settings.server_transport.value.replace("_", "-")` change in `src/main.py` that had been accidentally bundled into this branch; the transport-value normalization is out of scope here and will be proposed separately with its own rationale/tests if still needed.

## Validation

- **CI status:** This is a fork PR; GitHub gated the `CI` and `Security Scanning` workflow runs behind maintainer approval (`action_required`). They have not executed yet. Requesting a maintainer approve the pending runs so lint, pytest (3.10/3.11/3.12), CodeQL, Bandit, Trivy, OSV, secret scanning, pre-commit, Docker build, and codecov/patch checks actually run before merge.
- `pytest tests/unit/tools/test_channel_planning_tools.py` — **11 passed** locally against current `main` (includes 6 new edge-case tests: empty device list, all-APs-fail, invalid MAC entry in allowlist, non-list response shape, RSSI-vs-dropped counting).
- `black`, `isort`, `ruff` — clean on all changed files (`src/tools/channel_planning.py`, `tests/unit/tools/test_channel_planning_tools.py`, `src/main.py`).
- `detect-secrets scan` — no findings on changed files.
- Live-tested against the CasaMarezaten site (4 managed APs, 19 internal neighbor edges, 0 skipped APs, 0 dropped rows) and the Oosterberg site (17 managed APs — the largest site on this controller, 161 internal neighbor edges, 0 dropped rows, 0 RSSI-filtered rows, 0 skipped APs). Controller version tested: **UniFi Network 10.5.67** (build `atag_10.5.67_35187`).
- Endpoint contract confirmed against the live controller: `/proxy/network/v2/api/site/{site}/ap/{mac}/neighbors` accepts `start`/`end` as epoch-millisecond query params and returned HTTP 200 for all 17 APs on Oosterberg.
- Rate-limit check: with bounded concurrency (max 8 in flight), the 17-AP Oosterberg run completed all per-AP calls in well under 1 second, far inside the EA API's 100 req/min budget. Sequential-worst-case for the largest known site (17 requests) is also well within budget; concurrency bound protects future larger sites.