### PR TITLE
chore(security): bump click to fix CVE, regenerate secrets baseline

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -79,8 +79,14 @@ jobs:
           # PYSEC-2022-42969 / CVE-2022-42969: ReDoS in py's SVN info parsing.
           # No fix version exists; py is unmaintained. This project does not use SVN,
           # so the vulnerability is not exploitable here.
+          #
+          # PYSEC-2026-3740 / CVE-2026-81726: path-sandbox bypass in NLTK's model
+          # save/load APIs (TransitionParser, AveragedPerceptron, PerceptronTagger).
+          # No fix version exists yet. nltk is a dev-only dependency here and is
+          # never imported by src/ or tests/, so the vulnerable APIs are unreachable.
           pip-audit --format json --output pip-audit-report.json \
-            --ignore-vuln PYSEC-2022-42969
+            --ignore-vuln PYSEC-2022-42969 \
+            --ignore-vuln PYSEC-2026-3740
 
       - name: Upload Safety report
         uses: actions/upload-artifact@v4

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -266,14 +266,14 @@
         "filename": "README.md",
         "hashed_secret": "aecdccc1cf64595b34e0cc152d238daabb32183a",
         "is_verified": false,
-        "line_number": 756
+        "line_number": 771
       },
       {
         "type": "Secret Keyword",
         "filename": "README.md",
         "hashed_secret": "7f48abec62447532005fed3067c99429d41cff78",
         "is_verified": false,
-        "line_number": 1051
+        "line_number": 1066
       }
     ],
     "SECURITY.md": [
@@ -894,5 +894,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-16T05:50:32Z"
+  "generated_at": "2026-09-06T09:24:43Z"
 }

--- a/uv.lock
+++ b/uv.lock
@@ -453,14 +453,11 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.0"
+version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
 ]
 
 [[package]]
@@ -2468,8 +2465,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- Bump `click` 8.3.0 → 8.5.0, fixing a command-injection CVE (PYSEC-2026-2132 / CVE-2026-7246) in `click.edit()`.
- Document and ignore the one remaining unpatched nltk CVE (PYSEC-2026-3740): a model-persistence path-sandbox bypass in APIs this project's dev-only, never-imported `nltk` dependency doesn't call.
- Regenerate `.secrets.baseline`, which had drifted (stale line numbers vs. README.md/SECURITY.md) and was failing `detect-secrets` unconditionally on every branch, blocking CI for every open PR regardless of their actual content.

## Why
All 8 currently open contributor PRs were stuck with CI failing on these two unrelated, repo-wide issues, plus an automated review bot repeatedly posting a misleading "blocked by Mermaid check" comment. This clears the real blockers so each PR's CI reflects its actual code.

## Test plan
- [x] `pytest tests/unit` — 1946 passed
- [x] `pip-audit` clean (no known vulnerabilities, 1 documented ignore)
- [x] `pre-commit run --all-files` clean for the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Luz931i5borT1kVUSg5qqD