### PR TITLE
fix(security): enforce MCP trust boundaries

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -39,6 +39,14 @@ UNIFI_CLOUD_API_URL=https://api.ui.com
 # MCP Server Port
 MCP_SERVER_PORT=3000
 
+# Transport defaults to stdio. Every network transport requires a distinct
+# bearer token containing at least 32 random characters.
+MCP_SERVER_TRANSPORT=stdio
+# MCP_AUTH_TOKEN=replace-with-a-random-network-client-token
+
+# Backup downloads are restricted to this directory in the container.
+UNIFI_BACKUP_DIR=/app/backups
+
 # Log Level: DEBUG, INFO, WARNING, ERROR, CRITICAL
 MCP_LOG_LEVEL=INFO
 

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 # Obtain your API key from https://unifi.ui.com
 # Navigate to: Settings → Control Plane → Integrations → Create API Key
 # IMPORTANT: API key is shown only once - save it securely!
+# This file is a template only. The server does not automatically load .env
+# from its working directory. Export values or source an approved file explicitly.
 
 # Required: UniFi API Key
 UNIFI_API_KEY=your-api-key-here
@@ -40,6 +42,8 @@ UNIFI_CLOUD_API_URL=https://api.ui.com
 MCP_SERVER_TRANSPORT=stdio
 MCP_SERVER_HOST=0.0.0.0
 MCP_SERVER_PORT=3000
+# Required only for sse/http/streamable_http; use at least 32 random characters.
+# MCP_AUTH_TOKEN=replace-with-a-random-network-client-token
 MCP_LOG_LEVEL=INFO
 
 # Optional: Rate Limiting
@@ -51,6 +55,7 @@ MCP_LOG_LEVEL=INFO
 # UNIFI_MAX_RETRIES=3
 # UNIFI_RETRY_TOTAL_TIMEOUT=60
 # UNIFI_PROFILE=network
+# UNIFI_BACKUP_DIR=~/.unifi-mcp/backups
 # UNIFI_CONTROLLERS={"main":{"host":"192.168.2.1","site":"default"}}
 # DRY_RUN=false
 # UNIFI_AUDIT_LOG_PATH=./audit.log

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -220,28 +220,28 @@
         "filename": "API.md",
         "hashed_secret": "aecdccc1cf64595b34e0cc152d238daabb32183a",
         "is_verified": false,
-        "line_number": 286
+        "line_number": 288
       },
       {
         "type": "Hex High Entropy String",
         "filename": "API.md",
         "hashed_secret": "4aad81b82c54b35a326e72bb41999cf64cb5300a",
         "is_verified": false,
-        "line_number": 802
+        "line_number": 804
       },
       {
         "type": "Secret Keyword",
         "filename": "API.md",
         "hashed_secret": "4d6177cf672a3a086e9b91cf7e8c6a1798cf2b05",
         "is_verified": false,
-        "line_number": 1002
+        "line_number": 1004
       },
       {
         "type": "Secret Keyword",
         "filename": "API.md",
         "hashed_secret": "1816851d10187b57a93235b52495e615629f906d",
         "is_verified": false,
-        "line_number": 1797
+        "line_number": 1799
       }
     ],
     "GEMINI.md": [
@@ -266,14 +266,14 @@
         "filename": "README.md",
         "hashed_secret": "aecdccc1cf64595b34e0cc152d238daabb32183a",
         "is_verified": false,
-        "line_number": 756
+        "line_number": 791
       },
       {
         "type": "Secret Keyword",
         "filename": "README.md",
         "hashed_secret": "7f48abec62447532005fed3067c99429d41cff78",
         "is_verified": false,
-        "line_number": 1051
+        "line_number": 1089
       }
     ],
     "SECURITY.md": [
@@ -282,7 +282,7 @@
         "filename": "SECURITY.md",
         "hashed_secret": "e133b5083795190eae5d96c0d3a0aff1829dab3e",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 133
       }
     ],
     "SKILL.md": [
@@ -894,5 +894,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-16T05:50:32Z"
+  "generated_at": "2026-08-26T02:11:17Z"
 }

--- a/API.md
+++ b/API.md
@@ -106,7 +106,8 @@ Configure the MCP server using environment variables:
 | `UNIFI_RATE_LIMIT_PERIOD` | Rate limit period in seconds | No | `60` |
 | `UNIFI_REQUEST_TIMEOUT` | Request timeout in seconds | No | `30` |
 | `UNIFI_MAX_RETRIES` | Maximum retry attempts | No | `3` |
-| `UNIFI_PROFILE` | Tool exposure profile: `network`, `protect` (camera/NVR/device/view/event read wired; PTZ/media streams in progress), `access`, `talk`, `drive`, `read-only` | No | unset |
+| `UNIFI_PROFILE` | Tool exposure profile: `network`, `devices`, `security`, `system`, `minimal`, `protect`, `read-only`, or `all` | No | `all` |
+| `UNIFI_BACKUP_DIR` | Approved directory for downloaded backup files | No | `~/.unifi-mcp/backups` |
 | `UNIFI_CONTROLLERS` | JSON/YAML controller registry for multi-controller operation | No | unset |
 | `DRY_RUN` | Preview write/destructive tool actions without execution | No | `false` |
 | `UNIFI_AUDIT_LOG_PATH` | Append-only audit log path | No | `audit.jsonl` |
@@ -116,6 +117,7 @@ Configure the MCP server using environment variables:
 | `MCP_SERVER_TRANSPORT` | Transport: `stdio`, `http`, `sse`, `streamable_http` | No | `stdio` |
 | `MCP_SERVER_HOST` | Server bind address (http/sse transports) | No | `0.0.0.0` |
 | `MCP_SERVER_PORT` | Server port (http/sse transports) | No | `3000` |
+| `MCP_AUTH_TOKEN` | Bearer token for every non-stdio transport (minimum 32 characters) | Network only | - |
 | `LOG_LEVEL` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR` | No | `INFO` |
 
 - Required when `UNIFI_API_TYPE=local`.
@@ -268,7 +270,7 @@ The following metrics are automatically tracked by agnost.ai:
 docker run -i \
   --name unifi-mcp \
   -e UNIFI_API_KEY=your-unifi-api-key \
-  -e UNIFI_API_TYPE=cloud \
+  -e UNIFI_API_TYPE=cloud-ea \
   -e AGNOST_ENABLED=true \
   -e AGNOST_ORG_ID=your-organization-id \
   ghcr.io/enuno/unifi-mcp-server:latest
@@ -3065,7 +3067,7 @@ Download a backup file to local storage.
 
 - `site_id` (string, required): Site identifier
 - `backup_filename` (string, required): Backup filename
-- `output_path` (string, required): Local filesystem path to save
+- `output_path` (string, required): New relative filename beneath `UNIFI_BACKUP_DIR`
 - `verify_checksum` (boolean, optional): Calculate SHA-256 checksum (default: true)
 
 **Returns:**
@@ -3086,7 +3088,7 @@ Download a backup file to local storage.
 result = await mcp.call_tool("download_backup", {
     "site_id": "default",
     "backup_filename": "backup_2025-01-29.unf",
-    "output_path": "/backups/unifi_backup.unf",
+    "output_path": "unifi_backup.unf",
     "verify_checksum": True
 })
 print(f"Downloaded: {result['size_bytes']} bytes")
@@ -3292,7 +3294,7 @@ The assistant will use `trigger_backup` with `backup_type="system"` and `retenti
 
 Uses `list_backups` and filters results to show recent backups with size information.
 
-**Prompt:** "Download my latest network backup to /tmp/emergency-backup.unf and verify the checksum."
+**Prompt:** "Download my latest network backup as emergency-backup.unf and verify the checksum."
 
 The assistant uses `download_backup` with checksum verification enabled for data integrity.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,10 +78,13 @@ pre-commit install --hook-type commit-msg
 
 ### 4. Configure Environment
 
-Create a `.env` file for local development:
+Create an operator-controlled environment file for local development:
 
 ```bash
 cp .env.example .env
+set -a
+. ./.env
+set +a
 ```
 
 #### Obtain Your UniFi API Key
@@ -95,14 +98,15 @@ Before configuring the environment, you need to obtain an API key:
 
 #### Configure Your Environment
 
-Edit the `.env` file with your UniFi API key:
+Edit the file before explicitly sourcing it. The server does not discover or
+load `.env` from its working directory.
 
 ```env
 # Required: Your UniFi API Key
 UNIFI_API_KEY=your-api-key-here
 
 # For cloud API (recommended)
-UNIFI_API_TYPE=cloud
+UNIFI_API_TYPE=cloud-ea
 UNIFI_HOST=api.ui.com
 UNIFI_PORT=443
 UNIFI_VERIFY_SSL=true

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The UniFi MCP Server supports **multiple transport modes** for different deploym
 - ✅ **Network access**: Connect from any MCP client over HTTP
 - ✅ **MCP gateway compatible**: Works with MCP gateways that consolidate servers
 - ⚙️ **Configuration**: `MCP_SERVER_TRANSPORT=sse` + `MCP_SERVER_PORT=3000`
+- 🔐 **Authentication**: Set a separate `MCP_AUTH_TOKEN` (minimum 32 characters)
 - 👉 **Prefer Streamable HTTP below** for any new network-accessible deployment.
 
 ### HTTP 🌐
@@ -172,6 +173,7 @@ The UniFi MCP Server supports **multiple transport modes** for different deploym
 **Standard HTTP transport** — Alternative network mode.
 
 - ⚙️ **Configuration**: `MCP_SERVER_TRANSPORT=http` + `MCP_SERVER_PORT=3000`
+- 🔐 **Authentication**: Set a separate `MCP_AUTH_TOKEN` (minimum 32 characters)
 
 ### Streamable HTTP 🌐 ✅ Recommended for network access
 
@@ -181,6 +183,7 @@ The UniFi MCP Server supports **multiple transport modes** for different deploym
 - ✅ **MCP gateway compatible**: Works with MCP gateways that consolidate servers
 - ✅ **No SSE handshake race**: session initialization is part of the same request/response cycle, avoiding the class of timing issue SSE has with proxies like `mcp-remote`
 - ⚙️ **Configuration**: `MCP_SERVER_TRANSPORT=streamable_http` + `MCP_SERVER_PORT=3000`
+- 🔐 **Authentication**: Set a separate `MCP_AUTH_TOKEN` (minimum 32 characters)
 
 **💡 Recommendation**: Use **STDIO** for local AI clients (Claude Desktop, Cursor). Use **Streamable HTTP** when running behind an MCP gateway or for any other network-accessible deployment — prefer it over SSE, which is kept only for backward compatibility.
 
@@ -188,14 +191,15 @@ The UniFi MCP Server supports **multiple transport modes** for different deploym
 
 To reduce context-window bloat, the server will support named exposure profiles that register only the tools relevant to a given UniFi application area.
 
-### Planned profiles
+### Available profiles
 
-- `network` — network, switching, WiFi, DHCP, DNS, traffic, and client tools
-- `protect` — cameras, NVRs, devices, views, events, talkback, and Protect workflows (read surfaces wired; PTZ/media streams still in progress)
-- `access` — doors, readers, credentials, visitors, and access-control workflows
-- `talk` — UniFi Talk devices, calls, lines, and telephony workflows
-- `drive` — UniFi Drive storage, files, sharing, and drive workflows
+- `network`, `devices`, `security`, `system`, and `minimal` — focused operational groups
+- `protect` — cameras, NVRs, devices, views, and events
 - `read-only` — `get_*`, `list_*`, `stat_*`, and `search_*` tools only
+
+Unknown or API-incompatible profile names stop startup instead of exposing the
+full tool surface. Omit `UNIFI_PROFILE` or use `all` only when the complete
+surface is intended.
 
 ### Intended behavior
 
@@ -210,6 +214,7 @@ To reduce context-window bloat, the server will support named exposure profiles 
 # Set transport to Streamable HTTP
 export MCP_SERVER_TRANSPORT=streamable_http
 export MCP_SERVER_PORT=3000
+export MCP_AUTH_TOKEN='replace-with-at-least-32-random-characters'
 
 # Start the server
 unifi-mcp-server
@@ -228,6 +233,7 @@ services:
       UNIFI_LOCAL_HOST: 192.168.2.1
       MCP_SERVER_TRANSPORT: streamable_http
       MCP_SERVER_PORT: 3000
+      MCP_AUTH_TOKEN: replace-with-at-least-32-random-characters
     ports:
       - "3000:3000"
 ```
