### PR TITLE
fix(lint): tuple isinstance and import-order regressions from #152

### DIFF
--- a/src/tools/channel_planning.py
+++ b/src/tools/channel_planning.py
@@ -268,7 +268,7 @@ async def list_site_internal_ap_neighbors_v2(
 
         for ap_mac, outcome in zip(ap_macs, results, strict=True):
             if isinstance(outcome, BaseException):
-                if isinstance(outcome, (APIError, ResourceNotFoundError, ValidationError)):
+                if isinstance(outcome, APIError | ResourceNotFoundError | ValidationError):
                     skipped_aps.append({"ap_mac": ap_mac, "reason": str(outcome)})
                     continue
                 raise outcome

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -20,11 +20,7 @@ if importlib.util.find_spec("fastmcp") is None:
     fastmcp_stub.FastMCP = FastMCP
     sys.modules["fastmcp"] = fastmcp_stub
 
-from src.tool_registry import (
-    MUTATING_TOOLS_WITHOUT_GATE,
-    is_mutating_tool,
-    register_module_tools,
-)
+from src.tool_registry import MUTATING_TOOLS_WITHOUT_GATE, is_mutating_tool, register_module_tools
 from src.tools import dpi_tools, reference_data
 
 


### PR DESCRIPTION
## Summary
- `src/tools/channel_planning.py`: `isinstance(outcome, (A, B, C))` → `isinstance(outcome, A | B | C)` (ruff UP038).
- `tests/unit/test_tool_registry.py`: import-order fix from isort.

## Why
CI never actually ran clean against this code — it landed while every PR was blocked by the secrets-baseline/CVE issues fixed in #163/#165, so these two pre-commit failures shipped to `main` unnoticed and only surfaced once real CI started running again.

## Test plan
- [x] `pytest tests/unit` — 2108 passed
- [x] `pre-commit run ruff --all-files` / `isort --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Luz931i5borT1kVUSg5qqD