### PR TITLE
docs: fix references left stale by recent breaking changes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -226,28 +226,28 @@
         "filename": "API.md",
         "hashed_secret": "aecdccc1cf64595b34e0cc152d238daabb32183a",
         "is_verified": false,
-        "line_number": 288
+        "line_number": 289
       },
       {
         "type": "Hex High Entropy String",
         "filename": "API.md",
         "hashed_secret": "4aad81b82c54b35a326e72bb41999cf64cb5300a",
         "is_verified": false,
-        "line_number": 804
+        "line_number": 808
       },
       {
         "type": "Secret Keyword",
         "filename": "API.md",
         "hashed_secret": "4d6177cf672a3a086e9b91cf7e8c6a1798cf2b05",
         "is_verified": false,
-        "line_number": 1004
+        "line_number": 1008
       },
       {
         "type": "Secret Keyword",
         "filename": "API.md",
         "hashed_secret": "1816851d10187b57a93235b52495e615629f906d",
         "is_verified": false,
-        "line_number": 1799
+        "line_number": 1803
       }
     ],
     "GEMINI.md": [
@@ -909,5 +909,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-06T10:01:12Z"
+  "generated_at": "2026-09-06T14:30:53Z"
 }

--- a/API.md
+++ b/API.md
@@ -116,8 +116,9 @@ Configure the MCP server using environment variables:
 | `UNIFI_WEBHOOK_REDIS_URL` | Redis URL for webhook/event bus fan-out | No | unset |
 | `UNIFI_SITE_MANAGER_ENABLED` | Enable Site Manager API multi-site tools | No | `false` |
 | `MCP_SERVER_TRANSPORT` | Transport: `stdio`, `http`, `sse`, `streamable_http` | No | `stdio` |
-| `MCP_SERVER_HOST` | Server bind address (http/sse transports) | No | `0.0.0.0` |
+| `MCP_SERVER_HOST` | Server bind address for `http`/`sse`/`streamable_http` | No | `127.0.0.1` |
 | `MCP_SERVER_PORT` | Server port (http/sse transports) | No | `3000` |
+| `MCP_AUTH_TOKEN` | Bearer token required to call the server over a network transport; comma-separate for several. `http`/`sse`/`streamable_http` refuse to start without it. Ignored for `stdio` | No | unset |
 | `LOG_LEVEL` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR` | No | `INFO` |
 
 - Required when `UNIFI_API_TYPE=local`.
@@ -445,7 +446,10 @@ The currently implemented Protect MCP resources are:
 - `protect://cameras`
 - `protect://cameras/{camera_id}`
 
-The currently implemented Protect MCP tools are grouped below.
+The currently implemented Protect MCP tools are grouped below. `update_protect_device`,
+`update_protect_light`, `update_protect_sensor`, `update_protect_chime`, `update_protect_viewer`,
+`create_protect_live_view`, `update_protect_live_view`, and `send_protect_alarm_webhook` require
+`confirm=True` and support `dry_run`.
 
 #### Cameras
 
@@ -517,7 +521,7 @@ viewers = await mcp.call_tool("list_protect_viewers", {})
 events = await mcp.call_tool("list_protect_events", {})
 webhook = await mcp.call_tool(
     "send_protect_alarm_webhook",
-    {"webhook_id": "webhook-1", "payload": {"event": "manual-trigger"}},
+    {"webhook_id": "webhook-1", "payload": {"event": "manual-trigger"}, "confirm": True},
 )
 ```
 
@@ -3075,7 +3079,7 @@ Download a backup file to local storage.
 ```json
 {
   "backup_filename": "backup_2025-01-29.unf",
-  "local_path": "/backups/unifi_backup.unf",
+  "local_path": "/home/user/unifi_backup.unf",
   "size_bytes": 5242880,
   "checksum": "a3f2b1...c4d5",
   "download_time": "2025-01-29T15:45:00Z"

--- a/docs/UNIFI_API.md
+++ b/docs/UNIFI_API.md
@@ -2772,8 +2772,8 @@ Download a backup file to local storage.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `backup_filename` | string | Yes | Backup filename to download |
-| `output_path` | string | Yes | Local filesystem path to save |
+| `backup_filename` | string | Yes | Backup filename (a single path component; separators and `..` are rejected) |
+| `output_path` | string | Yes | Filename to save under. Only the filename is used — any directory component is ignored and the file is written inside `UNIFI_BACKUP_DOWNLOAD_DIR` (default: the current working directory) |
 | `verify_checksum` | boolean | No | Calculate SHA256 checksum (default: true) |
 
 **Example Usage:**
@@ -2782,7 +2782,7 @@ Download a backup file to local storage.
 result = await download_backup(
     site_id="default",
     backup_filename="backup_2026-01-24.unf",
-    output_path="/backups/unifi_backup.unf",
+    output_path="unifi_backup.unf",
     settings=settings
 )
 print(f"Downloaded: {result['size_bytes']} bytes")

--- a/skills/unifi-devices.md
+++ b/skills/unifi-devices.md
@@ -71,7 +71,7 @@ All tools require `local` API mode unless noted.
 
 | Tool | Description |
 |---|---|
-| `run_speed_test` | Trigger a WAN speed test |
+| `run_speed_test` | Trigger a WAN speed test (requires `confirm=True`) |
 | `get_speed_test_status` | Check status of a running speed test |
 | `get_speed_test_history` | Historical speed test results |
 | `get_spectrum_scan` | Get WiFi spectrum scan data for an AP |


### PR DESCRIPTION
## Summary
- `API.md`: `MCP_SERVER_HOST` default corrected to `127.0.0.1`, added missing `MCP_AUTH_TOKEN` row, noted which Protect tools require `confirm=True`, fixed a `send_protect_alarm_webhook` example that would now fail without it.
- `docs/UNIFI_API.md`: `download_backup` example updated — `output_path` is filename-only now, confined under `UNIFI_BACKUP_DOWNLOAD_DIR`.
- `skills/unifi-devices.md`: `run_speed_test` row now notes the `confirm=True` requirement, matching its `restore_backup`/`delete_backup` neighbors.

## Why
#156, #157, #158 (merged today) introduced three breaking changes but didn't update every doc that demonstrated the old behavior. This closes those gaps so copy-pasted examples don't fail.

Also dismissed GitHub Dependabot alert #83 (nltk path-sandbox CVE, no fix available) as `not_used` — already documented and ignored in `.github/workflows/security.yml`'s pip-audit step; nltk is dev-only and never imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Luz931i5borT1kVUSg5qqD