@@ -240,7 +246,10 @@ Once running in Streamable HTTP mode, configure your MCP gateway to connect:
 {
   "mcpServers": {
     "unifi": {
-      "url": "http://your-server-ip:3000/mcp"
+      "url": "http://your-server-ip:3000/mcp",
+      "headers": {
+        "Authorization": "Bearer replace-with-your-mcp-auth-token"
+      }
     }
   }
 }
@@ -253,6 +262,7 @@ SSE is kept for backward compatibility only — see the [transport modes](#-tran
 ```bash
 export MCP_SERVER_TRANSPORT=sse
 export MCP_SERVER_PORT=3000
+export MCP_AUTH_TOKEN='replace-with-at-least-32-random-characters'
 unifi-mcp-server
 # Server listening on 0.0.0.0:3000 via sse
 ```
@@ -463,7 +473,7 @@ docker pull ghcr.io/enuno/unifi-mcp-server:latest
 docker run -i -d \
   --name unifi-mcp \
   -e UNIFI_API_KEY=your-api-key \
-  -e UNIFI_API_TYPE=cloud \
+  -e UNIFI_API_TYPE=cloud-ea \
   ghcr.io/enuno/unifi-mcp-server:latest
 
 # OR run with local gateway proxy
@@ -558,6 +568,12 @@ cp .env.example .env
 # Edit .env with your UniFi credentials
 # Required: UNIFI_API_KEY
 # Recommended: UNIFI_API_TYPE=local, UNIFI_LOCAL_HOST=<gateway-ip>
+
+# Explicitly load the operator-controlled file; the server never discovers
+# .env from its working directory.
+set -a
+. ./.env
+set +a
 ```
 
 #### 4. Run Tests
@@ -617,7 +633,7 @@ docker buildx build \
 # Test the image
 docker run -i --rm \
   -e UNIFI_API_KEY=your-key \
-  -e UNIFI_API_TYPE=cloud \
+  -e UNIFI_API_TYPE=cloud-ea \
   unifi-mcp-server:0.2.0
 ```
 
@@ -684,11 +700,13 @@ See [docs/RELEASE_PROCESS.md](docs/RELEASE_PROCESS.md) for the complete release 
 2. Navigate to **Settings → Control Plane → Integrations**
 3. Click **Create API Key**
 4. **Save the key immediately** - it's only shown once!
-5. Store it securely in your `.env` file
+5. Store it in your process environment or approved secret manager
 
-#### Configuration File
+#### Process environment
 
-Create a `.env` file in the project root:
+Export the required values directly, or source an operator-controlled file
+explicitly before startup. The installed server intentionally ignores `.env`
+files discovered in its working directory.
 
 ```env
 # Required: Your UniFi API Key
@@ -738,7 +756,9 @@ WEBHOOK_SECRET=your-webhook-secret-here
 # SUPERMEMORY_API_KEY=your-supermemory-api-key-here
 ```
 
-See `.env.example` for all available options.
+See `.env.example` for all available options, then load it explicitly with
+`set -a; . ./.env; set +a`. Docker Compose may continue using its own `.env`
+interpolation behavior.
 
 ### Running the Server
 
@@ -825,7 +845,7 @@ For cloud API access, use:
         "-e",
         "UNIFI_API_KEY=your-api-key-here",
         "-e",
-        "UNIFI_API_TYPE=cloud",
+        "UNIFI_API_TYPE=cloud-ea",
         "ghcr.io/enuno/unifi-mcp-server:latest"
       ]
     }
@@ -1031,11 +1051,14 @@ See [docs/SKILLS.md](docs/SKILLS.md) for the full guide.
   - `UNIFI_DEFAULT_SITE`: Default site ID (default: default)
   - `UNIFI_SITE_MANAGER_ENABLED`: Enable Site Manager multi-site tools for cloud-ea (default: false)
 - **Tool Scope (reduces LLM context size)**:
-  - `UNIFI_PROFILE`: Load only a subset of tools — `network`, `devices`, `security`, `system`, or `minimal` (default: all tools)
+  - `UNIFI_PROFILE`: Load only a subset of tools — `network`, `devices`, `security`, `system`, `minimal`, `protect`, or `read-only` (default: all tools)
 - **MCP Server Transport**:
   - `MCP_SERVER_TRANSPORT`: Transport mode (`stdio`, `sse`, `http`, `streamable_http`; default: `stdio`)
   - `MCP_SERVER_HOST`: Bind address (default: `0.0.0.0`)
   - `MCP_SERVER_PORT`: Server port (default: `3000`)
+  - `MCP_AUTH_TOKEN`: Required bearer token for every network transport (minimum 32 characters)
+- **Backup downloads**:
+  - `UNIFI_BACKUP_DIR`: Approved destination directory for new backup files (default: `~/.unifi-mcp/backups`)
 
 ### Programmatic Usage
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -102,16 +102,12 @@ from pydantic_settings import BaseSettings
 from pydantic import Field, SecretStr
 
 class Settings(BaseSettings):
-    """Application settings loaded from environment."""
+    """Application settings loaded from the process environment."""
 
     unifi_api_key: SecretStr = Field(..., description="UniFi API Key from unifi.ui.com")
     unifi_api_type: str = Field(default="cloud", description="API type: cloud or local")
     unifi_host: str = Field(default="api.ui.com", description="API host")
     unifi_port: int = Field(default=443, description="API port")
-
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
 
 # Usage with automatic masking
 settings = Settings()
@@ -160,7 +156,9 @@ api_key = SecretStr(os.getenv("UNIFI_API_KEY"))
 
 **Secure Storage Options:**
 
-- Environment variables (`.env` file, never committed)
+- Process environment variables or an approved secret manager. If an
+  operator-managed file is used, source it explicitly; never discover `.env`
+  from an untrusted working directory.
 - AWS Secrets Manager
 - HashiCorp Vault
 - Azure Key Vault

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,11 @@ services:
     stdin_open: true  # Required for STDIO transport (kept for backward compatibility)
     tty: false
     ports:
-      - "${MCP_SERVER_PORT:-3000}:${MCP_SERVER_PORT:-3000}"  # Expose for SSE/HTTP transport
+      - "127.0.0.1:${MCP_SERVER_PORT:-3000}:${MCP_SERVER_PORT:-3000}"  # Loopback by default
     environment:
       # UniFi API Configuration
       UNIFI_API_KEY: ${UNIFI_API_KEY:?UNIFI_API_KEY required}
-      UNIFI_API_TYPE: ${UNIFI_API_TYPE:-cloud}
+      UNIFI_API_TYPE: ${UNIFI_API_TYPE:-cloud-ea}
       UNIFI_HOST: ${UNIFI_HOST:-api.ui.com}
       UNIFI_PORT: ${UNIFI_PORT:-443}
       UNIFI_LOCAL_HOST: ${UNIFI_LOCAL_HOST:-}
@@ -26,15 +26,18 @@ services:
       MCP_SERVER_TRANSPORT: ${MCP_SERVER_TRANSPORT:-stdio}
       MCP_SERVER_HOST: ${MCP_SERVER_HOST:-0.0.0.0}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT:-3000}
+      MCP_AUTH_TOKEN: ${MCP_AUTH_TOKEN:-}
       MCP_LOG_LEVEL: ${MCP_LOG_LEVEL:-INFO}
 
       # Optional: Rate Limiting
       UNIFI_RATE_LIMIT: ${UNIFI_RATE_LIMIT:-100}
       UNIFI_TIMEOUT: ${UNIFI_TIMEOUT:-30}
       UNIFI_MAX_RETRIES: ${UNIFI_MAX_RETRIES:-3}
-      UNIFI_PROFILE: ${UNIFI_PROFILE:-network}
+      # "minimal" is compatible with both cloud and local API modes.
+      UNIFI_PROFILE: ${UNIFI_PROFILE:-minimal}
       DRY_RUN: ${DRY_RUN:-false}
       UNIFI_AUDIT_LOG_PATH: ${UNIFI_AUDIT_LOG_PATH:-/app/audit.log}
+      UNIFI_BACKUP_DIR: ${UNIFI_BACKUP_DIR:-/app/backups}
       UNIFI_METRICS_ENABLED: ${UNIFI_METRICS_ENABLED:-false}
       UNIFI_WEBHOOK_REDIS_URL: ${UNIFI_WEBHOOK_REDIS_URL:-}
       UNIFI_CONTROLLERS: ${UNIFI_CONTROLLERS:-}
@@ -61,6 +64,7 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./audit.log:/app/audit.log
+      - ./backups:/app/backups
     healthcheck:
       test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:3000/health')"]
       interval: 30s

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -164,7 +164,7 @@ The existing profile system is the natural place to add more granular, applicati
 }
 ```
 
-#### Environment variable (shell / .env)
+#### Environment variable (shell)
 
 ```bash
 export UNIFI_API_KEY=your-api-key
@@ -267,4 +267,7 @@ If a tool you need isn't available, either switch profiles or unset `UNIFI_PROFI
 
 **Unknown profile name**
 
-If `UNIFI_PROFILE` is set to an unrecognized value, the server falls back to loading all modules for the API type. Valid values: `network`, `devices`, `security`, `system`, `minimal`, `all` (or unset).
+An unrecognized or API-incompatible profile stops startup. Valid values:
+`network`, `devices`, `security`, `system`, `minimal`, `protect`, `read-only`,
+and `all` (or unset). This fail-closed behavior prevents a typo from exposing
+the complete tool surface.

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,7 +8,8 @@
     "scrape": "node scraper/scrape-api-docs.js",
     "scrape:headed": "node scraper/scrape-api-docs.js --headed",
     "compare": "node compare/diff-api-specs.js",
-    "update-docs": "node update/update-docs.js"
+    "update-docs": "node update/update-docs.js",
+    "test": "node --test tests/*.test.js"
   },
   "devDependencies": {
     "puppeteer": "^24.0.0",

--- a/scripts/scraper/auth/unifi-login.js
+++ b/scripts/scraper/auth/unifi-login.js
@@ -4,6 +4,7 @@
  */
 
 import fs from 'fs/promises';
+import { constants as fsConstants } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { delay } from '../utils/delay.js';
@@ -11,6 +12,21 @@ import { delay } from '../utils/delay.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const COOKIES_FILE = path.join(__dirname, '../../session-cookies.json');
+
+async function rejectCookieSymlink(cookiesFile) {
+  try {
+    const stat = await fs.lstat(cookiesFile);
+    if (stat.isSymbolicLink()) {
+      throw new Error('Session cookie file must not be a symbolic link');
+    }
+    return stat;
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
 
 // Configurable timeouts (can be overridden by environment variables)
 const PASSKEY_TIMEOUT = parseInt(process.env.AUTH_PASSKEY_TIMEOUT || '120000'); // 2 minutes
@@ -21,15 +37,24 @@ const PASSWORD_TIMEOUT = parseInt(process.env.AUTH_PASSWORD_TIMEOUT || '15000');
  * Load existing session cookies if available
  * @returns {Promise<Array|null>} Cookies or null if not found
  */
-export async function loadSessionCookies() {
+export async function loadSessionCookies(cookiesFile = COOKIES_FILE) {
+  let cookieFile;
   try {
-    const cookiesData = await fs.readFile(COOKIES_FILE, 'utf-8');
+    const flags = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW || 0);
+    cookieFile = await fs.open(cookiesFile, flags);
+    const stat = await cookieFile.stat();
+    if (!stat.isFile() || (stat.mode & 0o077) !== 0) {
+      throw new Error('Session cookie file must have owner-only permissions');
+    }
+    const cookiesData = await cookieFile.readFile('utf-8');
     const cookies = JSON.parse(cookiesData);
     console.log('✓ Loaded existing session cookies');
     return cookies;
   } catch (error) {
     console.log('No existing session cookies found');
     return null;
+  } finally {
+    await cookieFile?.close();
   }
 }
 
@@ -37,8 +62,21 @@ export async function loadSessionCookies() {
  * Save session cookies to file
  * @param {Array} cookies - Browser cookies
  */
-export async function saveSessionCookies(cookies) {
-  await fs.writeFile(COOKIES_FILE, JSON.stringify(cookies, null, 2));
+export async function saveSessionCookies(cookies, cookiesFile = COOKIES_FILE) {
+  await rejectCookieSymlink(cookiesFile);
+  const flags =
+    fsConstants.O_WRONLY |
+    fsConstants.O_CREAT |
+    (fsConstants.O_NOFOLLOW || 0);
+  let cookieFile;
+  try {
+    cookieFile = await fs.open(cookiesFile, flags, 0o600);
+    await cookieFile.chmod(0o600);
+    await cookieFile.truncate(0);
+    await cookieFile.writeFile(JSON.stringify(cookies, null, 2), 'utf-8');
+  } finally {
+    await cookieFile?.close();
+  }
   console.log('✓ Session cookies saved');
 }
 
@@ -458,9 +496,9 @@ export async function authenticateUniFi(page, credentials) {
 /**
  * Clear saved session cookies
  */
-export async function clearSessionCookies() {
+export async function clearSessionCookies(cookiesFile = COOKIES_FILE) {
   try {
-    await fs.unlink(COOKIES_FILE);
+    await fs.unlink(cookiesFile);
     console.log('✓ Session cookies cleared');
   } catch (error) {
     // File doesn't exist, nothing to clear

--- a/scripts/tests/unifi-login.test.js
+++ b/scripts/tests/unifi-login.test.js
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+test('session cookies are stored owner-only and symlinks are rejected', async () => {
+  const tempDir = await fs.mkdtemp(path.join('/tmp', 'unifi-cookie-test-'));
+  const cookiePath = path.join(tempDir, 'session-cookies.json');
+  const previousUmask = process.umask(0o000);
+  const moduleUrl = new URL('../scraper/auth/unifi-login.js', import.meta.url);
+  moduleUrl.searchParams.set('test', Date.now().toString());
+  const { clearSessionCookies, loadSessionCookies, saveSessionCookies } = await import(moduleUrl);
+
+  try {
+    await saveSessionCookies([{ name: 'session', value: 'dummy-test-value' }], cookiePath);
+    const stat = await fs.lstat(cookiePath);
+    assert.equal(stat.mode & 0o077, 0);
+    assert.deepEqual(await loadSessionCookies(cookiePath), [
+      { name: 'session', value: 'dummy-test-value' }
+    ]);
+
+    await fs.chmod(cookiePath, 0o644);
+    assert.equal(await loadSessionCookies(cookiePath), null);
+    await saveSessionCookies([{ name: 'session', value: 'replacement' }], cookiePath);
+    const repairedStat = await fs.lstat(cookiePath);
+    assert.equal(repairedStat.mode & 0o077, 0);
+
+    await fs.unlink(cookiePath);
+    await fs.symlink(path.join(tempDir, 'attacker-target'), cookiePath);
+    await assert.rejects(
+      saveSessionCookies([{ name: 'session', value: 'replacement' }], cookiePath),
+      /symbolic link|symlink/i
+    );
+    assert.equal(await loadSessionCookies(cookiePath), null);
+  } finally {
+    process.umask(previousUmask);
+    await clearSessionCookies(cookiePath);
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,6 +1,11 @@
 """API client module for UniFi MCP Server."""
 
-from .client import RateLimiter, UniFiClient
+from .client import RateLimiter, UniFiClient, validate_controller_relative_endpoint
 from .protect_client import ProtectClient
 
-__all__ = ["UniFiClient", "RateLimiter", "ProtectClient"]
+__all__ = [
+    "UniFiClient",
+    "RateLimiter",
+    "ProtectClient",
+    "validate_controller_relative_endpoint",
+]

--- a/src/api/client.py
+++ b/src/api/client.py
@@ -17,9 +17,31 @@ from ..utils import (
     NetworkError,
     RateLimitError,
     ResourceNotFoundError,
+    ValidationError,
     get_logger,
     log_api_request,
 )
+
+
+def validate_controller_relative_endpoint(endpoint: str) -> str:
+    """Require a controller-relative path before attaching credentials.
+
+    Args:
+        endpoint: Candidate UniFi API endpoint.
+
+    Returns:
+        The validated endpoint unchanged.
+
+    Raises:
+        ValidationError: If the value could select or replace an origin.
+    """
+    if not endpoint.startswith("/") or endpoint.startswith("//"):
+        raise ValidationError(
+            "API endpoint must be a controller-relative path beginning with one '/'"
+        )
+    if "\\" in endpoint or any(ord(character) < 32 for character in endpoint):
+        raise ValidationError("API endpoint contains invalid path characters")
+    return endpoint
 
 
 class RateLimiter:
@@ -387,6 +409,8 @@ class UniFiClient:
             RateLimitError: If rate limit is exceeded
             NetworkError: If network communication fails
         """
+        endpoint = validate_controller_relative_endpoint(endpoint)
+
         if started_at is None:
             started_at = time.monotonic()
 
@@ -405,11 +429,7 @@ class UniFiClient:
 
             # Construct full URL explicitly to ensure HTTPS protocol is preserved
             # httpx's base_url joining can have issues with protocol handling
-            full_url = (
-                f"{self.settings.base_url}{translated_endpoint}"
-                if translated_endpoint.startswith("/")
-                else translated_endpoint
-            )
+            full_url = f"{self.settings.base_url}{translated_endpoint}"
 
             # CRITICAL: Ensure HTTPS scheme - force replace http:// with https://
             if full_url.startswith("http://"):

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,5 +1,5 @@
 """Configuration module for UniFi MCP Server."""
 
-from .config import APIType, Settings, TransportMode
+from .config import APIType, Settings, ToolProfile, TransportMode
 
-__all__ = ["Settings", "APIType", "TransportMode"]
+__all__ = ["Settings", "APIType", "ToolProfile", "TransportMode"]

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1,9 +1,10 @@
 """Configuration management for UniFi MCP Server using Pydantic Settings."""
 
 from enum import Enum
+from pathlib import Path
 from typing import Literal
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -27,12 +28,23 @@ class TransportMode(str, Enum):
     STREAMABLE_HTTP = "streamable_http"  # Modern HTTP transport
 
 
+class ToolProfile(str, Enum):
+    """Validated MCP tool exposure profiles."""
+
+    ALL = "all"
+    NETWORK = "network"
+    DEVICES = "devices"
+    SECURITY = "security"
+    SYSTEM = "system"
+    MINIMAL = "minimal"
+    PROTECT = "protect"
+    READ_ONLY = "read-only"
+
+
 class Settings(BaseSettings):
-    """Application settings loaded from environment variables and .env file."""
+    """Application settings loaded from process environment variables."""
 
     model_config = SettingsConfigDict(
-        env_file=".env",
-        env_file_encoding="utf-8",
         case_sensitive=False,
         extra="ignore",
     )
@@ -167,6 +179,12 @@ class Settings(BaseSettings):
         validation_alias="UNIFI_AUDIT_LOG_ENABLED",
     )
 
+    backup_directory: Path = Field(
+        default_factory=lambda: Path.home() / ".unifi-mcp" / "backups",
+        description="Operator-approved directory for downloaded controller backups",
+        validation_alias="UNIFI_BACKUP_DIR",
+    )
+
     # Supermemory Configuration (optional operator notes/context store)
     supermemory_enabled: bool = Field(
         default=False,
@@ -199,6 +217,18 @@ class Settings(BaseSettings):
         validation_alias="MCP_SERVER_PORT",
     )
 
+    mcp_auth_token: SecretStr | None = Field(
+        default=None,
+        description="Bearer token required by every network MCP transport",
+        validation_alias="MCP_AUTH_TOKEN",
+    )
+
+    profile: ToolProfile = Field(
+        default=ToolProfile.ALL,
+        description="Validated MCP tool exposure profile",
+        validation_alias="UNIFI_PROFILE",
+    )
+
     @field_validator("api_type", mode="before")
     @classmethod
     def validate_api_type(cls, v: str) -> APIType:
@@ -212,7 +242,10 @@ class Settings(BaseSettings):
         """
         if isinstance(v, APIType):
             return v
-        return APIType(v.lower())
+        normalized = v.lower()
+        if normalized == "cloud":
+            normalized = APIType.CLOUD_EA.value
+        return APIType(normalized)
 
     @field_validator("local_port")
     @classmethod
@@ -265,18 +298,33 @@ class Settings(BaseSettings):
             return v
         return TransportMode(v.lower())
 
+    @field_validator("profile", mode="before")
+    @classmethod
+    def validate_profile(cls, v: str | ToolProfile) -> ToolProfile:
+        """Normalize profile names while rejecting unknown values."""
+        if isinstance(v, ToolProfile):
+            return v
+        return ToolProfile(v.lower().strip())
+
     @model_validator(mode="after")
-    def validate_local_configuration(self) -> "Settings":
-        """Validate that local API has required configuration.
+    def validate_runtime_configuration(self) -> "Settings":
+        """Validate security-critical runtime configuration.
 
         Returns:
             Validated settings instance
 
         Raises:
-            ValueError: If local API is selected but host is not provided
+            ValueError: If a selected runtime mode lacks required configuration
         """
         if self.api_type == APIType.LOCAL and not self.local_host:
             raise ValueError("local_host is required when api_type is 'local'")
+        if self.server_transport != TransportMode.STDIO:
+            if self.mcp_auth_token is None:
+                raise ValueError(
+                    "MCP_AUTH_TOKEN is required for http, sse, and streamable_http transports"
+                )
+            if len(self.mcp_auth_token.get_secret_value()) < 32:
+                raise ValueError("MCP_AUTH_TOKEN must contain at least 32 characters")
         return self
 
     @property

--- a/src/main.py
+++ b/src/main.py
@@ -14,11 +14,13 @@ except importlib.metadata.PackageNotFoundError:
 
 from fastmcp import FastMCP
 
-from .a2a import A2AHTTPRouter, A2AState
+from .a2a import A2AState
 from .a2a.audit import get_audit_logger
 from .a2a.auth import AuthManager
 from .a2a.route_policy import ConfirmationWorkflow, SafetyController
-from .config import APIType, Settings, TransportMode
+from .api import validate_controller_relative_endpoint
+from .config import APIType, Settings, ToolProfile, TransportMode
+from .mcp_auth import build_mcp_auth, require_authenticated_request
 from .resources import ClientsResource, DevicesResource, NetworksResource, SitesResource
 from .resources import protect as protect_resource
 from .resources import site_manager as site_manager_resource
@@ -66,7 +68,7 @@ from .tools import vouchers as vouchers_tools
 from .tools import vpn as vpn_tools
 from .tools import wans as wans_tools
 from .tools import wifi as wifi_tools
-from .utils import get_logger
+from .utils import audit_on_failure, coerce_bool, get_logger, log_audit, validate_confirmation
 
 # ---------------------------------------------------------------------------
 # Initialisation
@@ -75,7 +77,7 @@ from .utils import get_logger
 settings = Settings()
 logger = get_logger(__name__, settings.log_level)
 
-mcp = FastMCP("UniFi MCP Server")
+mcp = FastMCP("UniFi MCP Server", auth=build_mcp_auth(settings))
 
 # ---------------------------------------------------------------------------
 # Optional: agnost tracking
@@ -174,7 +176,7 @@ _LOCAL_TOOL_MODULES = [
 # Profile-based module filtering (UNIFI_PROFILE env var)
 #
 # Set UNIFI_PROFILE to load only a subset of tools, reducing LLM context size.
-# Valid profiles: network, devices, security, system, minimal, protect
+# Valid profiles: network, devices, security, system, minimal, protect, read-only
 # Omit UNIFI_PROFILE (or set to "all") to load all tools for the API type.
 # ---------------------------------------------------------------------------
 
@@ -244,14 +246,28 @@ _PROFILE_MODULES: dict[str, list[Any]] = {
     ],
 }
 
-_active_profile = os.getenv("UNIFI_PROFILE", "").lower().strip()
+_active_profile = settings.profile.value
+_READ_ONLY_PREFIXES = ("get_", "list_", "stat_", "search_")
+
+
+def _read_only_include(module: Any) -> list[str] | None:
+    """Return a registration allowlist for the read-only profile."""
+    if settings.profile != ToolProfile.READ_ONLY:
+        return None
+    return [name for name in dir(module) if name.startswith(_READ_ONLY_PREFIXES)]
+
 
 _TOOL_MODULES: list[Any] = []
 if settings.api_type in (APIType.CLOUD_V1, APIType.CLOUD_EA):
     _base_modules = list(_CLOUD_TOOL_MODULES)
-    if _active_profile and _active_profile not in ("all", ""):
+    if _active_profile not in ("all", "read-only"):
         _profile_set = set(_PROFILE_MODULES.get(_active_profile, []))
-        _base_modules = [m for m in _base_modules if m in _profile_set] or _base_modules
+        _base_modules = [m for m in _base_modules if m in _profile_set]
+        if not _base_modules:
+            raise ValueError(
+                f"UNIFI_PROFILE={_active_profile!r} has no tools compatible with "
+                f"UNIFI_API_TYPE={settings.api_type.value!r}"
+            )
     _TOOL_MODULES = _base_modules
     logger.info(
         f"Cloud API mode ({settings.api_type.value})"
@@ -262,14 +278,22 @@ if settings.api_type in (APIType.CLOUD_V1, APIType.CLOUD_EA):
     # which all 404 on the live Cloud API
     for _module in _TOOL_MODULES:
         if _module is sites_tools:
-            register_module_tools(mcp, _module, settings, exclude=["get_site_statistics"])
+            register_module_tools(
+                mcp,
+                _module,
+                settings,
+                include=_read_only_include(_module),
+                exclude=["get_site_statistics"],
+            )
         else:
-            register_module_tools(mcp, _module, settings)
+            register_module_tools(mcp, _module, settings, include=_read_only_include(_module))
 else:
     _all_local = list(_CLOUD_TOOL_MODULES) + list(_LOCAL_TOOL_MODULES)
-    if _active_profile and _active_profile not in ("all", ""):
+    if _active_profile not in ("all", "read-only"):
         _profile_set = set(_PROFILE_MODULES.get(_active_profile, []))
-        _TOOL_MODULES = [m for m in _all_local if m in _profile_set] or _all_local
+        _TOOL_MODULES = [m for m in _all_local if m in _profile_set]
+        if not _TOOL_MODULES:
+            raise ValueError(f"UNIFI_PROFILE={_active_profile!r} has no compatible tools")
     else:
         _TOOL_MODULES = _all_local
     logger.info(
@@ -278,7 +302,7 @@ else:
         + f" - registering {len(_TOOL_MODULES)} tool module(s)"
     )
     for _module in _TOOL_MODULES:
-        register_module_tools(mcp, _module, settings)
+        register_module_tools(mcp, _module, settings, include=_read_only_include(_module))
 
 # ---------------------------------------------------------------------------
 # Resource handlers
@@ -313,29 +337,62 @@ async def health_check() -> dict[str, str]:
 
 
 # Conditional debug tool
-if os.getenv("DEBUG", "").lower() in ("true", "1", "yes"):
+if os.getenv("DEBUG", "").lower() in ("true", "1", "yes") and (
+    settings.profile != ToolProfile.READ_ONLY
+):
 
     @mcp.tool()
-    async def debug_api_request(endpoint: str, method: str = "GET") -> dict:
+    async def debug_api_request(
+        endpoint: str,
+        method: str = "GET",
+        confirm: bool | str = False,
+        dry_run: bool | str = False,
+    ) -> dict:
         """Debug tool to query arbitrary UniFi API endpoints.
 
         Args:
             endpoint: API endpoint path (e.g., /proxy/network/api/s/default/rest/networkconf)
             method: HTTP method (GET, POST, PUT, DELETE)
+            confirm: Required for DELETE requests
+            dry_run: Preview a DELETE without sending it
 
         Returns:
             Raw JSON response from the API
         """
         from .api import UniFiClient
 
-        async with UniFiClient(settings) as client:
-            await client.authenticate()
-            if method.upper() == "GET":
+        endpoint = validate_controller_relative_endpoint(endpoint)
+        normalized_method = method.upper()
+        if normalized_method == "DELETE":
+            validate_confirmation(confirm, "debug API DELETE", dry_run)
+            if coerce_bool(dry_run):
+                log_audit(
+                    operation="debug_api_request_delete",
+                    parameters={"endpoint": endpoint},
+                    result="dry_run",
+                    dry_run=True,
+                )
+                return {"dry_run": True, "would_delete": endpoint}
+
+        if normalized_method == "GET":
+            async with UniFiClient(settings) as client:
+                await client.authenticate()
                 return await client.get(endpoint)
-            elif method.upper() == "DELETE":
-                return await client.delete(endpoint)
-            else:
-                return {"error": f"Method {method} requires json_data parameter (not implemented)"}
+
+        if normalized_method == "DELETE":
+            parameters = {"endpoint": endpoint}
+            with audit_on_failure("debug_api_request_delete", parameters):
+                async with UniFiClient(settings) as client:
+                    await client.authenticate()
+                    result = await client.delete(endpoint)
+                log_audit(
+                    operation="debug_api_request_delete",
+                    parameters=parameters,
+                    result="success",
+                )
+                return result
+
+        return {"error": f"Method {method} requires json_data parameter (not implemented)"}
 
 
 # ---------------------------------------------------------------------------
@@ -501,7 +558,7 @@ def main() -> None:
     logger.info("Starting UniFi MCP Server...")
     logger.info(f"API Type: {settings.api_type.value}")
     logger.info(f"Base URL: {settings.base_url}")
-    if _active_profile:
+    if _active_profile != "all":
         logger.info(f"Profile: {_active_profile} ({len(_TOOL_MODULES)} module(s) active)")
 
     # ---------------------------------------------------------------------------
@@ -514,9 +571,6 @@ def main() -> None:
         safety_controller=SafetyController(),
         confirmation_workflow=ConfirmationWorkflow(),
     )
-    a2a_router = A2AHTTPRouter(state=a2a_state)
-    _ = a2a_router  # mounted below onto FastMCP's internal Starlette app
-
     if settings.server_transport == TransportMode.STDIO:
         logger.info("Transport: stdio (default)")
         logger.info("Server ready to handle requests")
@@ -527,8 +581,8 @@ def main() -> None:
         logger.info(
             "A2A endpoints: /a2a/agent-card, /a2a/discover, /a2a/delegate, /a2a/confirm, /a2a/audit"
         )
-        # FastMCP 3.x HTTP transport uses an internal Starlette app; we mount
-        # the A2A router after server startup via a small wrapper.
+        # Register custom A2A routes before FastMCP creates its Starlette app.
+        from starlette.requests import Request
         from starlette.responses import JSONResponse
 
         from .a2a.http_handlers import (
@@ -539,43 +593,37 @@ def main() -> None:
             get_audit_handler,
         )
 
-        async def _a2a_agent_card(request):
+        @mcp.custom_route("/a2a/agent-card", methods=["GET"])
+        async def _a2a_agent_card(request: Request) -> JSONResponse:
+            require_authenticated_request(request)
             return JSONResponse(get_agent_card_handler())
 
-        async def _a2a_discover(request):
+        @mcp.custom_route("/a2a/discover", methods=["POST"])
+        async def _a2a_discover(request: Request) -> JSONResponse:
+            require_authenticated_request(request)
             body = await request.body()
             payload = await request.json() if body else {}
             return JSONResponse(await discover_handler(payload, state=a2a_state))
 
-        async def _a2a_delegate(request):
+        @mcp.custom_route("/a2a/delegate", methods=["POST"])
+        async def _a2a_delegate(request: Request) -> JSONResponse:
+            require_authenticated_request(request)
             payload = await request.json()
             return JSONResponse(await delegate_handler(payload, state=a2a_state))
 
-        async def _a2a_confirm(request):
+        @mcp.custom_route("/a2a/confirm", methods=["POST"])
+        async def _a2a_confirm(request: Request) -> JSONResponse:
+            require_authenticated_request(request)
             payload = await request.json()
             return JSONResponse(await confirm_handler(payload, state=a2a_state))
 
-        async def _a2a_audit(request):
+        @mcp.custom_route("/a2a/audit", methods=["GET"])
+        async def _a2a_audit(request: Request) -> JSONResponse:
+            require_authenticated_request(request)
             payload = dict(request.query_params)
             return JSONResponse(await get_audit_handler(payload, state=a2a_state))
 
-        # Try to mount onto FastMCP's internal Starlette app if available
-        _mounted = False
-        for attr in ("app", "_app", "server", "_server"):
-            app = getattr(mcp, attr, None)
-            if app is not None and hasattr(app, "add_route"):
-                app.add_route("/a2a/agent-card", _a2a_agent_card, methods=["GET"])
-                app.add_route("/a2a/discover", _a2a_discover, methods=["POST"])
-                app.add_route("/a2a/delegate", _a2a_delegate, methods=["POST"])
-                app.add_route("/a2a/confirm", _a2a_confirm, methods=["POST"])
-                app.add_route("/a2a/audit", _a2a_audit, methods=["GET"])
-                logger.info("A2A routes mounted on FastMCP internal app")
-                _mounted = True
-                break
-        if not _mounted:
-            logger.warning(
-                "Could not auto-mount A2A routes onto FastMCP app; use A2AHTTPRouter.mount() manually"
-            )
+        logger.info("Authenticated A2A routes registered")
 
         mcp.run(
             transport=settings.server_transport.value,

--- a/src/mcp_auth.py
+++ b/src/mcp_auth.py
@@ -1,0 +1,50 @@
+"""Authentication boundary for network MCP transports."""
+
+from __future__ import annotations
+
+import secrets
+
+from fastmcp.server.auth import AccessToken, TokenVerifier
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+
+from .config import Settings, TransportMode
+
+
+class ConfiguredBearerTokenVerifier(TokenVerifier):
+    """Verify one operator-configured bearer token in constant time."""
+
+    def __init__(self, token: str) -> None:
+        """Initialize the verifier without exposing the token in metadata."""
+        super().__init__()
+        self._token = token
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Return an authenticated principal only for the configured token."""
+        if not secrets.compare_digest(token.encode(), self._token.encode()):
+            return None
+        return AccessToken(
+            token=token,
+            client_id="configured-mcp-client",
+            scopes=[],
+            claims={"authentication": "configured-bearer-token"},
+        )
+
+
+def require_authenticated_request(request: Request) -> None:
+    """Reject custom HTTP routes unless FastMCP authenticated the request."""
+    try:
+        authenticated = request.user.is_authenticated
+    except AssertionError:
+        authenticated = False
+    if not authenticated:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+
+def build_mcp_auth(settings: Settings) -> TokenVerifier | None:
+    """Build network authentication while preserving token-free stdio."""
+    if settings.server_transport == TransportMode.STDIO:
+        return None
+    if settings.mcp_auth_token is None:  # Defensive; Settings already fails closed.
+        raise ValueError("MCP_AUTH_TOKEN is required for network transports")
+    return ConfiguredBearerTokenVerifier(settings.mcp_auth_token.get_secret_value())

--- a/src/tools/backups.py
+++ b/src/tools/backups.py
@@ -1,6 +1,7 @@
 """Backup and restore operations MCP tools."""
 
 import hashlib
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -284,7 +285,7 @@ async def download_backup(
     Args:
         site_id: Site identifier
         backup_filename: Backup filename to download
-        output_path: Local filesystem path to save the backup
+        output_path: Relative filename beneath ``UNIFI_BACKUP_DIR``
         settings: Application settings
         verify_checksum: Whether to calculate and verify file checksum
 
@@ -296,7 +297,7 @@ async def download_backup(
         result = await download_backup(
             site_id="default",
             backup_filename="backup_2025-01-29.unf",
-            output_path="/backups/unifi_backup.unf",
+            output_path="unifi_backup.unf",
             settings=settings
         )
         print(f"Downloaded to: {result['local_path']}")
@@ -306,6 +307,39 @@ async def download_backup(
     """
     site_id = validate_site_id(site_id)
     logger = get_logger(__name__, settings.log_level)
+
+    relative_output = Path(output_path)
+    if (
+        not output_path.strip()
+        or relative_output.is_absolute()
+        or relative_output.name != output_path
+        or output_path in {".", ".."}
+    ):
+        raise ValidationError("output_path must be a relative filename beneath UNIFI_BACKUP_DIR")
+
+    backup_root = Path(settings.backup_directory).expanduser()
+    backup_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    output_file = backup_root.absolute() / output_path
+
+    if os.open not in os.supports_dir_fd:
+        raise ValidationError("Secure backup downloads are not supported on this platform")
+    directory_flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        directory_flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        directory_flags |= os.O_NOFOLLOW
+    backup_directory_fd: int | None = None
+    try:
+        backup_directory_fd = os.open(backup_root, directory_flags)
+        os.fchmod(backup_directory_fd, 0o700)
+    except OSError as exc:
+        if backup_directory_fd is not None:
+            os.close(backup_directory_fd)
+        raise ValidationError(
+            "UNIFI_BACKUP_DIR must resolve to an owner-only directory, not a symbolic link"
+        ) from exc
+    if backup_directory_fd is None:  # Defensive; os.open either returns an fd or raises.
+        raise ValidationError("Unable to open UNIFI_BACKUP_DIR securely")
 
     logger.info(
         sanitize_log_message(f"Downloading backup '{backup_filename}' from site '{site_id}'")
@@ -321,10 +355,24 @@ async def download_backup(
                 backup_filename=backup_filename,
             )
 
-            # Write to file
-            output_file = Path(output_path)
-            output_file.parent.mkdir(parents=True, exist_ok=True)
-            output_file.write_bytes(backup_content)
+            # Create a new owner-only file without following a final symlink or
+            # truncating an existing path.
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            try:
+                file_descriptor = os.open(
+                    output_path,
+                    flags,
+                    0o600,
+                    dir_fd=backup_directory_fd,
+                )
+            except FileExistsError as exc:
+                raise ValidationError(
+                    f"Backup destination already exists: {output_file.name}"
+                ) from exc
+            with os.fdopen(file_descriptor, "wb") as backup_file:
+                backup_file.write(backup_content)
 
             # Calculate checksum if requested
             checksum = ""
@@ -335,14 +383,14 @@ async def download_backup(
 
             result = {
                 "backup_filename": backup_filename,
-                "local_path": str(output_file.absolute()),
+                "local_path": str(output_file),
                 "size_bytes": len(backup_content),
                 "checksum": checksum if verify_checksum else None,
                 "download_time": datetime.now().isoformat(),
             }
 
             logger.info(
-                f"Successfully downloaded backup '{backup_filename}' to '{output_path}' "
+                f"Successfully downloaded backup '{backup_filename}' to '{output_file}' "
                 f"({len(backup_content)} bytes)"
             )
             log_audit(
@@ -364,6 +412,8 @@ async def download_backup(
             site_id=site_id,
         )
         raise
+    finally:
+        os.close(backup_directory_fd)
 
 
 async def delete_backup(

--- a/src/tools/diagnostics.py
+++ b/src/tools/diagnostics.py
@@ -57,36 +57,71 @@ async def get_network_references(
         }
 
 
-async def run_speed_test(site_id: str, settings: Settings) -> dict[str, Any]:
+async def run_speed_test(
+    site_id: str,
+    settings: Settings,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
+) -> dict[str, Any]:
     """Initiate a WAN speed test on the site.
 
     Args:
         site_id: Site identifier
         settings: Application settings
+        confirm: Confirmation flag required to start the test
+        dry_run: Preview the operation without starting a test
 
     Returns:
         Dictionary with speed test initiation status
     """
     site_id = validate_site_id(site_id)
+    validate_confirmation(confirm, "WAN speed test", dry_run)
+    dry_run = coerce_bool(dry_run)
     logger = get_logger(__name__, settings.log_level)
+    parameters = {"site_id": site_id}
 
-    async with UniFiClient(settings) as client:
-        await client.authenticate()
-
-        response = await client.post(
-            f"/ea/sites/{site_id}/cmd/devmgr",
-            json_data={"cmd": "speedtest"},
+    if dry_run:
+        log_audit(
+            operation="run_speed_test",
+            parameters=parameters,
+            result="dry_run",
+            site_id=site_id,
+            dry_run=True,
         )
-        data = response.get("data", {}) if isinstance(response, dict) else response
-        if not isinstance(data, dict):
-            data = {"status": "started"}
+        return {"dry_run": True, "would_start": "WAN speed test", "site_id": site_id}
 
-        logger.info(sanitize_log_message(f"Initiated speed test for site '{site_id}'"))
-        return {
-            "site_id": site_id,
-            "status": data.get("status", "started"),
-            "test_id": data.get("test_id"),
-        }
+    try:
+        async with UniFiClient(settings) as client:
+            await client.authenticate()
+
+            response = await client.post(
+                f"/ea/sites/{site_id}/cmd/devmgr",
+                json_data={"cmd": "speedtest"},
+            )
+            data = response.get("data", {}) if isinstance(response, dict) else response
+            if not isinstance(data, dict):
+                data = {"status": "started"}
+
+            log_audit(
+                operation="run_speed_test",
+                parameters=parameters,
+                result="success",
+                site_id=site_id,
+            )
+            logger.info(sanitize_log_message(f"Initiated speed test for site '{site_id}'"))
+            return {
+                "site_id": site_id,
+                "status": data.get("status", "started"),
+                "test_id": data.get("test_id"),
+            }
+    except Exception:
+        log_audit(
+            operation="run_speed_test",
+            parameters=parameters,
+            result="failed",
+            site_id=site_id,
+        )
+        raise
 
 
 async def get_speed_test_status(site_id: str, settings: Settings) -> dict[str, Any]:

--- a/src/tools/protect_devices.py
+++ b/src/tools/protect_devices.py
@@ -13,7 +13,16 @@ from ..models import (
     ProtectLight,
     ProtectSensor,
 )
-from ..utils import ValidationError, get_logger, sanitize_log_message, validate_limit_offset
+from ..utils import (
+    ValidationError,
+    audit_on_failure,
+    coerce_bool,
+    get_logger,
+    log_audit,
+    sanitize_log_message,
+    validate_confirmation,
+    validate_limit_offset,
+)
 
 
 def _validate_id(record_id: str, label: str) -> str:
@@ -40,6 +49,25 @@ def _extract_item(response: Any) -> dict[str, Any]:
             return data
         return response
     return {}
+
+
+def _prepare_mutation(
+    operation: str,
+    parameters: dict[str, Any],
+    confirm: bool | str,
+    dry_run: bool | str,
+) -> bool:
+    """Enforce confirmation and audit a side-effect-free preview."""
+    validate_confirmation(confirm, operation, dry_run)
+    is_dry_run = coerce_bool(dry_run)
+    if is_dry_run:
+        log_audit(
+            operation=operation,
+            parameters=parameters,
+            result="dry_run",
+            dry_run=True,
+        )
+    return is_dry_run
 
 
 async def list_protect_devices(
@@ -127,6 +155,8 @@ async def update_protect_device(
     state: str | int | None = None,
     mac: str | None = None,
     firmware_version: str | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
 ) -> dict[str, Any]:
     """Update a Protect device record."""
     logger = get_logger(__name__, settings.log_level)
@@ -146,16 +176,22 @@ async def update_protect_device(
     if firmware_version is not None:
         payload["firmwareVersion"] = firmware_version
 
-    async with ProtectClient(settings) as client:
-        await client.authenticate()
-        response = await client.patch(
-            settings.get_protect_integration_path(f"devices/{device_id}"),
-            json_data=payload,
-        )
+    parameters = {"device_id": device_id, "changed_fields": sorted(payload)}
+    if _prepare_mutation("update_protect_device", parameters, confirm, dry_run):
+        return {"dry_run": True, "would_update": device_id, "changes": payload}
 
-    device = ProtectDevice.model_validate(_extract_item(response))
-    logger.info(sanitize_log_message(f"Updated Protect device {device_id}"))
-    return device.model_dump(by_alias=True)
+    with audit_on_failure("update_protect_device", parameters):
+        async with ProtectClient(settings) as client:
+            await client.authenticate()
+            response = await client.patch(
+                settings.get_protect_integration_path(f"devices/{device_id}"),
+                json_data=payload,
+            )
+
+        device = ProtectDevice.model_validate(_extract_item(response))
+        log_audit(operation="update_protect_device", parameters=parameters, result="success")
+        logger.info(sanitize_log_message(f"Updated Protect device {device_id}"))
+        return device.model_dump(by_alias=True)
 
 
 async def list_protect_lights(
@@ -207,6 +243,8 @@ async def update_protect_light(
     is_light_force_enabled: bool | None = None,
     light_mode_settings: dict[str, Any] | None = None,
     light_device_settings: dict[str, Any] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
 ) -> dict[str, Any]:
     """Update Protect light settings."""
     logger = get_logger(__name__, settings.log_level)
@@ -222,16 +260,22 @@ async def update_protect_light(
     if light_device_settings is not None:
         payload["lightDeviceSettings"] = light_device_settings
 
-    async with ProtectClient(settings) as client:
-        await client.authenticate()
-        response = await client.patch(
-            settings.get_protect_integration_path(f"lights/{light_id}"),
-            json_data=payload,
-        )
+    parameters = {"light_id": light_id, "changed_fields": sorted(payload)}
+    if _prepare_mutation("update_protect_light", parameters, confirm, dry_run):
+        return {"dry_run": True, "would_update": light_id, "changes": payload}
 
-    light = ProtectLight.model_validate(_extract_item(response))
-    logger.info(sanitize_log_message(f"Updated Protect light {light_id}"))
-    return light.model_dump(by_alias=True)
+    with audit_on_failure("update_protect_light", parameters):
+        async with ProtectClient(settings) as client:
+            await client.authenticate()
+            response = await client.patch(
+                settings.get_protect_integration_path(f"lights/{light_id}"),
+                json_data=payload,
+            )
+
+        light = ProtectLight.model_validate(_extract_item(response))
+        log_audit(operation="update_protect_light", parameters=parameters, result="success")
+        logger.info(sanitize_log_message(f"Updated Protect light {light_id}"))
+        return light.model_dump(by_alias=True)
 
 
 async def list_protect_sensors(
@@ -285,6 +329,8 @@ async def update_protect_sensor(
     temperature_settings: dict[str, Any] | None = None,
     motion_settings: dict[str, Any] | None = None,
     alarm_settings: dict[str, Any] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
 ) -> dict[str, Any]:
     """Update Protect sensor settings."""
     logger = get_logger(__name__, settings.log_level)
@@ -304,16 +350,22 @@ async def update_protect_sensor(
     if alarm_settings is not None:
         payload["alarmSettings"] = alarm_settings
 
-    async with ProtectClient(settings) as client:
-        await client.authenticate()
-        response = await client.patch(
-            settings.get_protect_integration_path(f"sensors/{sensor_id}"),
-            json_data=payload,
-        )
+    parameters = {"sensor_id": sensor_id, "changed_fields": sorted(payload)}
+    if _prepare_mutation("update_protect_sensor", parameters, confirm, dry_run):
+        return {"dry_run": True, "would_update": sensor_id, "changes": payload}
 
-    sensor = ProtectSensor.model_validate(_extract_item(response))
-    logger.info(sanitize_log_message(f"Updated Protect sensor {sensor_id}"))
-    return sensor.model_dump(by_alias=True)
+    with audit_on_failure("update_protect_sensor", parameters):
+        async with ProtectClient(settings) as client:
+            await client.authenticate()
+            response = await client.patch(
+                settings.get_protect_integration_path(f"sensors/{sensor_id}"),
+                json_data=payload,
+            )
+
+        sensor = ProtectSensor.model_validate(_extract_item(response))
+        log_audit(operation="update_protect_sensor", parameters=parameters, result="success")
+        logger.info(sanitize_log_message(f"Updated Protect sensor {sensor_id}"))
+        return sensor.model_dump(by_alias=True)
 
 
 async def list_protect_chimes(
@@ -364,6 +416,8 @@ async def update_protect_chime(
     name: str | None = None,
     camera_ids: list[str] | None = None,
     ring_settings: list[dict[str, Any]] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
 ) -> dict[str, Any]:
     """Update Protect chime settings."""
     logger = get_logger(__name__, settings.log_level)
@@ -377,13 +431,19 @@ async def update_protect_chime(
     if ring_settings is not None:
         payload["ringSettings"] = ring_settings
 
-    async with ProtectClient(settings) as client:
-        await client.authenticate()
-        response = await client.patch(
-            settings.get_protect_integration_path(f"chimes/{chime_id}"),
-            json_data=payload,
-        )
+    parameters = {"chime_id": chime_id, "changed_fields": sorted(payload)}
+    if _prepare_mutation("update_protect_chime", parameters, confirm, dry_run):
+        return {"dry_run": True, "would_update": chime_id, "changes": payload}
 
-    chime = ProtectChime.model_validate(_extract_item(response))
-    logger.info(sanitize_log_message(f"Updated Protect chime {chime_id}"))
-    return chime.model_dump(by_alias=True)
+    with audit_on_failure("update_protect_chime", parameters):
+        async with ProtectClient(settings) as client:
+            await client.authenticate()
+            response = await client.patch(
+                settings.get_protect_integration_path(f"chimes/{chime_id}"),
+                json_data=payload,
+            )
+
+        chime = ProtectChime.model_validate(_extract_item(response))
+        log_audit(operation="update_protect_chime", parameters=parameters, result="success")
+        logger.info(sanitize_log_message(f"Updated Protect chime {chime_id}"))
+        return chime.model_dump(by_alias=True)

--- a/src/tools/protect_events.py
+++ b/src/tools/protect_events.py
@@ -7,7 +7,16 @@ from typing import Any
 from ..api import ProtectClient
 from ..config import Settings
 from ..models import ProtectAlarmWebhookResult, ProtectDeviceUpdateMessage, ProtectEventMessage
-from ..utils import ValidationError, get_logger, sanitize_log_message, validate_limit_offset
+from ..utils import (
+    ValidationError,
+    audit_on_failure,
+    coerce_bool,
+    get_logger,
+    log_audit,
+    sanitize_log_message,
+    validate_confirmation,
+    validate_limit_offset,
+)
 
 
 def _extract_collection(response: Any) -> list[dict[str, Any]]:
@@ -130,20 +139,42 @@ async def send_protect_alarm_webhook(
     webhook_id: str,
     settings: Settings,
     payload: dict[str, Any] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
 ) -> dict[str, Any]:
     """Send a webhook to the Protect alarm manager."""
     logger = get_logger(__name__, settings.log_level)
     webhook_id = webhook_id.strip()
     if not webhook_id:
         raise ValidationError("webhook_id is required")
+    validate_confirmation(confirm, "send Protect alarm webhook", dry_run)
+    parameters = {
+        "webhook_id": webhook_id,
+        "payload_fields": sorted((payload or {}).keys()),
+    }
 
-    async with ProtectClient(settings) as client:
-        await client.authenticate()
-        response = await client.post(
-            settings.get_protect_integration_path(f"alarm-manager/webhook/{webhook_id}"),
-            json_data=payload or {},
+    if coerce_bool(dry_run):
+        log_audit(
+            operation="send_protect_alarm_webhook",
+            parameters=parameters,
+            result="dry_run",
+            dry_run=True,
         )
+        return {"dry_run": True, "would_send": webhook_id, "payload": payload or {}}
 
-    result = ProtectAlarmWebhookResult.model_validate(_extract_item(response))
-    logger.info(sanitize_log_message(f"Sent Protect alarm webhook {webhook_id}"))
-    return result.model_dump(by_alias=True)
+    with audit_on_failure("send_protect_alarm_webhook", parameters):
+        async with ProtectClient(settings) as client:
+            await client.authenticate()
+            response = await client.post(
+                settings.get_protect_integration_path(f"alarm-manager/webhook/{webhook_id}"),
+                json_data=payload or {},
+            )
+
+        result = ProtectAlarmWebhookResult.model_validate(_extract_item(response))
+        log_audit(
+            operation="send_protect_alarm_webhook",
+            parameters=parameters,
+            result="success",
+        )
+        logger.info(sanitize_log_message(f"Sent Protect alarm webhook {webhook_id}"))
+        return result.model_dump(by_alias=True)

--- a/src/tools/protect_views.py
+++ b/src/tools/protect_views.py
@@ -7,7 +7,16 @@ from typing import Any
 from ..api import ProtectClient
 from ..config import Settings
 from ..models import ProtectLiveView, ProtectMetaInfo, ProtectViewer
-from ..utils import ValidationError, get_logger, sanitize_log_message, validate_limit_offset
+from ..utils import (
+    ValidationError,
+    audit_on_failure,
+    coerce_bool,
+    get_logger,
+    log_audit,
+    sanitize_log_message,
+    validate_confirmation,
+    validate_limit_offset,
+)
 
 
 def _validate_id(record_id: str, label: str) -> str:
@@ -34,6 +43,25 @@ def _extract_item(response: Any) -> dict[str, Any]:
             return data
         return response
     return {}
+
+
+def _prepare_mutation(
+    operation: str,
+    parameters: dict[str, Any],
+    confirm: bool | str,
+    dry_run: bool | str,
+) -> bool:
+    """Enforce confirmation and audit a side-effect-free preview."""
+    validate_confirmation(confirm, operation, dry_run)
+    is_dry_run = coerce_bool(dry_run)
+    if is_dry_run:
+        log_audit(
+            operation=operation,
+            parameters=parameters,
+            result="dry_run",
+            dry_run=True,
+        )
+    return is_dry_run
 
 
 async def get_protect_meta_info(settings: Settings) -> dict[str, Any]:
@@ -96,6 +124,8 @@ async def update_protect_viewer(
     settings: Settings,
     name: str | None = None,
     liveview: str | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
 ) -> dict[str, Any]:
     """Update Protect viewer settings."""
     logger = get_logger(__name__, settings.log_level)
@@ -107,16 +137,22 @@ async def update_protect_viewer(
     if liveview is not None:
         payload["liveview"] = liveview
 
-    async with ProtectClient(settings) as client:
-        await client.authenticate()
-        response = await client.patch(
-            settings.get_protect_integration_path(f"viewers/{viewer_id}"),
-            json_data=payload,
-        )
+    parameters = {"viewer_id": viewer_id, "changed_fields": sorted(payload)}
+    if _prepare_mutation("update_protect_viewer", parameters, confirm, dry_run):
+        return {"dry_run": True, "would_update": viewer_id, "changes": payload}
 
-    viewer = ProtectViewer.model_validate(_extract_item(response))
-    logger.info(sanitize_log_message(f"Updated Protect viewer {viewer_id}"))
-    return viewer.model_dump(by_alias=True)
+    with audit_on_failure("update_protect_viewer", parameters):
+        async with ProtectClient(settings) as client:
+            await client.authenticate()
+            response = await client.patch(
+                settings.get_protect_integration_path(f"viewers/{viewer_id}"),
+                json_data=payload,
+            )
+
+        viewer = ProtectViewer.model_validate(_extract_item(response))
+        log_audit(operation="update_protect_viewer", parameters=parameters, result="success")
+        logger.info(sanitize_log_message(f"Updated Protect viewer {viewer_id}"))
+        return viewer.model_dump(by_alias=True)
 
 
 async def list_protect_live_views(
@@ -168,20 +204,27 @@ async def get_protect_live_view(live_view_id: str, settings: Settings) -> dict[s
 async def create_protect_live_view(
     live_view: dict[str, Any],
     settings: Settings,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
 ) -> dict[str, Any]:
     """Create a Protect live view."""
     logger = get_logger(__name__, settings.log_level)
+    parameters = {"changed_fields": sorted(live_view)}
+    if _prepare_mutation("create_protect_live_view", parameters, confirm, dry_run):
+        return {"dry_run": True, "would_create": live_view}
 
-    async with ProtectClient(settings) as client:
-        await client.authenticate()
-        response = await client.post(
-            settings.get_protect_integration_path("liveviews"),
-            json_data=live_view,
-        )
+    with audit_on_failure("create_protect_live_view", parameters):
+        async with ProtectClient(settings) as client:
+            await client.authenticate()
+            response = await client.post(
+                settings.get_protect_integration_path("liveviews"),
+                json_data=live_view,
+            )
 
-    created = ProtectLiveView.model_validate(_extract_item(response))
-    logger.info(sanitize_log_message(f"Created Protect live view {created.id or 'unknown'}"))
-    return created.model_dump(by_alias=True)
+        created = ProtectLiveView.model_validate(_extract_item(response))
+        log_audit(operation="create_protect_live_view", parameters=parameters, result="success")
+        logger.info(sanitize_log_message(f"Created Protect live view {created.id or 'unknown'}"))
+        return created.model_dump(by_alias=True)
 
 
 async def update_protect_live_view(
@@ -194,6 +237,8 @@ async def update_protect_live_view(
     owner: str | None = None,
     layout: int | None = None,
     slots: list[dict[str, Any]] | None = None,
+    confirm: bool | str = False,
+    dry_run: bool | str = False,
 ) -> dict[str, Any]:
     """Update Protect live view settings."""
     logger = get_logger(__name__, settings.log_level)
@@ -215,13 +260,19 @@ async def update_protect_live_view(
     if slots is not None:
         payload["slots"] = slots
 
-    async with ProtectClient(settings) as client:
-        await client.authenticate()
-        response = await client.patch(
-            settings.get_protect_integration_path(f"liveviews/{live_view_id}"),
-            json_data=payload,
-        )
+    parameters = {"live_view_id": live_view_id, "changed_fields": sorted(payload)}
+    if _prepare_mutation("update_protect_live_view", parameters, confirm, dry_run):
+        return {"dry_run": True, "would_update": live_view_id, "changes": payload}
 
-    live_view = ProtectLiveView.model_validate(_extract_item(response))
-    logger.info(sanitize_log_message(f"Updated Protect live view {live_view_id}"))
-    return live_view.model_dump(by_alias=True)
+    with audit_on_failure("update_protect_live_view", parameters):
+        async with ProtectClient(settings) as client:
+            await client.authenticate()
+            response = await client.patch(
+                settings.get_protect_integration_path(f"liveviews/{live_view_id}"),
+                json_data=payload,
+            )
+
+        live_view = ProtectLiveView.model_validate(_extract_item(response))
+        log_audit(operation="update_protect_live_view", parameters=parameters, result="success")
+        logger.info(sanitize_log_message(f"Updated Protect live view {live_view_id}"))
+        return live_view.model_dump(by_alias=True)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,6 +1,6 @@
 """Utility modules for UniFi MCP Server."""
 
-from .audit import AuditLogger, audit_action, get_audit_logger, log_audit
+from .audit import AuditLogger, audit_action, audit_on_failure, get_audit_logger, log_audit
 from .exceptions import (
     APIError,
     AuthenticationError,
@@ -61,6 +61,7 @@ __all__ = [
     "get_audit_logger",
     "log_audit",
     "audit_action",
+    "audit_on_failure",
     # Logger
     "get_logger",
     "log_api_request",

--- a/src/utils/audit.py
+++ b/src/utils/audit.py
@@ -1,6 +1,8 @@
 """Audit logging for mutating operations."""
 
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -171,6 +173,25 @@ def log_audit(
     """
     logger = get_audit_logger(log_file)
     logger.log_operation(operation, parameters, result, user, site_id, dry_run, error)
+
+
+@contextmanager
+def audit_on_failure(
+    operation: str,
+    parameters: dict[str, Any],
+    site_id: str | None = None,
+) -> Iterator[None]:
+    """Record a failed mutation attempt while preserving its exception."""
+    try:
+        yield
+    except Exception:
+        log_audit(
+            operation=operation,
+            parameters=parameters,
+            result="failed",
+            site_id=site_id,
+        )
+        raise
 
 
 async def audit_action(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,10 +13,10 @@ sys.path.insert(0, str(project_root))
 
 @pytest.fixture(autouse=True, scope="function")
 def isolate_env_file(tmp_path, monkeypatch):
-    """Prevent Settings from loading .env file during unit tests.
+    """Isolate process environment and working directory during unit tests.
 
-    This ensures that tests using monkeypatch.delenv() actually work as expected,
-    since Pydantic Settings loads from both environment variables AND .env file.
+    Settings intentionally ignores working-directory .env files, but a temporary
+    directory also keeps file-producing tests isolated from the checkout.
     """
     # Change to a temp directory so .env file won't be found
     temp_dir = tmp_path / "test_env"

--- a/tests/integration/test_diagnostics_suite.py
+++ b/tests/integration/test_diagnostics_suite.py
@@ -79,6 +79,7 @@ async def test_run_speed_test(settings, env: TestEnvironment) -> dict[str, Any]:
         result = await diagnostics.run_speed_test(
             site_id=env.site_id,
             settings=settings,
+            confirm=True,
         )
 
         assert isinstance(result, dict), "Result must be a dictionary"

--- a/tests/integration/test_protect_mocked_integration.py
+++ b/tests/integration/test_protect_mocked_integration.py
@@ -287,7 +287,9 @@ async def test_protect_device_family_tools_cover_devices_lights_sensors_and_chim
 
     devices = await list_protect_devices(local_settings, limit=1, offset=0)
     device = await get_protect_device("device-1", local_settings)
-    updated_device = await update_protect_device("device-1", local_settings, name="Updated Hub")
+    updated_device = await update_protect_device(
+        "device-1", local_settings, name="Updated Hub", confirm=True
+    )
     lights = await list_protect_lights(local_settings)
     light = await get_protect_light("light-1", local_settings)
     updated_light = await update_protect_light(
@@ -295,6 +297,7 @@ async def test_protect_device_family_tools_cover_devices_lights_sensors_and_chim
         local_settings,
         name="Night Light",
         is_light_force_enabled=True,
+        confirm=True,
     )
     sensors = await list_protect_sensors(local_settings)
     sensor = await get_protect_sensor("sensor-1", local_settings)
@@ -303,6 +306,7 @@ async def test_protect_device_family_tools_cover_devices_lights_sensors_and_chim
         local_settings,
         name="Updated Garage Sensor",
         motion_settings={"isEnabled": True},
+        confirm=True,
     )
     chimes = await list_protect_chimes(local_settings)
     chime = await get_protect_chime("chime-1", local_settings)
@@ -311,6 +315,7 @@ async def test_protect_device_family_tools_cover_devices_lights_sensors_and_chim
         local_settings,
         name="Updated Chime",
         camera_ids=["cam-1"],
+        confirm=True,
     )
 
     assert devices["count"] == 1
@@ -453,12 +458,14 @@ async def test_protect_views_events_and_webhooks_cover_the_registered_phase_thre
         local_settings,
         name="North Lobby Viewer",
         liveview="liveview-1",
+        confirm=True,
     )
     live_views = await list_protect_live_views(local_settings)
     live_view = await get_protect_live_view("liveview-1", local_settings)
     created_live_view = await create_protect_live_view(
         {"name": "Warehouse View", "modelKey": "liveview", "layout": 4, "slots": []},
         local_settings,
+        confirm=True,
     )
     updated_live_view = await update_protect_live_view(
         "liveview-1",
@@ -467,6 +474,7 @@ async def test_protect_views_events_and_webhooks_cover_the_registered_phase_thre
         model_key="liveview",
         layout=2,
         slots=[],
+        confirm=True,
     )
     device_updates = await list_protect_device_updates(local_settings)
     events = await list_protect_events(local_settings)
@@ -474,6 +482,7 @@ async def test_protect_views_events_and_webhooks_cover_the_registered_phase_thre
         "webhook-1",
         local_settings,
         payload={"event": "manual-trigger"},
+        confirm=True,
     )
 
     assert meta["version"] == "6.2.83"

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -36,6 +36,12 @@ class TestSettingsValidateApiType:
         settings = Settings()
         assert settings.api_type == APIType.CLOUD_V1
 
+    def test_validate_legacy_cloud_alias(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UNIFI_API_KEY", "test-key")
+        monkeypatch.setenv("UNIFI_API_TYPE", "cloud")
+        settings = Settings()
+        assert settings.api_type == APIType.CLOUD_EA
+
     def test_validate_api_type_local(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("UNIFI_API_KEY", "test-key")
         monkeypatch.setenv("UNIFI_API_TYPE", "LOCAL")
@@ -325,24 +331,28 @@ class TestSettingsTransportConfiguration:
     def test_transport_sse(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("UNIFI_API_KEY", "test-key")
         monkeypatch.setenv("MCP_SERVER_TRANSPORT", "sse")
+        monkeypatch.setenv("MCP_AUTH_TOKEN", "a" * 32)
         settings = Settings()
         assert settings.server_transport == TransportMode.SSE
 
     def test_transport_http(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("UNIFI_API_KEY", "test-key")
         monkeypatch.setenv("MCP_SERVER_TRANSPORT", "http")
+        monkeypatch.setenv("MCP_AUTH_TOKEN", "a" * 32)
         settings = Settings()
         assert settings.server_transport == TransportMode.HTTP
 
     def test_transport_streamable_http(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("UNIFI_API_KEY", "test-key")
         monkeypatch.setenv("MCP_SERVER_TRANSPORT", "streamable_http")
+        monkeypatch.setenv("MCP_AUTH_TOKEN", "a" * 32)
         settings = Settings()
         assert settings.server_transport == TransportMode.STREAMABLE_HTTP
 
     def test_transport_uppercase(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("UNIFI_API_KEY", "test-key")
         monkeypatch.setenv("MCP_SERVER_TRANSPORT", "SSE")
+        monkeypatch.setenv("MCP_AUTH_TOKEN", "a" * 32)
         settings = Settings()
         assert settings.server_transport == TransportMode.SSE
 

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -108,7 +108,7 @@ class TestRunSpeedTest:
             mock_client_class.return_value = create_mock_client()
             mock_client_class.return_value.post = AsyncMock(return_value=response)
 
-            result = await run_speed_test("site-1", mock_settings)
+            result = await run_speed_test("site-1", mock_settings, confirm=True)
 
             assert isinstance(result, dict)
             assert result["status"] == "started"

--- a/tests/unit/test_security_regressions.py
+++ b/tests/unit/test_security_regressions.py
@@ -1,0 +1,243 @@
+"""Regression tests for validated server security boundaries."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+from starlette.responses import JSONResponse
+
+from src.api import validate_controller_relative_endpoint
+from src.config import APIType, Settings
+from src.mcp_auth import ConfiguredBearerTokenVerifier, require_authenticated_request
+from src.utils.exceptions import ValidationError
+
+
+def _reload_main(env: dict[str, str]) -> ModuleType:
+    """Import ``src.main`` with only the supplied environment."""
+    sys.modules.pop("src.main", None)
+    with patch.dict(os.environ, env, clear=True):
+        return importlib.import_module("src.main")
+
+
+def test_network_transport_requires_mcp_auth_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Network listeners must fail closed when no client token is configured."""
+    monkeypatch.setenv("UNIFI_API_KEY", "controller-key")  # pragma: allowlist secret
+    monkeypatch.setenv("MCP_SERVER_TRANSPORT", "streamable_http")
+    monkeypatch.delenv("MCP_AUTH_TOKEN", raising=False)
+
+    with pytest.raises(ValueError, match="MCP_AUTH_TOKEN"):
+        Settings()
+
+
+@pytest.mark.asyncio
+async def test_network_transport_installs_bearer_auth() -> None:
+    """The configured MCP token must actually protect the FastMCP server."""
+    main = _reload_main(
+        {
+            "UNIFI_API_KEY": "controller-key",  # pragma: allowlist secret
+            "MCP_SERVER_TRANSPORT": "streamable_http",
+            "MCP_AUTH_TOKEN": "mcp-client-token-with-sufficient-entropy",
+        }
+    )
+
+    assert main.mcp.auth is not None
+    assert await main.mcp.auth.verify_token("wrong-token") is None
+    assert await main.mcp.auth.verify_token("mcp-client-token-with-sufficient-entropy") is not None
+
+
+@pytest.mark.asyncio
+async def test_network_transport_rejects_unauthenticated_http_requests() -> None:
+    """FastMCP's HTTP boundary must return 401 before MCP request handling."""
+    token = "mcp-client-token-with-sufficient-entropy"
+    main = _reload_main(
+        {
+            "UNIFI_API_KEY": "controller-key",  # pragma: allowlist secret
+            "MCP_SERVER_TRANSPORT": "streamable_http",
+            "MCP_AUTH_TOKEN": token,
+        }
+    )
+    app = main.mcp.http_app()
+    transport = httpx.ASGITransport(app=app)
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "security-test", "version": "1"},
+        },
+    }
+
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            missing = await client.post("/mcp", json=payload)
+            wrong = await client.post(
+                "/mcp", headers={"Authorization": "Bearer wrong"}, json=payload
+            )
+            accepted = await client.post(
+                "/mcp", headers={"Authorization": f"Bearer {token}"}, json=payload
+            )
+
+    assert missing.status_code == 401
+    assert wrong.status_code == 401
+    assert accepted.status_code != 401
+
+
+@pytest.mark.asyncio
+async def test_custom_network_routes_require_bearer_auth() -> None:
+    """Custom A2A-style routes must share the network authentication boundary."""
+    token = "mcp-client-token-with-sufficient-entropy"
+    server = FastMCP("security-test", auth=ConfiguredBearerTokenVerifier(token))
+
+    @server.custom_route("/custom", methods=["GET"])
+    async def protected_route(request):
+        require_authenticated_request(request)
+        return JSONResponse({"status": "authenticated"})
+
+    app = server.http_app()
+    transport = httpx.ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            missing = await client.get("/custom")
+            wrong = await client.get("/custom", headers={"Authorization": "Bearer wrong"})
+            accepted = await client.get("/custom", headers={"Authorization": f"Bearer {token}"})
+
+    assert missing.status_code == 401
+    assert wrong.status_code == 401
+    assert accepted.status_code == 200
+
+
+def test_settings_do_not_load_working_directory_dotenv(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An untrusted workspace .env must not redirect a process-environment key."""
+    (tmp_path / ".env").write_text(
+        "UNIFI_API_TYPE=local\n"
+        "UNIFI_LOCAL_HOST=attacker-controlled.example\n"
+        "UNIFI_LOCAL_VERIFY_SSL=false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("UNIFI_API_KEY", "controller-key")  # pragma: allowlist secret
+
+    settings = Settings()
+
+    assert settings.api_type == APIType.CLOUD_EA
+    assert settings.base_url == "https://api.ui.com"
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://attacker.example/capture",
+        "http://attacker.example/capture",
+        "HTTPS://attacker.example/capture",
+        "//attacker.example/capture",
+        "attacker.example/capture",
+        "/\\attacker.example/capture",
+    ],
+)
+def test_controller_endpoint_rejects_origin_changing_forms(endpoint: str) -> None:
+    """Credentialed API requests must accept only one-slash relative paths."""
+    with pytest.raises(ValidationError):
+        validate_controller_relative_endpoint(endpoint)
+
+
+def test_controller_endpoint_accepts_normal_unifi_path() -> None:
+    """Legitimate UniFi controller paths remain compatible."""
+    endpoint = "/proxy/network/api/s/default/stat/device"
+    assert validate_controller_relative_endpoint(endpoint) == endpoint
+
+
+@pytest.mark.asyncio
+async def test_debug_tool_rejects_absolute_url_before_creating_client() -> None:
+    """Debug endpoints must remain relative to the configured UniFi origin."""
+    main = _reload_main(
+        {"UNIFI_API_KEY": "controller-key", "DEBUG": "true"}  # pragma: allowlist secret
+    )
+
+    with patch("src.api.UniFiClient") as client_class:
+        with pytest.raises(ValidationError, match="relative"):
+            await main.debug_api_request("https://attacker.example/capture")
+
+    client_class.assert_not_called()
+
+
+def test_unknown_profile_fails_closed() -> None:
+    """A profile typo must never fall back to the complete mutation surface."""
+    with pytest.raises(ValueError, match="UNIFI_PROFILE"):
+        _reload_main(
+            {
+                "UNIFI_API_KEY": "controller-key",  # pragma: allowlist secret
+                "UNIFI_PROFILE": "netwrok",
+            }
+        )
+
+
+def test_api_incompatible_profile_fails_closed() -> None:
+    """A known profile with no cloud modules must not fall back to all tools."""
+    with pytest.raises(ValueError, match="no tools compatible"):
+        _reload_main(
+            {
+                "UNIFI_API_KEY": "controller-key",  # pragma: allowlist secret
+                "UNIFI_PROFILE": "protect",
+            }
+        )
+
+
+def test_minimal_profile_is_compatible_with_cloud_mode() -> None:
+    """The least-privilege Docker default must remain usable in cloud mode."""
+    main = _reload_main(
+        {
+            "UNIFI_API_KEY": "controller-key",  # pragma: allowlist secret
+            "UNIFI_API_TYPE": "cloud-ea",
+            "UNIFI_PROFILE": "minimal",
+        }
+    )
+
+    assert main.mcp._registered_tool_names
+    assert "list_sites" in main.mcp._registered_tool_names
+
+
+def test_read_only_profile_registers_only_read_tools() -> None:
+    """The documented read-only profile must exclude every mutation tool."""
+    main = _reload_main(
+        {
+            "UNIFI_API_KEY": "controller-key",  # pragma: allowlist secret
+            "UNIFI_PROFILE": "read-only",
+        }
+    )
+    names = main.mcp._registered_tool_names
+    allowed_prefixes = ("get_", "list_", "stat_", "search_")
+
+    assert names
+    assert "create_network" not in names
+    assert all(name == "health_check" or name.startswith(allowed_prefixes) for name in names)
+
+
+@pytest.mark.asyncio
+async def test_debug_delete_requires_confirmation() -> None:
+    """The debug tool must not provide an unconfirmed DELETE bypass."""
+    main = _reload_main(
+        {"UNIFI_API_KEY": "controller-key", "DEBUG": "true"}  # pragma: allowlist secret
+    )
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.delete = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.api.UniFiClient", return_value=mock_client):
+        with pytest.raises(ValidationError, match="confirmation"):
+            await main.debug_api_request("/proxy/network/api/s/default/rest/networkconf", "DELETE")
+
+    mock_client.delete.assert_not_awaited()

--- a/tests/unit/tools/test_backups_tools.py
+++ b/tests/unit/tools/test_backups_tools.py
@@ -209,6 +209,7 @@ async def test_download_backup_success(mock_settings, tmp_path):
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
 
+    mock_settings.backup_directory = tmp_path
     output_path = tmp_path / "test_backup.unf"
 
     with patch.object(backups_module, "UniFiClient", return_value=mock_client):
@@ -216,7 +217,7 @@ async def test_download_backup_success(mock_settings, tmp_path):
             result = await download_backup(
                 "default",
                 "backup_20260101.unf",
-                str(output_path),
+                output_path.name,
                 mock_settings,
                 verify_checksum=True,
             )
@@ -238,6 +239,7 @@ async def test_download_backup_no_checksum(mock_settings, tmp_path):
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
 
+    mock_settings.backup_directory = tmp_path
     output_path = tmp_path / "test_backup.unf"
 
     with patch.object(backups_module, "UniFiClient", return_value=mock_client):
@@ -245,12 +247,91 @@ async def test_download_backup_no_checksum(mock_settings, tmp_path):
             result = await download_backup(
                 "default",
                 "backup.unf",
-                str(output_path),
+                output_path.name,
                 mock_settings,
                 verify_checksum=False,
             )
 
             assert result["checksum"] is None
+
+
+@pytest.mark.asyncio
+async def test_download_backup_rejects_absolute_output_path_before_request(mock_settings, tmp_path):
+    """MCP callers must not select arbitrary process-writable destinations."""
+    mock_settings.backup_directory = tmp_path / "approved-backups"
+
+    with patch.object(backups_module, "UniFiClient") as client_class:
+        with pytest.raises(ValidationError, match="relative filename"):
+            await download_backup(
+                "default",
+                "backup.unf",
+                str(tmp_path / "outside" / "overwrite-me"),
+                mock_settings,
+            )
+
+    client_class.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_symlink", [False, True])
+async def test_download_backup_never_overwrites_existing_destination(
+    mock_settings, tmp_path, use_symlink
+):
+    """Existing regular files and symlinks must remain unchanged."""
+    backup_root = tmp_path / "approved-backups"
+    backup_root.mkdir()
+    protected_file = tmp_path / "protected.txt"
+    protected_file.write_bytes(b"original")
+    destination = backup_root / "existing.unf"
+    if use_symlink:
+        destination.symlink_to(protected_file)
+    else:
+        destination.write_bytes(b"original")
+    mock_settings.backup_directory = backup_root
+
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.download_backup = AsyncMock(return_value=b"replacement")
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(backups_module, "UniFiClient", return_value=mock_client):
+        with pytest.raises(ValidationError, match="already exists"):
+            await download_backup("default", "backup.unf", destination.name, mock_settings)
+
+    assert protected_file.read_bytes() == b"original"
+    if not use_symlink:
+        assert destination.read_bytes() == b"original"
+
+
+@pytest.mark.asyncio
+async def test_download_backup_uses_open_directory_when_root_path_is_swapped(
+    mock_settings, tmp_path
+):
+    """Replacing the configured root with a symlink must not redirect the write."""
+    backup_root = tmp_path / "approved-backups"
+    backup_root.mkdir()
+    opened_root = tmp_path / "opened-backup-directory"
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    mock_settings.backup_directory = backup_root
+
+    async def swap_root_then_return_content(**_kwargs):
+        backup_root.rename(opened_root)
+        backup_root.symlink_to(outside_root, target_is_directory=True)
+        return b"controller-backup"
+
+    mock_client = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.download_backup = AsyncMock(side_effect=swap_root_then_return_content)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(backups_module, "UniFiClient", return_value=mock_client):
+        await download_backup("default", "backup.unf", "saved.unf", mock_settings)
+
+    assert not (outside_root / "saved.unf").exists()
+    assert (opened_root / "saved.unf").read_bytes() == b"controller-backup"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tools/test_mutation_security.py
+++ b/tests/unit/tools/test_mutation_security.py
@@ -1,0 +1,105 @@
+"""Regression tests for mutation confirmation, preview, and audit controls."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.tools.diagnostics import run_speed_test
+from src.tools.protect_devices import (
+    update_protect_chime,
+    update_protect_device,
+    update_protect_light,
+    update_protect_sensor,
+)
+from src.tools.protect_events import send_protect_alarm_webhook
+from src.tools.protect_views import (
+    create_protect_live_view,
+    update_protect_live_view,
+    update_protect_viewer,
+)
+from src.utils.exceptions import ValidationError
+
+Mutation = Callable[..., Coroutine[Any, Any, dict[str, Any]]]
+
+
+@pytest.fixture
+def settings() -> MagicMock:
+    """Return settings sufficient for pre-request safety checks."""
+    value = MagicMock()
+    value.log_level = "INFO"
+    value.get_protect_integration_path.side_effect = lambda endpoint: f"/protect/{endpoint}"
+    return value
+
+
+MUTATIONS: list[tuple[Mutation, dict[str, Any]]] = [
+    (run_speed_test, {"site_id": "default"}),
+    (update_protect_device, {"device_id": "device-1", "name": "Front Door"}),
+    (update_protect_light, {"light_id": "light-1", "name": "Porch"}),
+    (update_protect_sensor, {"sensor_id": "sensor-1", "name": "Garage"}),
+    (update_protect_chime, {"chime_id": "chime-1", "name": "Hall"}),
+    (update_protect_viewer, {"viewer_id": "viewer-1", "name": "Lobby"}),
+    (create_protect_live_view, {"live_view": {"name": "Operations", "slots": []}}),
+    (update_protect_live_view, {"live_view_id": "view-1", "name": "Operations"}),
+    (send_protect_alarm_webhook, {"webhook_id": "webhook-1", "payload": {"alarm": True}}),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("mutation", "kwargs"), MUTATIONS)
+async def test_mutation_requires_confirmation_before_client_creation(
+    mutation: Mutation, kwargs: dict[str, Any], settings: MagicMock
+) -> None:
+    """Every affected mutation must reject an unconfirmed call before I/O."""
+    client_name = "UniFiClient" if mutation is run_speed_test else "ProtectClient"
+
+    with patch(f"{mutation.__module__}.{client_name}") as client_class:
+        with pytest.raises(ValidationError, match="confirmation"):
+            await mutation(settings=settings, confirm=False, **kwargs)
+
+    client_class.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("mutation", "kwargs"), MUTATIONS)
+async def test_mutation_dry_run_is_side_effect_free_and_audited(
+    mutation: Mutation, kwargs: dict[str, Any], settings: MagicMock
+) -> None:
+    """Every affected mutation must provide an audited no-I/O preview."""
+    client_name = "UniFiClient" if mutation is run_speed_test else "ProtectClient"
+
+    with (
+        patch(f"{mutation.__module__}.{client_name}") as client_class,
+        patch(f"{mutation.__module__}.log_audit") as audit,
+    ):
+        result = await mutation(settings=settings, dry_run=True, **kwargs)
+
+    assert result["dry_run"] is True
+    client_class.assert_not_called()
+    audit.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("mutation", "kwargs"), MUTATIONS)
+async def test_mutation_failure_is_audited(
+    mutation: Mutation, kwargs: dict[str, Any], settings: MagicMock
+) -> None:
+    """Every attempted mutation must leave an audit record when execution fails."""
+    client_name = "UniFiClient" if mutation is run_speed_test else "ProtectClient"
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(side_effect=RuntimeError("simulated API failure"))
+
+    with (
+        patch(f"{mutation.__module__}.{client_name}", return_value=client),
+        patch(f"{mutation.__module__}.log_audit") as direct_audit,
+        patch("src.utils.audit.log_audit") as shared_audit,
+    ):
+        with pytest.raises(RuntimeError, match="simulated API failure"):
+            await mutation(settings=settings, confirm=True, **kwargs)
+
+    audit = direct_audit if mutation is run_speed_test else shared_audit
+    audit.assert_called_once()
+    assert audit.call_args.kwargs["result"] == "failed"

--- a/tests/unit/tools/test_protect_events.py
+++ b/tests/unit/tools/test_protect_events.py
@@ -80,7 +80,7 @@ async def test_send_protect_alarm_webhook_success(mock_settings, mock_client):
     send_protect_alarm_webhook = _tool("send_protect_alarm_webhook")
 
     with patch(f"{protect_events.__name__}.ProtectClient", return_value=mock_client):
-        result = await send_protect_alarm_webhook("webhook-1", mock_settings)
+        result = await send_protect_alarm_webhook("webhook-1", mock_settings, confirm=True)
 
     mock_client.authenticate.assert_awaited_once()
     mock_client.post.assert_awaited_once_with(


### PR DESCRIPTION
## Summary

Remediates the seven validated security findings from the repository-wide standard scan:

- require a distinct bearer token for every network MCP transport and protect custom A2A routes
- stop implicit working-directory `.env` discovery
- constrain credentialed API requests to controller-relative paths
- confine backup downloads to exclusive, no-follow creation beneath an approved directory
- add confirmation, dry-run, and success/failure audit controls to nine mutation tools
- make tool profiles typed and fail closed, including a functional `read-only` profile
- store and load scraper session cookies with owner-only, no-follow file handling

Docker now binds the published port to loopback by default and uses compatible `cloud-ea` / `minimal` defaults.

## Compatibility changes

- Network clients must send `Authorization: Bearer <MCP_AUTH_TOKEN>`; the token must be at least 32 characters.
- `.env` files must be sourced explicitly by an operator or injected by the deployment system.
- `download_backup.output_path` is now a new filename beneath `UNIFI_BACKUP_DIR`; existing files are never replaced.
- The affected mutation tools require `confirm=true` unless `dry_run=true`.
- Unknown or API-incompatible `UNIFI_PROFILE` values stop startup instead of broadening the tool surface.

## Validation

- `1996 passed, 14 skipped, 4 deselected`
- coverage: `82.86%` (required: `80%`)
- focused security regression suite: passed
- Node cookie-permission regression under umask `000`: passed
- Ruff, Black, isort, Bandit, Interrogate, detect-secrets, Docker Compose validation, and diff checks: passed
- independent post-patch bypass review: clean after follow-up remediation

The existing mypy baseline is still non-green: the scanned revision has 37 errors in 16 files; this branch has 32 errors in the same 16 files and introduces no new mypy error.

## Review requirement

AI-assisted implementation. This is intentionally a draft and requires independent human security review before merge.
